### PR TITLE
[AG-1016] CI pipeline should indicate failure when file upload fails 

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -18,9 +18,9 @@ jobs:
       matrix:
         python-version: [3.7, 3.8, 3.9]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -33,7 +33,7 @@ jobs:
         run: |
           pytest tests/ --cov=agoradatatools --cov-report=html
       - name: Upload pytest test results
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: pytest-results-${{ matrix.python-version }}
           path: htmlcov
@@ -46,8 +46,8 @@ jobs:
     name: test data processing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
         with:
           python-version: "3.9"
       - run: pip install -U setuptools

--- a/agoradatatools/errors.py
+++ b/agoradatatools/errors.py
@@ -1,0 +1,13 @@
+"""Custom error classes for agoradatatools."""
+
+
+class ADTError(Exception):
+    """Base class for all custom exceptions in agoradatatools."""
+
+
+class ADTDataProcessingError(ADTError):
+    """Error to be raised when Data Processing runs fail."""
+
+    def __init__(self, message):
+        super().__init__(message)
+        self.message = message

--- a/agoradatatools/etl/load.py
+++ b/agoradatatools/etl/load.py
@@ -86,7 +86,7 @@ def remove_non_values(d: dict) -> dict:
 
 def load(
     file_path: str, provenance: list, destination: str, syn: Synapse = None
-) -> Union[tuple, None]:
+) -> tuple:
     """Reads file to be loaded into Synapse
     :param syn: synapse object
     :return: synapse id of the file loaded into Synapse.  Returns None if it
@@ -99,8 +99,7 @@ def load(
         syn (synapseclient.Synapse, optional): synapseclient session. Defaults to None.
 
     Returns:
-        Union[tuple, None]: On success, returns a tuple of the name fo the file and the version number.
-                            On fail returns None.
+        tuple: Returns a tuple of the name fo the file and the version number.
     """
 
     if syn is None:

--- a/agoradatatools/etl/load.py
+++ b/agoradatatools/etl/load.py
@@ -105,32 +105,9 @@ def load(
 
     if syn is None:
         syn = utils._login_to_synapse()
-
-    try:
-        activity = Activity(used=provenance)
-    except ValueError:
-        print(str(provenance) + " has one or more invalid syn ids")
-        return (
-            None  # added to be more explicit and consistent with the rest of the script
-        )
-
-    try:
-        file = File(file_path, parent=destination)
-        file = syn.store(file, activity=activity, forceVersion=False)
-    except OSError as e:
-        print(
-            f"Either the file path ({file_path}) or the destination ({destination}) are invalid."
-        )
-
-        print(e)
-        return None
-    except ValueError:
-        print(
-            "Please make sure that the Synapse id of "
-            + "the provenances and the destination are valid"
-        )
-        return None
-
+    activity = Activity(used=provenance)
+    file = File(file_path, parent=destination)
+    file = syn.store(file, activity=activity, forceVersion=False)
     return (file.id, file.versionNumber)
 
 

--- a/agoradatatools/etl/load.py
+++ b/agoradatatools/etl/load.py
@@ -1,6 +1,5 @@
 import json
 import os
-from typing import Union
 
 import numpy as np
 import pandas as pd
@@ -110,7 +109,7 @@ def load(
     return (file.id, file.versionNumber)
 
 
-def df_to_json(df: pd.DataFrame, staging_path: str, filename: str) -> Union[None, str]:
+def df_to_json(df: pd.DataFrame, staging_path: str, filename: str) -> str:
     """Converts a data frame into a json file.
 
     Args:
@@ -119,29 +118,18 @@ def df_to_json(df: pd.DataFrame, staging_path: str, filename: str) -> Union[None
         filename (str): name of JSON file to be created
 
     Returns:
-        Union[None, str]: can return None (if the first `try` fails), or a string containing the name of the new JSON file if the function succeeds
+       str: Returns a string containing the name of the new JSON file
     """
 
-    try:
-        df = df.replace({np.nan: None})
-
-        df_as_dict = df.to_dict(orient="records")
-
-        temp_json = open(os.path.join(staging_path, filename), "w+")
-        json.dump(df_as_dict, temp_json, cls=NumpyEncoder, indent=2)
-    except Exception as e:
-        print(e)
-        try:  # this was failing if the `try` above fails before creating `temp_json`
-            temp_json.close()
-        except:
-            return None
-        return None
-
+    df = df.replace({np.nan: None})
+    df_as_dict = df.to_dict(orient="records")
+    temp_json = open(os.path.join(staging_path, filename), "w+")
+    json.dump(df_as_dict, temp_json, cls=NumpyEncoder, indent=2)
     temp_json.close()
     return temp_json.name
 
 
-def df_to_csv(df: pd.DataFrame, staging_path: str, filename: str) -> Union[None, str]:
+def df_to_csv(df: pd.DataFrame, staging_path: str, filename: str) -> str:
     """Converts a data frame into a csv file.
 
     Args:
@@ -150,21 +138,16 @@ def df_to_csv(df: pd.DataFrame, staging_path: str, filename: str) -> Union[None,
         filename (str): name of csv file to be created
 
     Returns:
-        Union[None, str]: can return None (if the first `try` fails), or a string containing the name of the new csv file if the function succeeds
+        str: Returns a string containing the name of the new CSV file
     """
-    try:
-        temp_csv = open(os.path.join(staging_path, filename), "w+")
-        df.to_csv(path_or_buf=temp_csv, index=False)
-    except AttributeError:
-        print("Invalid dataframe.")
-        temp_csv.close()
-        return None
 
+    temp_csv = open(os.path.join(staging_path, filename), "w+")
+    df.to_csv(path_or_buf=temp_csv, index=False)
     temp_csv.close()
     return temp_csv.name
 
 
-def dict_to_json(df: dict, staging_path: str, filename: str) -> Union[None, str]:
+def dict_to_json(df: dict, staging_path: str, filename: str) -> str:
     """Converts a data dictionary into a JSON file.
 
     Args:
@@ -173,24 +156,13 @@ def dict_to_json(df: dict, staging_path: str, filename: str) -> Union[None, str]
         filename (str): name of JSON file to be created
 
     Returns:
-        Union[None, str]: can return None (if the first `try` fails), or a string containing the name of the new JSON file if the function succeeds
+        str: Returns a string containing the name of the new JSON file
     """
-    try:
-        df_as_dict = [  # TODO explore the df.to_dict() function for this case
-            {
-                d: remove_non_values(v) if isinstance(v, dict) else v
-                for d, v in df.items()
-            }
-        ]
-        temp_json = open(os.path.join(staging_path, filename), "w+")
-        json.dump(df_as_dict, temp_json, cls=NumpyEncoder, indent=2)
-    except Exception as e:
-        print(e)
-        try:  # handle case where `try` fails before temp_json is created
-            temp_json.close()
-        except:
-            return None
-        return None
 
+    df_as_dict = [  # TODO explore the df.to_dict() function for this case
+        {d: remove_non_values(v) if isinstance(v, dict) else v for d, v in df.items()}
+    ]
+    temp_json = open(os.path.join(staging_path, filename), "w+")
+    json.dump(df_as_dict, temp_json, cls=NumpyEncoder, indent=2)
     temp_json.close()
     return temp_json.name

--- a/agoradatatools/process.py
+++ b/agoradatatools/process.py
@@ -1,5 +1,4 @@
 import argparse
-from typing import Union
 
 from pandas import DataFrame
 
@@ -11,9 +10,7 @@ import agoradatatools.etl.utils as utils
 from agoradatatools.errors import ADTDataProcessingError
 
 
-def process_dataset(
-    dataset_obj: dict, staging_path: str, syn=None
-) -> Union[tuple, None]:
+def process_dataset(dataset_obj: dict, staging_path: str, syn=None) -> tuple:
     """Takes in a dataset from the configuration file and passes it through the ETL process
 
     Args:
@@ -22,8 +19,7 @@ def process_dataset(
         syn (synapseclient.Synapse, optional): synapseclient.Synapse session. Defaults to None.
 
     Returns:
-        Union[tuple, None]: Tuple containing the id and version number of the uploaded file if successful,
-        returns None if not successful
+        syn_obj (tuple): Tuple containing the id and version number of the uploaded file.
     """
 
     dataset_name = list(dataset_obj.keys())[0]

--- a/agoradatatools/process.py
+++ b/agoradatatools/process.py
@@ -60,7 +60,7 @@ def process_dataset(
             df=df, column_map=dataset_obj[dataset_name]["agora_rename"]
         )
 
-    if type(df) == dict:
+    if isinstance(df, dict):
         json_path = load.dict_to_json(
             df=df,
             staging_path=staging_path,
@@ -148,7 +148,7 @@ def process_all_files(config_path: str = None, syn=None):
 
     destination = utils._find_config_by_name(config, "destination")
 
-    if error_list == []:
+    if not error_list:
         # create manifest if no errors
         manifest_df = create_data_manifest(parent=destination, syn=syn)
         manifest_path = load.df_to_csv(

--- a/agoradatatools/process.py
+++ b/agoradatatools/process.py
@@ -137,10 +137,7 @@ def process_all_files(config_path: str = None, syn=None):
     if datasets:
         for dataset in datasets:
             try:
-                new_syn_tuple = process_dataset(
-                    dataset_obj=dataset, staging_path=staging_path, syn=syn
-                )
-                # TODO in the future we should log new_syn_tuples that are none
+                process_dataset(dataset_obj=dataset, staging_path=staging_path, syn=syn)
             except Exception as e:
                 print(e)
                 error_list.append({list(dataset.keys())[0]: e})
@@ -148,7 +145,7 @@ def process_all_files(config_path: str = None, syn=None):
     destination = utils._find_config_by_name(config, "destination")
 
     if not error_list:
-        # create manifest if no errors
+        # create manifest if there are no errors
         manifest_df = create_data_manifest(parent=destination, syn=syn)
         manifest_path = load.df_to_csv(
             df=manifest_df, staging_path=staging_path, filename="data_manifest.csv"

--- a/agoradatatools/process.py
+++ b/agoradatatools/process.py
@@ -1,6 +1,7 @@
 import argparse
 
 from pandas import DataFrame
+import synapseclient
 
 import agoradatatools.etl.extract as extract
 import agoradatatools.etl.transform as transform
@@ -10,13 +11,15 @@ import agoradatatools.etl.utils as utils
 from agoradatatools.errors import ADTDataProcessingError
 
 
-def process_dataset(dataset_obj: dict, staging_path: str, syn=None) -> tuple:
+def process_dataset(
+    dataset_obj: dict, staging_path: str, syn: synapseclient.Synapse
+) -> tuple:
     """Takes in a dataset from the configuration file and passes it through the ETL process
 
     Args:
         dataset_obj (dict): A dataset defined in the configuration file
         staging_path (str): Staging path
-        syn (synapseclient.Synapse, optional): synapseclient.Synapse session. Defaults to None.
+        syn (synapseclient.Synapse): synapseclient.Synapse session.
 
     Returns:
         syn_obj (tuple): Tuple containing the id and version number of the uploaded file.
@@ -41,7 +44,7 @@ def process_dataset(dataset_obj: dict, staging_path: str, syn=None) -> tuple:
             )
 
         entities_as_df[entity_name] = df
-    # print(dataset_name)
+
     if "custom_transformations" in dataset_obj[dataset_name].keys():
         df = transform.apply_custom_transformations(
             datasets=entities_as_df,

--- a/agoradatatools/process.py
+++ b/agoradatatools/process.py
@@ -160,7 +160,7 @@ def process_all_files(config_path: str = None, syn=None):
         )
     else:
         raise ADTDataProcessingError(
-            "\nData Processing has failed for one or more data sources.\n Refer to the list of errors below to address issues:\n"
+            "\nData Processing has failed for one or more data sources. Refer to the list of errors below to address issues:\n"
             + "\n".join(error_list)
         )
 

--- a/agoradatatools/process.py
+++ b/agoradatatools/process.py
@@ -139,8 +139,9 @@ def process_all_files(config_path: str = None, syn=None):
             try:
                 process_dataset(dataset_obj=dataset, staging_path=staging_path, syn=syn)
             except Exception as e:
-                print(e)
-                error_list.append({list(dataset.keys())[0]: e})
+                error_list.append(
+                    f"{list(dataset.keys())[0]}: " + str(e).replace("\n", "")
+                )
 
     destination = utils._find_config_by_name(config, "destination")
 
@@ -159,8 +160,8 @@ def process_all_files(config_path: str = None, syn=None):
         )
     else:
         raise ADTDataProcessingError(
-            "Data Processing has failed for one or more data sources. Refer to the list of errors below to address issues:\n"
-            + str(error_list)
+            "\nData Processing has failed for one or more data sources.\n Refer to the list of errors below to address issues:\n"
+            + "\n".join(error_list)
         )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 pandas~=1.2.4
 numpy~=1.21.0
 pytest~=6.2.4
-synapseclient~=2.5.0
+synapseclient~=2.7.0
 setuptools~=49.2.1
 PyYAML~=5.4.1
 pyarrow~=3.0.0

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -1,5 +1,5 @@
 # - destination: &dest syn17015333
- - destination: &dest syn999999999
+- destination: &dest syn999999999
 - staging_path: ./staging
 - datasets:
     - genes_biodomains:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -1,4 +1,5 @@
-- destination: &dest syn17015333
+- destination: &dest syn999999999
+# - destination: &dest syn17015333
 - staging_path: ./staging
 - datasets:
     - genes_biodomains:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -1,5 +1,4 @@
-- destination: &dest syn999999999
-# - destination: &dest syn17015333
+- destination: &dest syn17015333
 - staging_path: ./staging
 - datasets:
     - genes_biodomains:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -1,5 +1,4 @@
-# - destination: &dest syn17015333
-- destination: &dest syn999999999
+- destination: &dest syn17015333
 - staging_path: ./staging
 - datasets:
     - genes_biodomains:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -1,4 +1,5 @@
-- destination: &dest syn17015333
+# - destination: &dest syn17015333
+ - destination: &dest syn999999999
 - staging_path: ./staging
 - datasets:
     - genes_biodomains:

--- a/tests/test_load/test_load.py
+++ b/tests/test_load/test_load.py
@@ -84,48 +84,6 @@ class TestLoad:
         self.patch_syn_login.assert_not_called()
         assert test_tuple == ("syn1111114", 1)
 
-    def test_load_activity_fails_ValueError(self):
-        captured_output = StringIO()
-        sys.stdout = captured_output
-        test_tuple = load.load(
-            file_path="fake/path/to/fake/file",
-            provenance=["not a syn id", "also not a syn id"],
-            destination="syn1111113",
-            syn=None,
-        )
-        self.patch_syn_login.assert_called_once()
-        assert "one or more invalid syn ids" in captured_output.getvalue()
-        self.patch_syn_store.assert_not_called()
-        assert test_tuple is None
-
-    def test_load_syn_store_fails_OSError(self):
-        self.patch_syn_store.side_effect = OSError  # can't induce failure in mocked object with arguments, so do manually
-        captured_output = StringIO()
-        sys.stdout = captured_output
-        test_tuple = load.load(
-            file_path="fake/path/to/fake/file",
-            provenance=["syn1111111", "syn1111112"],
-            destination="syn1111113",
-            syn=None,
-        )
-        self.patch_syn_login.assert_called_once()
-        assert "Either the file path" in captured_output.getvalue()
-        assert test_tuple is None
-
-    def test_load_syn_store_fails_ValueError(self):
-        self.patch_syn_store.side_effect = ValueError  # can't induce failure in mocked object with arguments, so do manually
-        captured_output = StringIO()
-        sys.stdout = captured_output
-        test_tuple = load.load(
-            file_path="fake/path/to/fake/file",
-            provenance=["syn1111111", "syn1111112"],
-            destination="syn1111113",
-            syn=None,
-        )
-        self.patch_syn_login.assert_called_once()
-        assert "Please make sure that the Synapse id of" in captured_output.getvalue()
-        assert test_tuple is None
-
 
 class TestDFToJSON:
     def setup_method(self):

--- a/tests/test_load/test_load.py
+++ b/tests/test_load/test_load.py
@@ -113,15 +113,6 @@ class TestDFToJSON:
         )
         assert json_name == "./staging/test.json"
 
-    def test_df_to_json_failure(self):
-        json_name = load.df_to_json(
-            df=pd.DataFrame(), staging_path=1, filename="test.json"
-        )
-        self.patch_replace.assert_called_once_with({np.nan: None})
-        self.patch_to_dict.assert_called_once_with(orient="records")
-        self.patch_json_dump.assert_not_called()  # should fail at the open() step
-        assert json_name is None
-
 
 class TestDFToCSV:
     def setup_method(self):
@@ -141,13 +132,6 @@ class TestDFToCSV:
             index=False,
         )
         assert csv_name == "./staging/test.json"
-
-    def test_df_to_csv_failure(self):
-        json_name = load.df_to_csv(
-            df="bad_df", staging_path="./staging", filename="test.json"
-        )
-        self.patch_to_csv.assert_not_called()  # invalid dataframe causes this not to be called and produces the AttributeError which is handled, but not raised
-        assert json_name is None
 
 
 class TestDictToJSON:
@@ -175,11 +159,3 @@ class TestDictToJSON:
             indent=2,
         )
         assert json_name == "./staging/test.json"
-
-    def test_dict_to_json_failure(self):
-        json_name = load.dict_to_json(
-            df=self.df_dict, staging_path=1, filename="test.json"
-        )
-        self.patch_remove_non_values.assert_called_once_with({"d": "e"})
-        self.patch_json_dump.assert_not_called()  # `try` fails on open() call now, no json.dump called
-        assert json_name is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,10 +54,9 @@ def test_get_config_with_no_config_path():
     assert list(config)[0] == {"destination": "syn12177492"}
 
 
-# commented out for testing
-# def test_get_config_with_config_path():
-#     config = utils._get_config(config_path="./test_config.yaml")
-#     assert list(config)[0] == {"destination": "syn17015333"}
+def test_get_config_with_config_path():
+    config = utils._get_config(config_path="./test_config.yaml")
+    assert list(config)[0] == {"destination": "syn17015333"}
 
 
 def test_find_config_by_name_where_name_in_config():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,9 +54,9 @@ def test_get_config_with_no_config_path():
     assert list(config)[0] == {"destination": "syn12177492"}
 
 
-def test_get_config_with_config_path():
-    config = utils._get_config(config_path="./test_config.yaml")
-    assert list(config)[0] == {"destination": "syn17015333"}
+# def test_get_config_with_config_path():
+#     config = utils._get_config(config_path="./test_config.yaml")
+#     assert list(config)[0] == {"destination": "syn17015333"}
 
 
 def test_find_config_by_name_where_name_in_config():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,9 +54,9 @@ def test_get_config_with_no_config_path():
     assert list(config)[0] == {"destination": "syn12177492"}
 
 
-# def test_get_config_with_config_path():
-#     config = utils._get_config(config_path="./test_config.yaml")
-#     assert list(config)[0] == {"destination": "syn17015333"}
+def test_get_config_with_config_path():
+    config = utils._get_config(config_path="./test_config.yaml")
+    assert list(config)[0] == {"destination": "syn17015333"}
 
 
 def test_find_config_by_name_where_name_in_config():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -54,9 +54,10 @@ def test_get_config_with_no_config_path():
     assert list(config)[0] == {"destination": "syn12177492"}
 
 
-def test_get_config_with_config_path():
-    config = utils._get_config(config_path="./test_config.yaml")
-    assert list(config)[0] == {"destination": "syn17015333"}
+# commented out for testing
+# def test_get_config_with_config_path():
+#     config = utils._get_config(config_path="./test_config.yaml")
+#     assert list(config)[0] == {"destination": "syn17015333"}
 
 
 def test_find_config_by_name_where_name_in_config():


### PR DESCRIPTION
This PR addresses the issue of failed data processing runs continuing to completion and resulting in outdated or incorrect versions of datasets being used downstream. In order to address this problem and simplify the codebase somewhat, I have implemented the following changes:

- Try/Excepts in `load.py` and  `process.process_dataset()` have been removed.
- Try/Except is implemented in `process.process_all_datasets()` to capture all error messages in one go.
- Tests in `test_load.py` adjusted for removed error handling.
- Formatted strings containing information about failed data processing are appended to `error_list` in the format: `"dataset_name: error_message"` in `process.process_all_datasets()`
- `error_list` is checked before manifest generation. If it is empty then the run is considered successful and a manifest is generated and uploaded. If it is not empty, the run is considered to have failed, and no manifest is created.
- In the event of a failed run, a custom exception I created is raised and the information about each dataset that failed is printed, allowing the user to investigate further with that information as a starting point. Example:
```
errors.ADTDataProcessingError: 
Data Processing has failed for one or more data sources. Refer to the list of errors below to address issues:
genes_biodomains: 403 Client Error: Lack of READ permission on the parent entity.
neuropath_corr: 403 Client Error: Lack of READ permission on the parent entity.
proteomics: 403 Client Error: Lack of READ permission on the parent entity.
```
These changes should provide a more unified approach to catching errors and notifying the user of them when running data processing.

I also bumped the versions of some dependencies and GitHub Actions:
- `synapseclient` from `2.5.0` -> `2.7.0`
- `actions/checkout@v2` -> `actions/checkout@v3`
- `actions/setup-python@v1` -> `actions/setup-python@v4`
- `actions/upload-artifact@v2` -> `actions/upload-artifact@v3`

Updating the GitHub Action versions seems to have had a positive effect on the time that it takes for our "Test Data Processing" Action to run, though [not always](https://github.com/Sage-Bionetworks/agora-data-tools/actions/runs/4440491841). Further testing and investigation may be necessary if long runtimes persist.
