### PR TITLE
Ag-935 rna distribution updates

### DIFF
--- a/agoradatatools/etl/transform.py
+++ b/agoradatatools/etl/transform.py
@@ -476,7 +476,9 @@ def transform_distribution_data(
 
 
 def transform_rna_distribution_data(datasets: dict):
-    rna_df = datasets["rna"]
+    # "datasets" contains the unprocessed RNA-seq data, which needs to go
+    # through the same processing as before in order to use it here. 
+    rna_df = transform_rna_seq_data(datasets)
     rna_df = rna_df[["tissue", "model", "logfc"]]
 
     rna_df = (

--- a/config.yaml
+++ b/config.yaml
@@ -191,12 +191,7 @@
             id: syn27211942.1
             format: tsv
         final_format: json
-        custom_transformations:
-          models_to_keep:
-            - Diagnosis AD-CONTROL ALL
-            - Diagnosis.AOD AD-CONTROL ALL
-            - Diagnosis.Sex AD-CONTROL FEMALE
-            - Diagnosis.Sex AD-CONTROL MALE
+        custom_transformations: 1
         provenance:
           - syn27211942.1
         destination: *dest

--- a/config.yaml
+++ b/config.yaml
@@ -218,14 +218,12 @@
 
     - rna_distribution_data:
         files:
-          - name: rna
-            # use the latest rnaseq JSON file (generated via the current run)
-            id: syn12177499
-            format: json
+          - name: diff_exp_data
+            id: syn27211942.1
+            format: tsv
         final_format: json
         custom_transformations: 1
         provenance:
-          # same provenance as rnaseq JSON file (syn12177499)
           - syn27211942.1
         destination: *dest
 

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -218,14 +218,12 @@
 
     - rna_distribution_data:
         files:
-          - name: rna
-            # use the latest rnaseq JSON file (generated via the current run)
-            id: syn17015360
-            format: json
+          - name: diff_exp_data
+            id: syn27211942.1
+            format: tsv
         final_format: json
         custom_transformations: 1
         provenance:
-          # same provenance as rnaseq JSON file (syn17015360)
           - syn27211942.1
         destination: *dest
 

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -191,12 +191,7 @@
             id: syn27211942.1
             format: tsv
         final_format: json
-        custom_transformations:
-          models_to_keep:
-            - Diagnosis AD-CONTROL ALL
-            - Diagnosis.AOD AD-CONTROL ALL
-            - Diagnosis.Sex AD-CONTROL FEMALE
-            - Diagnosis.Sex AD-CONTROL MALE
+        custom_transformations: 1
         provenance:
           - syn27211942.1
         destination: *dest


### PR DESCRIPTION
Previously, the `rna_distribution_data` transform took as input the JSON file created by the `rnaseq_differential_expression` transform, which created a dependency on the order they are listed in the config file. This update changes the `rna_distribution_data` transform to use the original source file (which is also used for `rnaseq_differential_expression`). 