### PR TITLE
Modified nest_fields to allow dropping columns from the nested dictionary

### DIFF
--- a/agoradatatools/etl/transform.py
+++ b/agoradatatools/etl/transform.py
@@ -46,7 +46,7 @@ def rename_columns(df: pd.DataFrame, column_map: dict) -> pd.DataFrame:
     return df
 
 
-def nest_fields(df: pd.DataFrame, grouping: str, new_column: str) -> pd.DataFrame:
+def nest_fields(df: pd.DataFrame, grouping: str, new_column: str, drop_columns: list = []) -> pd.DataFrame:
     """
     This will create a dictionary object with the result of the grouping provided
     :param df: a dataframe
@@ -56,7 +56,8 @@ def nest_fields(df: pd.DataFrame, grouping: str, new_column: str) -> pd.DataFram
     :return: a dataframe
     """
     return (df.groupby(grouping)
-            .apply(lambda row: row.replace({np.nan: None}).to_dict('records'))
+            .apply(lambda row: row.replace({np.nan: None})
+                   .drop(columns = drop_columns).to_dict('records'))
             .reset_index()
             .rename(columns={0: new_column}))
 

--- a/agoradatatools/etl/transform.py
+++ b/agoradatatools/etl/transform.py
@@ -53,6 +53,8 @@ def nest_fields(df: pd.DataFrame, grouping: str, new_column: str, drop_columns: 
     :param grouping: a string containing the column to group by
     :param new_column: a string with the name of the new column that will contain
     the nested field
+    :param drop_columns: a list of column names to drop (remove) from the 
+    nested dictionary. Optional argument, defaults to empty list.
     :return: a dataframe
     """
     return (df.groupby(grouping)


### PR DESCRIPTION
In transform.py, the function `nest_fields` collects rows with the same `grouping` ID (e.g. the same Ensembl ID), turns all of those rows into dictionaries with keys = column names, and turns it into a single row with 2 columns: the name of the `grouping` column, and a list of the dictionaries. 

This means that currently, all data frames created from this function have both an `ensembl_gene_id` column _and_ an `ensembl_gene_id` field inside each dictionary in each list, which is unnecessary and creates issues around using column_rename or agora_rename (see https://sagebionetworks.jira.com/browse/AG-893 for an example). 

I have added an optional argument to `nest_fields`: `drop_columns`, which should be a list of columns to remove from the nested dictionaries (defaults to an empty list).

**By default**, any code calling this function without the `drop_columns` argument specified will have nothing dropped, which is the same behavior as before this change. Requires no change anything calling this function. 

Columns can be removed from the dictionary by adding a `drop_columns` argument. All of the following are valid:
```
df = nest_fields(..., drop_columns = []) # Don't drop anything. Equivalent to calling the function without drop_columns
df = nest_fields(..., drop_columns = ['ensembl_gene_id'] # Drop 'ensembl_gene_id'
df = nest_fields(..., drop_columns = ['ensembl_gene_id', 'hgnc_symbol'] # Drop these two columns
```

[AG-893]: https://sagebionetworks.jira.com/browse/AG-893?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ