### PR TITLE
Created eQTL preprocessing script to update eQTL data with Solly's data

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -86,7 +86,7 @@
             id: syn12514826.4
             format: csv
           - name: eqtl
-            id: syn12514912.2
+            id: syn12514912.3
             format: csv
           - name: proteomics
             id: syn18689335.3
@@ -116,7 +116,7 @@
         provenance:
           - syn25953363.4
           - syn12514826.4
-          - syn12514912.2
+          - syn12514912.3
           - syn18689335.3
           - syn35221005.2
           - syn27211942.1

--- a/data_analysis/notebooks/AG-1001_Preprocess_EQTL.ipynb
+++ b/data_analysis/notebooks/AG-1001_Preprocess_EQTL.ipynb
@@ -1,0 +1,370 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2b9a48db",
+   "metadata": {},
+   "source": [
+    "# Pre-process eQTL meta-analysis data\n",
+    "\n",
+    "This script reads in the eQTL meta-analysis output at [syn16984815](https://www.synapse.org/#!Synapse:syn16984815) and condenses it for ingest into Agora. For each gene (Ensembl ID), there are multiple SNPs with different p-values / FDRs. Here we take the smallest FDR for each gene, mark that gene as significant if the smallest FDR is <= 0.05, and discard all other duplicate gene rows. \n",
+    "\n",
+    "The output is a data frame with one row per Ensembl ID, with two columns: one for the Ensembl ID and one for whether the gene was significant for at least one SNP. The output file is uploaded to [syn12514912](https://www.synapse.org/#!Synapse:syn12514912)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "eeb9a9e7",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Welcome, Jaclyn Beck!\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from agoradatatools.etl import utils\n",
+    "import pandas as pd\n",
+    "syn = utils._login_to_synapse()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4c203f2a",
+   "metadata": {},
+   "source": [
+    "This file will take awhile to download, as it's >17 GB. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "10e18da3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eqtl_meta = syn.get(\"syn16984815\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85b40da5",
+   "metadata": {},
+   "source": [
+    "This file is extremely large and has a lot of columns we don't need, so we only have `read_csv` return the two columns we are interested in. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "e91c739c",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>gene</th>\n",
+       "      <th>FDR</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>ENSG00000227232</td>\n",
+       "      <td>0.962800</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ENSG00000227232</td>\n",
+       "      <td>0.756904</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>ENSG00000227232</td>\n",
+       "      <td>0.958278</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>ENSG00000227232</td>\n",
+       "      <td>0.961634</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>ENSG00000227232</td>\n",
+       "      <td>0.892694</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "              gene       FDR\n",
+       "0  ENSG00000227232  0.962800\n",
+       "1  ENSG00000227232  0.756904\n",
+       "2  ENSG00000227232  0.958278\n",
+       "3  ENSG00000227232  0.961634\n",
+       "4  ENSG00000227232  0.892694"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eqtl_meta = pd.read_csv(eqtl_meta.path, usecols=[\"gene\", \"FDR\"])\n",
+    "eqtl_meta.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2411fd4f",
+   "metadata": {},
+   "source": [
+    "Take the minimum FDR for each gene, and determine significance. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "5c5e242b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True     18395\n",
+       "False      997\n",
+       "Name: has_eqtl, dtype: int64"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eqtl_meta = eqtl_meta.groupby(\"gene\")[\"FDR\"].agg(\"min\").reset_index()\n",
+    "eqtl_meta[\"has_eqtl\"] = eqtl_meta[\"FDR\"] <= 0.05\n",
+    "eqtl_meta[\"has_eqtl\"].value_counts()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "51b2ace5",
+   "metadata": {},
+   "source": [
+    "Rename \"gene\" column and get rid of \"FDR\" column."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "d0a71f1e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ensembl_gene_id</th>\n",
+       "      <th>has_eqtl</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>ENSG00000000419</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>ENSG00000000457</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>ENSG00000000460</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>ENSG00000000938</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>ENSG00000000971</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19387</th>\n",
+       "      <td>ENSG00000282936</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19388</th>\n",
+       "      <td>ENSG00000283041</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19389</th>\n",
+       "      <td>ENSG00000283050</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19390</th>\n",
+       "      <td>ENSG00000283078</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>19391</th>\n",
+       "      <td>ENSG00000283103</td>\n",
+       "      <td>True</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>19392 rows × 2 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       ensembl_gene_id  has_eqtl\n",
+       "0      ENSG00000000419      True\n",
+       "1      ENSG00000000457      True\n",
+       "2      ENSG00000000460      True\n",
+       "3      ENSG00000000938      True\n",
+       "4      ENSG00000000971      True\n",
+       "...                ...       ...\n",
+       "19387  ENSG00000282936      True\n",
+       "19388  ENSG00000283041      True\n",
+       "19389  ENSG00000283050      True\n",
+       "19390  ENSG00000283078      True\n",
+       "19391  ENSG00000283103      True\n",
+       "\n",
+       "[19392 rows x 2 columns]"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "eqtl_meta = eqtl_meta.rename(columns = {\"gene\": \"ensembl_gene_id\"}).drop(columns=\"FDR\")\n",
+    "eqtl_meta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40357c54",
+   "metadata": {},
+   "source": [
+    "Make sure there are no NA values in the data frame."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e70b7602",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "False\n",
+      "False\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(any(eqtl_meta[\"ensembl_gene_id\"].isna()))\n",
+    "print(any(eqtl_meta[\"has_eqtl\"].isna()))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32997bda",
+   "metadata": {},
+   "source": [
+    "Write to a file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "3a5fb20c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "eqtl_meta.to_csv(\"../output/eqtl_meta_analysis.csv\", index=False)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:agora]",
+   "language": "python",
+   "name": "conda-env-agora-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.15"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -86,7 +86,7 @@
             id: syn12514826.4
             format: csv
           - name: eqtl
-            id: syn12514912.2
+            id: syn12514912.3
             format: csv
           - name: proteomics
             id: syn18689335.3
@@ -112,11 +112,10 @@
           protein_level_threshold: 0.05
         column_rename:
           ensg: ensembl_gene_id
-          haseqtl: has_eqtl
         provenance:
           - syn25953363.4
           - syn12514826.4
-          - syn12514912.2
+          - syn12514912.3
           - syn18689335.3
           - syn35221005.2
           - syn27211942.1


### PR DESCRIPTION
This notebook ingests the file from Solly's meta-analysis (https://www.synapse.org/#!Synapse:syn16984815) and turns it into a file like the one we have been using for eQTL, with columns for `ensembl_gene_id` and `has_eqtl`. 

I omitted the column `hgnc_symbol` from this version of the file because it's never used in our transforms. I also made the column "has_eqtl" instead of "hasEqtl" so that no `column_rename` is necessary. The new file has been uploaded as version 3 of https://www.synapse.org/#!Synapse:syn12514912

The test and normal config.yaml have been updated to use the new version of this file. You can view the new notebook here https://github.com/Sage-Bionetworks/agora-data-tools/blob/3a0a361151e4ae2169e7a93efba5a5ed174691a5/data_analysis/notebooks/AG-1001_Preprocess_EQTL.ipynb