### PR TITLE
AG-827: Update and reenable distribution_data processing

### DIFF
--- a/agoradatatools/etl/transform.py
+++ b/agoradatatools/etl/transform.py
@@ -75,13 +75,14 @@ def calculate_distribution(df: pd.DataFrame, col: str, is_scored, upper_bound):
     '''
     In order to smooth out the bins and make sure the entire range from 0
     to the theoretical maximum value has been found, we create a copy of the
-    column with that maximum value added to it.  We use the copy to calculate 
-    distributions and bins, and subtract the value at the end
+    column with both 0 and that maximum value added to it.  We use the copy to calculate 
+    distributions and bins, and subtract the values at the end
     '''
-    distribution = df[col].append(pd.Series([upper_bound]), ignore_index=True)
+    distribution = df[col].append(pd.Series([0, upper_bound]), ignore_index=True)
 
     obj["distribution"] = list(pd.cut(distribution, bins=10, precision=3, include_lowest=True, right=True)
                                .value_counts(sort=False))
+    obj["distribution"][0] -= 1  # since this was calculated with the artificial 0 value, we subtract it
     obj["distribution"][-1] -= 1  # since this was calculated with the artificial upper_bound, we subtract it
 
     discard, obj["bins"] = list(pd.cut(distribution, bins=10, precision=3, retbins=True))

--- a/config.yaml
+++ b/config.yaml
@@ -238,17 +238,20 @@
           - syn12514912
         destination: *dest
 
-# Disable production processing of this file until AG-701 is addressed
-#    - distribution_data:
-#        files:
-#          - name: overall_scores
-#            id: syn25575156
-#            format: table
-#        final_format: json
-#        custom_transformations: 1
-#        provenance:
-#          - syn25575156
-#        destination: *dest
+    - distribution_data:
+        files:
+          - name: overall_scores
+            id: syn25575156
+            format: table
+        final_format: json
+        custom_transformations:
+          overall_max_score: 5
+          genetics_max_score: 3
+          omics_max_score: 2
+          lit_max_score: 2
+        provenance:
+          - syn25575156
+        destination: *dest
 
     - rna_distribution_data:
         files:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -31,7 +31,7 @@
           ensemble_gene_id: ensembl_gene_id
           hgnc_gene_id: hgnc_symbol
         destination: *dest
-        
+
     - proteomics_tmt:
         files:
           - name: agora_proteomics_tmt
@@ -237,16 +237,20 @@
           - syn12514912
         destination: *dest
 
-#    - distribution_data:
-#        files:
-#          - name: overall_scores
-#            id: syn25575156.9 #pinned to an older version of the scores file (see AG-701)
-#            format: table
-#        final_format: json
-#        custom_transformations: 1
-#        provenance:
-#          - syn25575156
-#        destination: *dest
+    - distribution_data:
+        files:
+          - name: overall_scores
+            id: syn25575156
+            format: table
+        final_format: json
+        custom_transformations:
+          overall_max_score: 5
+          genetics_max_score: 3
+          omics_max_score: 2
+          lit_max_score: 2
+        provenance:
+          - syn25575156
+        destination: *dest
 
     - rna_distribution_data:
         files:


### PR DESCRIPTION
* Align transform_distribution_data with v13 of source file
* Pass max possible score values via config, rather than assuming we will always have a score in the highest bin for all datasets
* Include 0 (min possible score value) to ensure correct binning for all datasets
* Disable default sort in calculate_distribution that resulted in distributions being associated with the wrong bins
* Reenable overall_scores processing for test and prod