### PR TITLE
AG-1001: Align config.yaml with test_config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -112,7 +112,6 @@
           protein_level_threshold: 0.05
         column_rename:
           ensg: ensembl_gene_id
-          haseqtl: has_eqtl
         provenance:
           - syn25953363.6
           - syn12514826.4


### PR DESCRIPTION
The new version of the EQTL source file changed the hasEqtl column to has_eqtl, so the column_rename we had in place to adjust the name is no longer needed.