### PR TITLE
[AG-1041] Adds timestamp logging for processing runs

### DIFF
--- a/src/agoradatatools/__init__.py
+++ b/src/agoradatatools/__init__.py
@@ -4,6 +4,6 @@ import logging
 logging.basicConfig(
     stream=sys.stdout,
     level=logging.INFO,
-    format="INFO | %(asctime)s | %(message)s",
+    format="%(levelname)s: %(asctime)s | %(name)s | %(message)s",
     datefmt="%Y-%m-%d %H:%M:%S",
 )

--- a/src/agoradatatools/__init__.py
+++ b/src/agoradatatools/__init__.py
@@ -1,5 +1,9 @@
 import sys
 import logging
 
-logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s")
-logger = logging.getLogger(__name__)
+logging.basicConfig(
+    stream=sys.stdout,
+    level=logging.INFO,
+    format="INFO | %(asctime)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)

--- a/src/agoradatatools/__init__.py
+++ b/src/agoradatatools/__init__.py
@@ -1,0 +1,5 @@
+import sys
+import logging
+
+logging.basicConfig(stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s")
+logger = logging.getLogger(__name__)

--- a/src/agoradatatools/logging.py
+++ b/src/agoradatatools/logging.py
@@ -1,0 +1,58 @@
+import time
+import logging
+import sys
+
+
+def format_seconds(seconds):
+    """Converts a floating-point seconds value to format hh:mm:ss format."""
+    minutes, seconds = divmod(int(seconds), 60)
+    hours, minutes = divmod(minutes, 60)
+    return f"{hours:02}:{minutes:02}:{seconds:02}"
+
+
+def log_time(config: str):
+    """Wrapper that calculates how long it takes for a function to run and then logs that time.
+
+    Args:
+        config (str): Name of function to be wrapped.
+        Set up configurations for process_dataset and process_all_files functions
+
+    Raises:
+        ValueError: If the configuration is not supported, error is raised.
+
+    Returns:
+        log: log containing timestamp for function run.
+    """
+    if config not in ["process_dataset", "process_all_files"]:
+        raise ValueError(f"configuration {config} not supported for log_time wrapper.")
+
+    def log(func):
+        # 'wrap' this puppy up if needed
+        def wrapped(*args, **kwargs):
+            # start timing
+            start_time = time.monotonic()
+            func(*args, **kwargs)
+            # Record the end time
+            end_time = time.monotonic()
+            # Calculate the elapsed time
+            elapsed_time = round(end_time - start_time, 2)
+            elapse_time_formatted = format_seconds(elapsed_time)
+            logger = logging.getLogger()
+            logging.basicConfig(
+                stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s"
+            )
+            if config == "process_dataset":
+                dataset = next(iter(kwargs["dataset_obj"]))
+                logger.info(
+                    "Elapsed time: %s for %s dataset",
+                    elapse_time_formatted,
+                    dataset,
+                )
+            if config == "process_all_files":
+                logger.info(
+                    "Elapsed time: %s for all data processing", elapse_time_formatted
+                )
+
+        return wrapped
+
+    return log

--- a/src/agoradatatools/logs.py
+++ b/src/agoradatatools/logs.py
@@ -10,6 +10,15 @@ def format_seconds(seconds):
     return f"{hours:02}:{minutes:02}:{seconds:02}"
 
 
+def create_logger():
+    """Creates basic logger."""
+    logger = logging.getLogger()
+    logging.basicConfig(
+        stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s"
+    )
+    return logger
+
+
 def log_time(config: str):
     """Wrapper that calculates how long it takes for a function to run and then logs that time.
 
@@ -37,21 +46,17 @@ def log_time(config: str):
             # Calculate the elapsed time
             elapsed_time = round(end_time - start_time, 2)
             elapse_time_formatted = format_seconds(elapsed_time)
-            logger = logging.getLogger()
-            logging.basicConfig(
-                stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s"
-            )
+            logger = create_logger()
             if config == "process_dataset":
                 dataset = next(iter(kwargs["dataset_obj"]))
-                logger.info(
-                    "Elapsed time: %s for %s dataset",
-                    elapse_time_formatted,
-                    dataset,
-                )
+                string_list = [elapse_time_formatted, dataset]
+                message = "Elapsed time: %s for %s dataset"
+
             if config == "process_all_files":
-                logger.info(
-                    "Elapsed time: %s for all data processing", elapse_time_formatted
-                )
+                string_list = [elapse_time_formatted]
+                message = "Elapsed time: %s for all data processing"
+
+            logger.info(message, *string_list)
 
         return wrapped
 

--- a/src/agoradatatools/logs.py
+++ b/src/agoradatatools/logs.py
@@ -1,6 +1,5 @@
 import time
-
-from . import logger
+import logging
 
 
 def format_seconds(seconds):
@@ -10,12 +9,23 @@ def format_seconds(seconds):
     return f"{hours:02}:{minutes:02}:{seconds:02}"
 
 
-def log_time(config: str):
-    """Wrapper that calculates how long it takes for a function to run and then logs that time.
+def time_function(func, *args, **kwargs):
+    """Returns the elapsed time for a function to run."""
+    start_time = time.monotonic()
+    func(*args, **kwargs)
+    end_time = time.monotonic()
+    elapsed_time = end_time - start_time
+    elapsed_time_formatted = format_seconds(elapsed_time)
+    return elapsed_time_formatted
+
+
+def log_time(func_name: str, logger: logging.Logger):
+    """Decorator function that calculates how long it takes for a function to run and then logs that time.
 
     Args:
-        config (str): Name of function to be wrapped.
+        func_name (str): Name of function to be wrapped.
         Set up configurations for process_dataset and process_all_files functions
+        logger (logging.Logger): logger initialized in the module this decorator is used in
 
     Raises:
         ValueError: If the configuration is not supported, error is raised.
@@ -23,27 +33,26 @@ def log_time(config: str):
     Returns:
         log: log containing timestamp for function run.
     """
-    if config not in ["process_dataset", "process_all_files"]:
-        raise ValueError(f"configuration {config} not supported for log_time wrapper.")
+    if func_name not in ["process_dataset", "process_all_files"]:
+        raise ValueError(
+            f"configuration {func_name} not supported for log_time decorator."
+        )
 
     def log(func):
         def wrapped(*args, **kwargs):
-            # start timing
-            start_time = time.monotonic()
-            func(*args, **kwargs)
-            # Record the end time
-            end_time = time.monotonic()
-            # Calculate the elapsed time
-            elapsed_time = round(end_time - start_time, 2)
-            elapse_time_formatted = format_seconds(elapsed_time)
-            # logger = create_logger()
-            if config == "process_dataset":
+            if func_name == "process_dataset":
                 dataset = next(iter(kwargs["dataset_obj"]))
-                string_list = [elapse_time_formatted, dataset]
+                logger.info("Now processing %s dataset", dataset)
+                elapsed_time_formatted = time_function(func, *args, **kwargs)
+                logger.info("Processing complete for %s dataset", dataset)
+                string_list = [elapsed_time_formatted, dataset]
                 message = "Elapsed time: %s for %s dataset"
 
-            if config == "process_all_files":
-                string_list = [elapse_time_formatted]
+            if func_name == "process_all_files":
+                logger.info("Agora Data Tools processing has started")
+                elapsed_time_formatted = time_function(func, *args, **kwargs)
+                logger.info("Agora Data Tools processing has completed")
+                string_list = [elapsed_time_formatted]
                 message = "Elapsed time: %s for all data processing"
 
             logger.info(message, *string_list)

--- a/src/agoradatatools/logs.py
+++ b/src/agoradatatools/logs.py
@@ -36,7 +36,6 @@ def log_time(config: str):
         raise ValueError(f"configuration {config} not supported for log_time wrapper.")
 
     def log(func):
-        # 'wrap' this puppy up if needed
         def wrapped(*args, **kwargs):
             # start timing
             start_time = time.monotonic()

--- a/src/agoradatatools/logs.py
+++ b/src/agoradatatools/logs.py
@@ -1,6 +1,6 @@
-import logging
-import sys
 import time
+
+from . import logger
 
 
 def format_seconds(seconds):
@@ -8,15 +8,6 @@ def format_seconds(seconds):
     minutes, seconds = divmod(int(seconds), 60)
     hours, minutes = divmod(minutes, 60)
     return f"{hours:02}:{minutes:02}:{seconds:02}"
-
-
-def create_logger():
-    """Creates basic logger."""
-    logger = logging.getLogger()
-    logging.basicConfig(
-        stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s"
-    )
-    return logger
 
 
 def log_time(config: str):
@@ -45,7 +36,7 @@ def log_time(config: str):
             # Calculate the elapsed time
             elapsed_time = round(end_time - start_time, 2)
             elapse_time_formatted = format_seconds(elapsed_time)
-            logger = create_logger()
+            # logger = create_logger()
             if config == "process_dataset":
                 dataset = next(iter(kwargs["dataset_obj"]))
                 string_list = [elapse_time_formatted, dataset]

--- a/src/agoradatatools/logs.py
+++ b/src/agoradatatools/logs.py
@@ -1,6 +1,6 @@
-import time
 import logging
 import sys
+import time
 
 
 def format_seconds(seconds):

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -1,3 +1,4 @@
+import logging
 import synapseclient
 from pandas import DataFrame
 from typer import Argument, Option, Typer
@@ -9,8 +10,10 @@ import agoradatatools.etl.utils as utils
 from agoradatatools.errors import ADTDataProcessingError
 from agoradatatools.logs import log_time
 
+logger = logging.getLogger(__name__)
 
-@log_time(config="process_dataset")
+
+@log_time(config="process_dataset", logger=logger)
 def process_dataset(
     dataset_obj: dict, staging_path: str, syn: synapseclient.Synapse
 ) -> tuple:
@@ -108,7 +111,7 @@ def create_data_manifest(parent=None, syn=None) -> DataFrame:
     return DataFrame(folder)
 
 
-@log_time(config="process_all_files")
+@log_time(config="process_all_files", logger=logger)
 def process_all_files(config_path: str = None, syn=None):
     """This function will read through the entire configuration and process each file listed.
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -13,7 +13,7 @@ from agoradatatools.logs import log_time
 logger = logging.getLogger(__name__)
 
 
-@log_time(config="process_dataset", logger=logger)
+@log_time(func_name="process_dataset", logger=logger)
 def process_dataset(
     dataset_obj: dict, staging_path: str, syn: synapseclient.Synapse
 ) -> tuple:
@@ -111,7 +111,7 @@ def create_data_manifest(parent=None, syn=None) -> DataFrame:
     return DataFrame(folder)
 
 
-@log_time(config="process_all_files", logger=logger)
+@log_time(func_name="process_all_files", logger=logger)
 def process_all_files(config_path: str = None, syn=None):
     """This function will read through the entire configuration and process each file listed.
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -7,7 +7,7 @@ import agoradatatools.etl.load as load
 import agoradatatools.etl.transform as transform
 import agoradatatools.etl.utils as utils
 from agoradatatools.errors import ADTDataProcessingError
-from agoradatatools.logging import log_time
+from agoradatatools.logs import log_time
 
 
 @log_time(config="process_dataset")

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -1,4 +1,7 @@
 import os
+import time
+import logging
+import sys
 
 import synapseclient
 from pandas import DataFrame
@@ -11,6 +14,52 @@ import agoradatatools.etl.utils as utils
 from agoradatatools.errors import ADTDataProcessingError
 
 
+def log_time_process_dataset():
+    def log(func):
+        # 'wrap' this puppy up if needed
+        def wrapped(*args, **kwargs):
+            # start timing
+            start_time = time.monotonic()
+            func(*args, **kwargs)
+            # Record the end time
+            end_time = time.monotonic()
+            # Calculate the elapsed time
+            elapsed_time = round(end_time - start_time, 2)
+            logger = logging.getLogger()
+            logging.basicConfig(
+                stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s"
+            )
+            dataset = next(iter(kwargs["dataset_obj"]))
+            logger.info(f"Elapsed time: {elapsed_time} seconds for {dataset} dataset")
+
+        return wrapped
+
+    return log
+
+
+def log_time_process_all_files():
+    def log(func):
+        # 'wrap' this puppy up if needed
+        def wrapped(*args, **kwargs):
+            # start timing
+            start_time = time.monotonic()
+            func(*args, **kwargs)
+            # Record the end time
+            end_time = time.monotonic()
+            # Calculate the elapsed time
+            elapsed_time = round(end_time - start_time, 2)
+            logger = logging.getLogger()
+            logging.basicConfig(
+                stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s"
+            )
+            logger.info(f"Elapsed time: {elapsed_time} seconds for All Uploads")
+
+        return wrapped
+
+    return log
+
+
+@log_time_process_dataset()
 def process_dataset(
     dataset_obj: dict, staging_path: str, syn: synapseclient.Synapse
 ) -> tuple:
@@ -108,6 +157,7 @@ def create_data_manifest(parent=None, syn=None) -> DataFrame:
     return DataFrame(folder)
 
 
+@log_time_process_all_files()
 def process_all_files(config_path: str = None, syn=None):
     """This function will read through the entire configuration and process each file listed.
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -1,8 +1,3 @@
-import os
-import time
-import logging
-import sys
-
 import synapseclient
 from pandas import DataFrame
 from typer import Argument, Option, Typer
@@ -12,54 +7,10 @@ import agoradatatools.etl.load as load
 import agoradatatools.etl.transform as transform
 import agoradatatools.etl.utils as utils
 from agoradatatools.errors import ADTDataProcessingError
+from agoradatatools.logging import log_time
 
 
-def log_time_process_dataset():
-    def log(func):
-        # 'wrap' this puppy up if needed
-        def wrapped(*args, **kwargs):
-            # start timing
-            start_time = time.monotonic()
-            func(*args, **kwargs)
-            # Record the end time
-            end_time = time.monotonic()
-            # Calculate the elapsed time
-            elapsed_time = round(end_time - start_time, 2)
-            logger = logging.getLogger()
-            logging.basicConfig(
-                stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s"
-            )
-            dataset = next(iter(kwargs["dataset_obj"]))
-            logger.info(f"Elapsed time: {elapsed_time} seconds for {dataset} dataset")
-
-        return wrapped
-
-    return log
-
-
-def log_time_process_all_files():
-    def log(func):
-        # 'wrap' this puppy up if needed
-        def wrapped(*args, **kwargs):
-            # start timing
-            start_time = time.monotonic()
-            func(*args, **kwargs)
-            # Record the end time
-            end_time = time.monotonic()
-            # Calculate the elapsed time
-            elapsed_time = round(end_time - start_time, 2)
-            logger = logging.getLogger()
-            logging.basicConfig(
-                stream=sys.stdout, level=logging.INFO, format="INFO: %(message)s"
-            )
-            logger.info(f"Elapsed time: {elapsed_time} seconds for All Uploads")
-
-        return wrapped
-
-    return log
-
-
-@log_time_process_dataset()
+@log_time(config="process_dataset")
 def process_dataset(
     dataset_obj: dict, staging_path: str, syn: synapseclient.Synapse
 ) -> tuple:
@@ -157,7 +108,7 @@ def create_data_manifest(parent=None, syn=None) -> DataFrame:
     return DataFrame(folder)
 
 
-@log_time_process_all_files()
+@log_time(config="process_all_files")
 def process_all_files(config_path: str = None, syn=None):
     """This function will read through the entire configuration and process each file listed.
 


### PR DESCRIPTION
This PR adds a new module to `agoradatatools`: `logs.py`. The new module contains the `log_time` decorator function along with a couple of helper functions. log_time` works by decorating a function like so:
```
@log_time(func_name="process_dataset", logger=logger)
def process_dataset():
     ...
```
It takes the name of the function (for configuring the logging output) and the `logger` instance for the module that it is being used in as arguments. At the moment, `log_time` has configurations for `process_dataset` and `process_all_files`, so that we can time and timestamp the processing of each dataset and data processing as a whole.

In practice, when you run `adt test_config.yaml`, you should see an output like this for each dataset:
```
INFO | 2023-05-04 16:05:00 | Now processing genes_biodomains dataset

##################################################
 Uploading file to Synapse storage 
##################################################

INFO | 2023-05-04 16:05:12 | 
##################################################
 Uploading file to Synapse storage 
##################################################

 / INFO | 2023-05-04 16:05:13 | Processing complete for genes_biodomains dataset
INFO | 2023-05-04 16:05:13 | Elapsed time: 00:00:13 for genes_biodomains dataset
```

And like this for the whole process:
```
INFO | 2023-05-04 16:04:47 | Agora Data Tools processing has started
...
...
...
...
INFO | 2023-05-04 16:07:12 | Elapsed time: 00:02:11 for all data processing
```