### PR TITLE
Temporarily reenable TREAT-AD score processing in test-config only

### DIFF
--- a/test_config.yaml
+++ b/test_config.yaml
@@ -164,27 +164,27 @@
           - syn12615633
         destination: *dest
 
-#    - overall_scores:
-#        files:
-#          - name: overall_scores
-#            id: syn25575156.9 #pinned to an older version of the scores file (see AG-701)
-#            format: table
-#        final_format: json
-#        custom_transformations: 1
-#        column_rename:
-#          genename: hgnc_gene_id
-#        provenance:
-#          - syn25575156
-#          - syn25575153
-#          - syn22758536
-#        agora_rename:
-#          ensg: ENSG
-#          hgnc_gene_id: GeneName
-#          geneticsscore: GeneticsScore
-#          literaturescore: LiteratureScore
-#          overall: Logsdon
-#          omicsscore: OmicsScore
-#        destination: *dest
+    - overall_scores:
+        files:
+          - name: overall_scores
+            id: syn25575156.9 #pinned to an older version of the scores file (see AG-701)
+            format: table
+        final_format: json
+        custom_transformations: 1
+        column_rename:
+          genename: hgnc_gene_id
+        provenance:
+          - syn25575156
+          - syn25575153
+          - syn22758536
+        agora_rename:
+          ensg: ENSG
+          hgnc_gene_id: GeneName
+          geneticsscore: GeneticsScore
+          literaturescore: LiteratureScore
+          overall: Logsdon
+          omicsscore: OmicsScore
+        destination: *dest
 
     - network:
         files:
@@ -237,16 +237,16 @@
           - syn12514912
         destination: *dest
 
-#    - distribution_data:
-#        files:
-#          - name: overall_scores
-#            id: syn25575156.9 #pinned to an older version of the scores file (see AG-701)
-#            format: table
-#        final_format: json
-#        custom_transformations: 1
-#        provenance:
-#          - syn25575156
-#        destination: *dest
+    - distribution_data:
+        files:
+          - name: overall_scores
+            id: syn25575156.9 #pinned to an older version of the scores file (see AG-701)
+            format: table
+        final_format: json
+        custom_transformations: 1
+        provenance:
+          - syn25575156
+        destination: *dest
 
     - rna_distribution_data:
         files:


### PR DESCRIPTION
To validate that we still have permissions to access TREAT-AD source files 