### PR TITLE
[AG-809] Synapse Upload Versions

### DIFF
--- a/agoradatatools/etl/load.py
+++ b/agoradatatools/etl/load.py
@@ -116,7 +116,7 @@ def load(
 
     try:
         file = File(file_path, parent=destination)
-        file = syn.store(file, activity=activity)
+        file = syn.store(file, activity=activity, forceVersion=False)
     except OSError as e:
         print(
             f"Either the file path ({file_path}) or the destination ({destination}) are invalid."


### PR DESCRIPTION
This PR makes a small change to `load.py` which prevents unchanged files from being minted as new versions in Synapse when uploaded repeatedly, such as in the case of testing the pipeline using:
```
python ./agoradatatools/process.py test_config.yaml
```
This has been tested by running the command above before and after this change to ensure that new versions were not created when `forceVersion` was set to `False` in `syn.store`