### PR TITLE
Added tests and test input/output for the team_info transform

### DIFF
--- a/tests/test_assets/team_info/input/team_info_good_input.csv
+++ b/tests/test_assets/team_info/input/team_info_good_input.csv
@@ -1,0 +1,4 @@
+team,team_full,program,description
+Team A,Team A University,AMP-AD,Description of team A's research.
+Team B,Team B University,AMP-AD,Team B does 'omics research. 
+Team-C,Team C Lab - Team C University / Biotech Corp,Community Contributed,"Description of Team-C's research, which involves imaging."

--- a/tests/test_assets/team_info/input/team_info_missing_input.csv
+++ b/tests/test_assets/team_info/input/team_info_missing_input.csv
@@ -1,0 +1,4 @@
+team,team_full,program,description
+,Team A University,AMP-AD,Description of team A's research.
+Team B,,AMP-AD,Team B does 'omics research. 
+Team-C,Team C Lab - Team C University / Biotech Corp,,

--- a/tests/test_assets/team_info/input/team_member_info_good_input.csv
+++ b/tests/test_assets/team_info/input/team_member_info_good_input.csv
@@ -1,0 +1,8 @@
+team,name,isprimaryinvestigator,url
+Team A,A. Scientist,TRUE,http://www.fake-url.edu/a-scientist
+Team A,P-I Jones,TRUE,
+Team A,Jane Doe,FALSE,http://www.fake-url.edu/citations?user=janedoe;year=2020
+Team B,John Smith,FALSE,
+Team B,Bea Scientist,TRUE,
+Team-C,P-I Smythe,TRUE,http://www.fake-url.edu/#profile/lab=team%20c
+Team-C,J. O'Brian,FALSE,

--- a/tests/test_assets/team_info/input/team_member_info_missing_input.csv
+++ b/tests/test_assets/team_info/input/team_member_info_missing_input.csv
@@ -1,0 +1,8 @@
+team,name,isprimaryinvestigator,url
+Team A,A. Scientist,TRUE,http://www.fake-url.edu/a-scientist
+,P-I Jones,TRUE,
+Team A,Jane Doe,FALSE,http://www.fake-url.edu/citations?user=janedoe;year=2020
+Team B,,FALSE,
+Team B,Bea Scientist,TRUE,
+Team-C,P-I Smythe,,http://www.fake-url.edu/#profile/lab=team%20c
+Team-C,J. O'Brian,FALSE,

--- a/tests/test_assets/team_info/output/team_info_good_test_output.json
+++ b/tests/test_assets/team_info/output/team_info_good_test_output.json
@@ -1,0 +1,61 @@
+[
+  {
+    "team": "Team A",
+    "team_full": "Team A University",
+    "program": "AMP-AD",
+    "description": "Description of team A's research.",
+    "members": [
+      {
+        "isprimaryinvestigator": true,
+        "name": "A. Scientist",
+        "url": "http://www.fake-url.edu/a-scientist"
+      },
+      {
+        "isprimaryinvestigator": true,
+        "name": "P-I Jones",
+        "url": ""
+      },
+      {
+        "isprimaryinvestigator": false,
+        "name": "Jane Doe",
+        "url": "http://www.fake-url.edu/citations?user=janedoe;year=2020"
+      }
+    ]
+  },
+  {
+    "team": "Team B",
+    "team_full": "Team B University",
+    "program": "AMP-AD",
+    "description": "Team B does 'omics research. ",
+    "members": [
+      {
+        "isprimaryinvestigator": false,
+        "name": "John Smith",
+        "url": ""
+      },
+      {
+        "isprimaryinvestigator": true,
+        "name": "Bea Scientist",
+        "url": ""
+      }
+    ]
+  },
+  {
+    "team": "Team-C",
+    "team_full": "Team C Lab - Team C University / Biotech Corp",
+    "program": "Community Contributed",
+    "description": "Description of Team-C's research, which involves imaging.",
+    "members": [
+      {
+        "isprimaryinvestigator": true,
+        "name": "P-I Smythe",
+        "url": "http://www.fake-url.edu/#profile/lab=team%20c"
+      },
+      {
+        "isprimaryinvestigator": false,
+        "name": "J. O'Brian",
+        "url": ""
+      }
+    ]
+  }
+]

--- a/tests/test_assets/team_info/output/team_info_missing_both_test_output.json
+++ b/tests/test_assets/team_info/output/team_info_missing_both_test_output.json
@@ -1,0 +1,45 @@
+[
+  {
+    "team": null,
+    "team_full": "Team A University",
+    "program": "AMP-AD",
+    "description": "Description of team A's research.",
+    "members": null
+  },
+  {
+    "team": "Team B",
+    "team_full": null,
+    "program": "AMP-AD",
+    "description": "Team B does 'omics research. ",
+    "members": [
+      {
+        "isprimaryinvestigator": false,
+        "name": "",
+        "url": ""
+      },
+      {
+        "isprimaryinvestigator": true,
+        "name": "Bea Scientist",
+        "url": ""
+      }
+    ]
+  },
+  {
+    "team": "Team-C",
+    "team_full": "Team C Lab - Team C University / Biotech Corp",
+    "program": null,
+    "description": null,
+    "members": [
+      {
+        "isprimaryinvestigator": "",
+        "name": "P-I Smythe",
+        "url": "http://www.fake-url.edu/#profile/lab=team%20c"
+      },
+      {
+        "isprimaryinvestigator": false,
+        "name": "J. O'Brian",
+        "url": ""
+      }
+    ]
+  }
+]

--- a/tests/test_assets/team_info/output/team_info_missing_ti_test_output.json
+++ b/tests/test_assets/team_info/output/team_info_missing_ti_test_output.json
@@ -1,0 +1,45 @@
+[
+  {
+    "team": null,
+    "team_full": "Team A University",
+    "program": "AMP-AD",
+    "description": "Description of team A's research.",
+    "members": null
+  },
+  {
+    "team": "Team B",
+    "team_full": null,
+    "program": "AMP-AD",
+    "description": "Team B does 'omics research. ",
+    "members": [
+      {
+        "isprimaryinvestigator": false,
+        "name": "John Smith",
+        "url": ""
+      },
+      {
+        "isprimaryinvestigator": true,
+        "name": "Bea Scientist",
+        "url": ""
+      }
+    ]
+  },
+  {
+    "team": "Team-C",
+    "team_full": "Team C Lab - Team C University / Biotech Corp",
+    "program": null,
+    "description": null,
+    "members": [
+      {
+        "isprimaryinvestigator": true,
+        "name": "P-I Smythe",
+        "url": "http://www.fake-url.edu/#profile/lab=team%20c"
+      },
+      {
+        "isprimaryinvestigator": false,
+        "name": "J. O'Brian",
+        "url": ""
+      }
+    ]
+  }
+]

--- a/tests/test_assets/team_info/output/team_info_missing_tmi_test_output.json
+++ b/tests/test_assets/team_info/output/team_info_missing_tmi_test_output.json
@@ -1,0 +1,56 @@
+[
+  {
+    "team": "Team A",
+    "team_full": "Team A University",
+    "program": "AMP-AD",
+    "description": "Description of team A's research.",
+    "members": [
+      {
+        "isprimaryinvestigator": true,
+        "name": "A. Scientist",
+        "url": "http://www.fake-url.edu/a-scientist"
+      },
+      {
+        "isprimaryinvestigator": false,
+        "name": "Jane Doe",
+        "url": "http://www.fake-url.edu/citations?user=janedoe;year=2020"
+      }
+    ]
+  },
+  {
+    "team": "Team B",
+    "team_full": "Team B University",
+    "program": "AMP-AD",
+    "description": "Team B does 'omics research. ",
+    "members": [
+      {
+        "isprimaryinvestigator": false,
+        "name": "",
+        "url": ""
+      },
+      {
+        "isprimaryinvestigator": true,
+        "name": "Bea Scientist",
+        "url": ""
+      }
+    ]
+  },
+  {
+    "team": "Team-C",
+    "team_full": "Team C Lab - Team C University / Biotech Corp",
+    "program": "Community Contributed",
+    "description": "Description of Team-C's research, which involves imaging.",
+    "members": [
+      {
+        "isprimaryinvestigator": "",
+        "name": "P-I Smythe",
+        "url": "http://www.fake-url.edu/#profile/lab=team%20c"
+      },
+      {
+        "isprimaryinvestigator": false,
+        "name": "J. O'Brian",
+        "url": ""
+      }
+    ]
+  }
+]

--- a/tests/transform/test_team_info.py
+++ b/tests/transform/test_team_info.py
@@ -1,0 +1,74 @@
+import os
+import pandas as pd
+import pytest
+
+from agoradatatools.etl.transform import team_info
+
+class TestTransformTeamInfo:
+    data_files_path = "tests/test_assets/team_info"
+    pass_test_data = [
+        (  # Pass with good data
+            "team_info_good_input.csv",
+            "team_member_info_good_input.csv",
+            "team_info_good_test_output.json",
+        ),
+        # For the following 3 cases, we do NOT expect to ever have missing data
+        # in any column except for "url", because this data is hand-curated. 
+        # We are testing this scenario anyway, just in case. 
+        (  # Pass with missing values in team_info file
+            "team_info_missing_input.csv",
+            "team_member_info_good_input.csv",
+            "team_info_missing_ti_test_output.json",
+        ),
+        (  # Pass with missing values in team_member_info file
+            "team_info_good_input.csv",
+            "team_member_info_missing_input.csv",
+            "team_info_missing_tmi_test_output.json",
+        ),
+        (  # Pass with missing values in both input files
+            "team_info_missing_input.csv",
+            "team_member_info_missing_input.csv",
+            "team_info_missing_both_test_output.json",
+        )
+    ]
+    pass_test_ids = [
+        "Pass with good data",
+        "Pass with missing values in team_info file",
+        "Pass with missing values in team_member_info file",
+        "Pass with missing values in both input files"
+    ]
+    fail_test_data = [
+        # No failure cases for this transform
+    ]
+    fail_test_ids = [
+        # No failure cases for this transform
+    ]
+
+    @pytest.mark.parametrize(
+        "team_info_file, team_member_file, expected_output_file", pass_test_data, ids=pass_test_ids
+    )
+    def test_transform_team_info_should_pass(
+        self, team_info_file, team_member_file, expected_output_file
+    ):
+        team_info_df = pd.read_csv(os.path.join(self.data_files_path, "input", team_info_file))
+        team_member_df = pd.read_csv(os.path.join(self.data_files_path, "input", team_member_file))
+        output_df = team_info.transform_team_info(
+            datasets={"team_info": team_info_df, "team_member_info": team_member_df}
+        )
+        expected_df = pd.read_json(
+            os.path.join(self.data_files_path, "output", expected_output_file),
+        )
+        pd.testing.assert_frame_equal(output_df, expected_df)
+
+
+    """
+    # Leaving code stub for failure case, in case we want to add this in the future
+    @pytest.mark.parametrize("team_info_file, team_member_file", fail_test_data, ids=fail_test_ids)
+    def test_transform_team_info_should_fail(self, team_info_file, team_member_file):
+        with pytest.raises(<Error type>):
+            team_info_df = pd.read_csv(os.path.join(self.data_files_path, "input", team_info_file))
+            team_member_df = pd.read_csv(os.path.join(self.data_files_path, "input", team_member_file))
+            team_info.transform_team_info(
+                datasets={"team_info": team_info_df, "team_member_info": team_member_df}
+            )
+    """


### PR DESCRIPTION
This test has 4 test cases, all of which should pass. There are no failure cases for this transform, as the transform is simple and doesn't care what the values are in each column. Since the data in the original team info source files is hand-curated and small, we assume that the contents of each column have been validated by the person curating the file, prior to the transform. 

I made the test files to have values with a few properties, some of which are not explicitly tested by this test but may be useful in future: 
- missing a value in various columns
- punctuation in the team names and people names
- special characters in the URL fields (which I verified made it through `standardize_values` intact)
- One team with multiple `isprincipalinvestigator` TRUE values (which happens in the real files)