### PR TITLE
Update load functions

### DIFF
--- a/agoradatatools/etl/load.py
+++ b/agoradatatools/etl/load.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import json
-from os import mkdir, rmdir
+from os import mkdir, rmdir, path
 from . import utils
 from synapseclient import File, Activity
 import numpy as np
@@ -103,7 +103,7 @@ def load(file_path: str, provenance: list[str], destination: str, syn=None):
     return (file.id, file.versionNumber)
 
 
-def df_to_json(df: pd.core.frame.DataFrame, staging_path: str, filename: str):
+def df_to_json(df: pd.DataFrame, staging_path: str, filename: str):
     """
     Converts a data frame into a json file.
     :param df: a dataframe
@@ -116,7 +116,7 @@ def df_to_json(df: pd.core.frame.DataFrame, staging_path: str, filename: str):
 
         df_as_dict = df.to_dict(orient='records')
 
-        temp_json = open(staging_path + "/" + filename, 'w+')
+        temp_json = open(path.join(staging_path, filename), 'w+')
         json.dump(df_as_dict, temp_json,
                  cls=NumpyEncoder,
                  indent=2)
@@ -125,12 +125,11 @@ def df_to_json(df: pd.core.frame.DataFrame, staging_path: str, filename: str):
         temp_json.close()
         return None
 
-
     temp_json.close()
     return temp_json.name
 
 
-def df_to_csv(df: pd.core.frame.DataFrame, staging_path: str, filename: str):
+def df_to_csv(df: pd.DataFrame, staging_path: str, filename: str):
     """
     Converts a data frame into a csv file.
     :param df: a dataframe
@@ -138,7 +137,7 @@ def df_to_csv(df: pd.core.frame.DataFrame, staging_path: str, filename: str):
     :return: the path of the newly created temporary csv file
     """
     try:
-        temp_csv = open(staging_path + "/" + filename, 'w+')
+        temp_csv = open(path.join(staging_path, filename), 'w+')
         df.to_csv(path_or_buf=temp_csv, index=False)
     except AttributeError:
         print("Invalid dataframe.")
@@ -153,7 +152,7 @@ def dict_to_json(df: dict, staging_path: str, filename: str):
     try:
         df_as_dict = [{d: remove_non_values(v) if isinstance(v, dict) else v for d,v in df.items()}]
 
-        temp_json = open(staging_path + "/" + filename, 'w+')
+        temp_json = open(path.join(staging_path, filename), 'w+')
         json.dump(df_as_dict, temp_json,
                   cls=NumpyEncoder,
                   indent=2)

--- a/agoradatatools/etl/load.py
+++ b/agoradatatools/etl/load.py
@@ -17,21 +17,21 @@ class NumpyEncoder(json.JSONEncoder):
         return json.JSONEncoder.default(self, obj)
 
 
-def create_temp_location():
+def create_temp_location(staging_path: str):
     """
     Creates a temporary location to store the json files
     """
     try:
-        mkdir('./staging')
+        mkdir(staging_path)
     except FileExistsError:
         return
 
 
-def delete_temp_location():
+def delete_temp_location(staging_path: str):
     """
     Deletes the default temporary location
     """
-    rmdir('./staging')
+    rmdir(staging_path)
 
 
 def remove_non_values(d: dict) -> dict:
@@ -103,7 +103,7 @@ def load(file_path: str, provenance: list[str], destination: str, syn=None):
     return (file.id, file.versionNumber)
 
 
-def df_to_json(df: pd.core.frame.DataFrame, filename: str):
+def df_to_json(df: pd.core.frame.DataFrame, staging_path: str, filename: str):
     """
     Converts a data frame into a json file.
     :param df: a dataframe
@@ -116,7 +116,7 @@ def df_to_json(df: pd.core.frame.DataFrame, filename: str):
 
         df_as_dict = df.to_dict(orient='records')
 
-        temp_json = open("./staging/" + filename, 'w+')
+        temp_json = open(staging_path + "/" + filename, 'w+')
         json.dump(df_as_dict, temp_json,
                  cls=NumpyEncoder,
                  indent=2)
@@ -130,7 +130,7 @@ def df_to_json(df: pd.core.frame.DataFrame, filename: str):
     return temp_json.name
 
 
-def df_to_csv(df: pd.core.frame.DataFrame, filename: str):
+def df_to_csv(df: pd.core.frame.DataFrame, staging_path: str, filename: str):
     """
     Converts a data frame into a csv file.
     :param df: a dataframe
@@ -138,7 +138,7 @@ def df_to_csv(df: pd.core.frame.DataFrame, filename: str):
     :return: the path of the newly created temporary csv file
     """
     try:
-        temp_csv = open("./staging/" + filename, 'w+')
+        temp_csv = open(staging_path + "/" + filename, 'w+')
         df.to_csv(path_or_buf=temp_csv, index=False)
     except AttributeError:
         print("Invalid dataframe.")
@@ -149,11 +149,11 @@ def df_to_csv(df: pd.core.frame.DataFrame, filename: str):
     return temp_csv.name
 
 
-def dict_to_json(df: dict, filename: str):
+def dict_to_json(df: dict, staging_path: str, filename: str):
     try:
         df_as_dict = [{d: remove_non_values(v) if isinstance(v, dict) else v for d,v in df.items()}]
 
-        temp_json = open("./staging/" + filename, 'w+')
+        temp_json = open(staging_path + "/" + filename, 'w+')
         json.dump(df_as_dict, temp_json,
                   cls=NumpyEncoder,
                   indent=2)

--- a/agoradatatools/etl/utils.py
+++ b/agoradatatools/etl/utils.py
@@ -30,3 +30,28 @@ def _get_config(config_path: str = None):
         print("Invalid file.  Please provide a valid YAML file.")
         sys.exit(errno.EBADF)
     return config
+
+
+def _find_config_by_name(config: list, name: str):
+    """
+    Iterates through the list to find a dictionary with a key matching 'name'
+
+    Parameters
+    ----------
+    config : list
+        A list of dicts, each of which usually contain a single key. These
+        come from the config yaml file. 
+    name : str
+        The name of that key.
+
+    Returns
+    -------
+    object
+        If a dictionary is found, returns the contents of dict[name]. Otherwise 
+        returns None. 
+
+    """
+    for item in config:
+        if name in item.keys():
+            return item[name]
+    return None

--- a/agoradatatools/etl/utils.py
+++ b/agoradatatools/etl/utils.py
@@ -33,22 +33,16 @@ def _get_config(config_path: str = None):
 
 
 def _find_config_by_name(config: list, name: str):
-    """
-    Iterates through the list to find a dictionary with a key matching 'name'
+    """Iterates through the list to find a dictionary with a key matching 'name'
 
-    Parameters
-    ----------
-    config : list
-        A list of dicts, each of which usually contain a single key. These
-        come from the config yaml file. 
-    name : str
-        The name of that key.
+    Args:
+        config: A list of dicts, each of which usually contain a single key.
+            These come from the config yaml file.
+        name: The name of that key.
 
-    Returns
-    -------
-    object
-        If a dictionary is found, returns the contents of dict[name]. Otherwise 
-        returns None. 
+    Returns:
+        object: If a dictionary is found, returns the contents of dict[name].
+            Otherwise returns None.
 
     """
     for item in config:

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,5 @@
 - destination: &dest syn12177492
+- staging_path: ./staging
 - datasets:
     - neuropath_corr:
         files:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -1,4 +1,5 @@
 - destination: &dest syn17015333
+- staging_path: ./staging
 - datasets:
     - neuropath_corr:
         files:


### PR DESCRIPTION
Previously, `load.py` had `"./staging"` hard-coded in several places as the folder where staged json files go before upload to Synapse. This became an issue when trying to write test functions for our various custom transforms, because files in ./staging would get over-written with test data unless I wrote some really awful patch code to get around it. 

To fix this, I added `- staging_path: ./staging` to the config files, and whatever is in `staging_path` now gets passed as an argument to the load functions. By default, if `- staging_path` is missing from the config file, it will get set to "./staging" so it behaves as before. 

I also added a utility function, `_find_config_by_name`, to get the correct config data from the config list. Previously, objects were retrieved from the config list by numerical index (e.g. `datasets = config[1]["datasets"]`), which meant that either `staging_path` had to get lost at the bottom of the config file or I had to change the indexes on each reference to config. Adding a function to access by name instead of numerical index seemed more robust. 

Looking for input from Data & Tooling about these changes!