### PR TITLE
Added n_terms and enrichment_pct calculations to biodomains output

### DIFF
--- a/agoradatatools/etl/transform.py
+++ b/agoradatatools/etl/transform.py
@@ -151,28 +151,70 @@ def calculate_distribution(df: pd.DataFrame, col: str, is_scored, upper_bound) -
     return obj
 
 
+def count_grouped_total(df: pd.DataFrame,
+                        grouping: [str, list],
+                        input_colname: str,
+                        output_colname: str) -> pd.DataFrame:
+    """For each unique item/combination in the column(s) specified by grouping,
+    counts the number of unique items in the column [input_colname] that
+    correspond to that grouping. The calculated counts are put in a new
+    column and named with [output_colname].
+    Args:
+        df (pd.DataFrame): contains columns listed in grouping and
+                           input_colname. May contain other columns as well, but
+                           these will be dropped from the returned data frame.
+        grouping (str or list): a string with a single column name, or a list of
+                                strings for multiple column names
+        input_colname (str): the name of the column to count
+        output_colname (str): the name of the new column with calculated counts
+    Returns:
+        pd.DataFrame: a data frame containing the grouping column(s) and a
+                      new column for output_colname, which contains the count of
+                      unique items in input_colname for each grouping item.
+    """
+    df = (
+        df.groupby(grouping)[input_colname]
+        .nunique().reset_index()
+        .rename(columns={input_colname: output_colname})
+    )
+    return df
+
+
 def transform_genes_biodomains(datasets: dict) -> pd.DataFrame:
-    """Takes dictionary of dataset DataFrames, extracts genes_biodomains DataFrame, perfomes nest_fields on
-    interesting_columns resulting in a 2 column DataFrame grouped by "ensembl_gene_id" and including a
-    collapsed nested dictionary field gene_biodomains
+    """Takes dictionary of dataset DataFrames, extracts the genes_biodomains
+    DataFrame, calculates some metrics on GO terms per gene / biodomain, and
+    performs nest_fields on the final DataFrame. This results in a 2 column
+    DataFrame grouped by "ensembl_gene_id" and includes a collapsed nested
+    dictionary field "gene_biodomains"
 
     Args:
         datasets (dict[str, pd.DataFrame]): dictionary of dataset names mapped to their DataFrame
 
     Returns:
-        pd.DataFrame: 2 column DataFrame grouped by "ensembl_gene_id" and including a
-    collapsed nested dictionary field gene_biodomains
+        pd.DataFrame: 2 column DataFrame grouped by "ensembl_gene_id" including
+                      a collapsed nested dictionary field "gene_biodomains"
     """
     genes_biodomains = datasets["genes_biodomains"]
     interesting_columns = ["ensembl_gene_id", "biodomain", "go_terms"]
     genes_biodomains = genes_biodomains[interesting_columns].dropna()
 
     # Count the number of go_terms associated with each biodomain
-    totals = (
-        genes_biodomains.groupby("biodomain")["go_terms"]
-        .nunique().reset_index()
-        .rename(columns={"go_terms": "n_go_terms"})
-    )
+    n_biodomain_terms = count_grouped_total(genes_biodomains,
+                                            "biodomain",
+                                            "go_terms",
+                                            "n_biodomain_terms")
+
+    # Count the number of go_terms associated with each gene, ignoring biodomain
+    n_gene_total_terms = count_grouped_total(genes_biodomains,
+                                             "ensembl_gene_id",
+                                             "go_terms",
+                                             "n_gene_total_terms")
+
+    # Count the number of go_terms associated with each gene / biodomain combo
+    n_gene_biodomain_terms = count_grouped_total(genes_biodomains,
+                                                 ["ensembl_gene_id", "biodomain"],
+                                                 "go_terms",
+                                                 "n_gene_biodomain_terms")
 
     # Group rows by ensg and biodomain to produce nested lists of go_terms per ensg/biodomain
     genes_biodomains = (
@@ -181,17 +223,24 @@ def transform_genes_biodomains(datasets: dict) -> pd.DataFrame:
         .reset_index()
     )
 
-    # Count the number of go_terms associated with each gene
-    genes_biodomains["n_terms"] = genes_biodomains["go_terms"].apply(len)
+    # Merge all the different count metrics into the main data frame so each
+    # ensembl_gene_id / biodomain combo has an entry for each count
+    genes_biodomains = (
+        genes_biodomains.merge(n_gene_total_terms, on="ensembl_gene_id", how="left")
+        .merge(n_biodomain_terms, on="biodomain", how="left")
+        .merge(n_gene_biodomain_terms, on=["ensembl_gene_id", "biodomain"], how="left")
+    )
 
-    # Calculate percent enrichment: merge the list of n_go_terms to match with
-    # each biodomain and then divide n_terms / n_go_terms
-    genes_biodomains = genes_biodomains.merge(totals, on="biodomain", how="left")
-    genes_biodomains["enrichment_pct"] = \
-        genes_biodomains["n_terms"] / genes_biodomains["n_go_terms"] * 100
+    # Calculate percent linking terms:
+    # n_gene_biodomain_terms / n_gene_total_terms * 100
+    genes_biodomains["pct_linking_terms"] = (
+        (genes_biodomains["n_gene_biodomain_terms"] /
+         genes_biodomains["n_gene_total_terms"] * 100)
+        .round(decimals=2)
+    )
 
-    # Remove n_go_terms from the data frame
-    genes_biodomains = genes_biodomains.drop(columns="n_go_terms")
+    # Remove n_gene_total_terms column
+    genes_biodomains = genes_biodomains.drop(columns="n_gene_total_terms")
 
     genes_biodomains = nest_fields(
         df=genes_biodomains,

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -126,6 +126,48 @@ def test_nest_fields():
     assert list(nested_df["e"]) == expected_column_e
 
 
+class TestCountGroupedTotal():
+    df = pd.DataFrame(
+        {
+            "col_1": ["a", "a", "a", "b", "c", "c", "c"],  # 3 'Ensembl IDs'
+            "col_2": ["x", "y", "z", "x", "y", "z", "z"],  # 3 'biodomains'
+            "col_3": ["1", "1", "2", "3", "2", "1", "3"],  # 3 'go_terms'
+            "col_4": ["m", "m", "n", "n", "o", "o", "o"]   # An extra column that should get ignored
+        }
+    )
+
+    # How many unique "col_2"'s per unique "col_1" value?
+    def test_count_grouped_total_one_group(self):
+        expected_df = pd.DataFrame(
+            {
+                "col_1":  ["a", "b", "c"],
+                "output": [3, 1, 2]
+            }
+        )
+        counted = transform.count_grouped_total(
+            df=self.df, grouping="col_1",
+            input_colname="col_2", output_colname="output"
+        )
+        assert counted.equals(expected_df)
+
+    # How many unique "col_3"'s per unique combination of "col_1" + "col_2"?
+    def test_count_grouped_total_two_groups(self):
+        expected_df = pd.DataFrame(
+            {
+                "col_1": ["a", "a", "a", "b", "c", "c"],
+                "col_2": ["x", "y", "z", "x", "y", "z"],
+                "output": [1, 1, 1, 1, 1, 2]
+            }
+        )
+
+        counted = transform.count_grouped_total(
+            df=self.df, grouping=["col_1", "col_2"],
+            input_colname="col_3", output_colname="output"
+        )
+        assert counted.equals(expected_df)
+
+
+
 # def test_transform_biodomains():
 #     test_datasets = {
 #         "biodomains": pd.DataFrame(


### PR DESCRIPTION
Added three new fields to the output of the biodomains transform:

1. `n_gene_biodomain_terms` is the number of GO terms associated with each Ensembl ID, for each biodomain. 
2. `n_biodomain_terms` is the number of GO terms associated with each biodomain
3. `pct_linking_terms` is the percentage of GO terms for this gene that are in the specified biodomain, defined as (`n_gene_biodomain_terms / n_gene_total_terms * 100`) where `n_gene_total_terms` is the total number of GO terms associated with the gene, across all biodomains. 

The output for each gene now looks like this:
```
  {
    "ensembl_gene_id": "ENSG00000000457",
    "gene_biodomains": [
      {
        "biodomain": "Immune Response",
        "go_terms": [
          "inflammatory response"
        ],
        "n_biodomain_terms": 852,
        "n_gene_biodomain_terms": 1,
        "pct_linking_terms": 33.33
      },
      {
        "biodomain": "Proteostasis",
        "go_terms": [
          "Golgi apparatus",
          "Golgi membrane"
        ],
        "n_biodomain_terms": 695,
        "n_gene_biodomain_terms": 2,
        "pct_linking_terms": 66.67
      }
    ]
  },
...
```
