### PR TITLE
AG-1154: Added biodomains column to gene_info transform

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -106,12 +106,16 @@
           - name: druggability
             id: syn13363443.11
             format: csv
+          - name: genes_biodomains
+            id: syn44151254.1
+            format: csv
         final_format: json
         custom_transformations:
           adjusted_p_value_threshold: 0.05
           protein_level_threshold: 0.05
         column_rename:
           ensg: ensembl_gene_id
+          ensembl_id: ensembl_gene_id
         provenance:
           - syn25953363.6
           - syn12514826.4
@@ -122,6 +126,7 @@
           - syn12540368.36
           - syn27211878.2
           - syn13363443.11
+          - syn44151254.1
         agora_rename:
           has_eqtl: haseqtl
           is_igap: isIGAP

--- a/src/agoradatatools/etl/transform/gene_info.py
+++ b/src/agoradatatools/etl/transform/gene_info.py
@@ -20,6 +20,7 @@ def transform_gene_info(
     target_list = datasets["target_list"]
     median_expression = datasets["median_expression"]
     druggability = datasets["druggability"]
+    biodomains = datasets["genes_biodomains"]
 
     # Modify the data before merging
 
@@ -69,6 +70,14 @@ def transform_gene_info(
         df=druggability, grouping="geneid", new_column="druggability"
     )
     druggability.rename(columns={"geneid": "ensembl_gene_id"}, inplace=True)
+    
+    biodomains = (
+        biodomains.groupby("ensembl_gene_id")["biodomain"]
+        .apply(set) # ensure unique biodomain names
+        .apply(list)
+        .reset_index()
+        .rename(columns={"biodomain": "biodomains"})
+    )
 
     # Merge all the datasets
 
@@ -82,6 +91,7 @@ def transform_gene_info(
         target_list,
         median_expression,
         druggability,
+        biodomains
     ]:
         gene_info = pd.merge(
             left=gene_info,
@@ -142,6 +152,7 @@ def transform_gene_info(
             "median_expression",
             "druggability",
             "nominations",
+            "biodomains"
         ]
     ]
 

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -106,12 +106,16 @@
           - name: druggability
             id: syn13363443.11
             format: csv
+          - name: genes_biodomains
+            id: syn44151254.1
+            format: csv
         final_format: json
         custom_transformations:
           adjusted_p_value_threshold: 0.05
           protein_level_threshold: 0.05
         column_rename:
           ensg: ensembl_gene_id
+          ensembl_id: ensembl_gene_id
         provenance:
           - syn25953363.6
           - syn12514826.4
@@ -122,6 +126,7 @@
           - syn12540368.36
           - syn27211878.2
           - syn13363443.11
+          - syn44151254.1
         agora_rename:
           has_eqtl: haseqtl
           is_igap: isIGAP


### PR DESCRIPTION
Modified the `gene_info` transform to include a column called "biodomains", which contains a list of all biodomains associated with each Ensembl ID. This data comes from the `gene_biodomains` input file, syn44151254.1. 

Both `test_config.yaml` and `config.yaml` have been updated to include the new input file under the `gene_info` dataset, including provenance. 

I spot-checked the resulting `gene_info.json` file and confirmed that the only difference is the addition of a "biodomains" field, which has the biodomains in list format. 