### PR TITLE
Fixed logic for determining if rna or protein was changed in AD

### DIFF
--- a/agoradatatools/etl/transform.py
+++ b/agoradatatools/etl/transform.py
@@ -375,12 +375,14 @@ def transform_gene_info(
 
     gene_info["rna_brain_change_studied"] = gene_info["adj_p_val"] != -1
     gene_info["rna_in_ad_brain_change"] = (
-        gene_info["adj_p_val"] <= adjusted_p_value_threshold
+        (gene_info["adj_p_val"] <= adjusted_p_value_threshold) &
+        gene_info["rna_brain_change_studied"]
     )
 
     gene_info["protein_brain_change_studied"] = gene_info["cor_pval"] != -1
     gene_info["protein_in_ad_brain_change"] = (
-        gene_info["cor_pval"] <= protein_level_threshold
+        (gene_info["cor_pval"] <= protein_level_threshold) &
+        gene_info["protein_brain_change_studied"]
     )
 
     # create 'nominations' field


### PR DESCRIPTION
When the `gene_info` table is created, merging in RNA and protein p-value tables results in p-values being filled out for genes that exist in those tables, and NA otherwise. The code fills in these NAs with -1 to distinguish between a real p-value and one that doesn't exist, but then marks genes as significant/changed in AD if `p_value <= threshold`. 

This means genes that weren't studied end up getting marked as true when they should be false. This is masked/taken care of in the Agora front-end so only genes that were studied have their significance true/false displayed, but it seems better to have the rna/protein changed fields be accurate in the file so mistakes aren't made with new development down the line. 