### PR TITLE
Added transform for biodomain_info

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,8 @@
         custom_transformations: 1
         provenance:
           - syn44151254.1
+        column_rename:
+          biodomain: name
         destination: *dest
         
     - genes_biodomains:

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,17 @@
 - destination: &dest syn12177492
 - staging_path: ./staging
 - datasets:
+    - biodomain_info:
+        files:
+          - name: genes_biodomains
+            id: syn44151254.1
+            format: csv
+        final_format: json
+        custom_transformations: 1
+        provenance:
+          - syn44151254.1
+        destination: *dest
+        
     - genes_biodomains:
         files:
           - name: genes_biodomains

--- a/src/agoradatatools/etl/transform/__init__.py
+++ b/src/agoradatatools/etl/transform/__init__.py
@@ -4,6 +4,9 @@ from agoradatatools.etl.transform.distribution_data import (
     transform_distribution_data,
 )
 from agoradatatools.etl.transform.gene_info import transform_gene_info
+from agoradatatools.etl.transform.biodomain_info import (
+    transform_biodomain_info,
+)
 from agoradatatools.etl.transform.genes_biodomains import (
     transform_genes_biodomains,
 )
@@ -22,6 +25,7 @@ from agoradatatools.etl.transform.team_info import transform_team_info
 __all__ = [
     "transform_distribution_data",
     "transform_gene_info",
+    "transform_biodomain_info",
     "transform_genes_biodomains",
     "transform_overall_scores",
     "create_proteomics_distribution_data",

--- a/src/agoradatatools/etl/transform/biodomain_info.py
+++ b/src/agoradatatools/etl/transform/biodomain_info.py
@@ -14,12 +14,11 @@ def transform_biodomain_info(datasets: dict) -> pd.DataFrame:
     """
     genes_biodomains = datasets["genes_biodomains"]
     biodomain_info = (
-        genes_biodomains["biodomain"]
+        genes_biodomains["name"]
         .dropna()
         .drop_duplicates()
         .reset_index()
         .drop(columns="index")
-        .rename(columns={"biodomain": "name"})
         .sort_values(by="name", ignore_index=True)
     )
 

--- a/src/agoradatatools/etl/transform/biodomain_info.py
+++ b/src/agoradatatools/etl/transform/biodomain_info.py
@@ -1,0 +1,26 @@
+import pandas as pd
+
+
+def transform_biodomain_info(datasets: dict) -> pd.DataFrame:
+    """Takes dictionary of dataset DataFrames, extracts the genes_biodomains
+    DataFrame, gets a unique list of biodomain names, and outputs the list as
+    a single-column DataFrame with column "name".
+
+    Args:
+        datasets (dict[str, pd.DataFrame]): dictionary of dataset names mapped to their DataFrame
+
+    Returns:
+        pd.DataFrame: 1-column DataFrame with column "name"
+    """
+    genes_biodomains = datasets["genes_biodomains"]
+    biodomain_info = (
+        genes_biodomains["biodomain"]
+        .dropna()
+        .drop_duplicates()
+        .reset_index()
+        .drop(columns="index")
+        .rename(columns={"biodomain": "name"})
+        .sort_values(by="name")
+    )
+
+    return biodomain_info

--- a/src/agoradatatools/etl/transform/biodomain_info.py
+++ b/src/agoradatatools/etl/transform/biodomain_info.py
@@ -20,7 +20,7 @@ def transform_biodomain_info(datasets: dict) -> pd.DataFrame:
         .reset_index()
         .drop(columns="index")
         .rename(columns={"biodomain": "name"})
-        .sort_values(by="name")
+        .sort_values(by="name", ignore_index=True)
     )
 
     return biodomain_info

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -14,6 +14,8 @@ logger = logging.getLogger(__name__)
 def apply_custom_transformations(datasets: dict, dataset_name: str, dataset_obj: dict):
     if not isinstance(datasets, dict) or not isinstance(dataset_name, str):
         return None
+    if dataset_name == "biodomain_info":
+        return transform.transform_biodomain_info(datasets=datasets)
     if dataset_name == "genes_biodomains":
         return transform.transform_genes_biodomains(datasets=datasets)
     if dataset_name == "overall_scores":

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -10,8 +10,10 @@
         custom_transformations: 1
         provenance:
           - syn44151254.1
+        column_rename:
+          biodomain: name
         destination: *dest
-        
+
     - genes_biodomains:
         files:
           - name: genes_biodomains

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -1,6 +1,17 @@
 - destination: &dest syn17015333
 - staging_path: ./staging
 - datasets:
+    - biodomain_info:
+        files:
+          - name: genes_biodomains
+            id: syn44151254.1
+            format: csv
+        final_format: json
+        custom_transformations: 1
+        provenance:
+          - syn44151254.1
+        destination: *dest
+        
     - genes_biodomains:
         files:
           - name: genes_biodomains

--- a/tests/test_assets/biodomain_info/input/biodomain_info_good_input.csv
+++ b/tests/test_assets/biodomain_info/input/biodomain_info_good_input.csv
@@ -1,4 +1,4 @@
-﻿biodomain,abbr,label,color,go_id,goterm_name,ensembl_id
+﻿name,abbr,label,color,go_id,goterm_name,ensembl_id
 Proteostasis,Pr,Proteostasis [Pr],#c8b269,GO:0048199,"vesicle targeting, to, from or within Golgi",ENSG00000170348
 Proteostasis,Pr,Proteostasis [Pr],#c8b269,GO:0007030,Golgi organization,ENSG00000243414
 Immune Response,IR,Immune Response [IR],#9ccdcc,GO:0006955,immune response,ENSG00000115008

--- a/tests/test_assets/biodomain_info/input/biodomain_info_good_input.csv
+++ b/tests/test_assets/biodomain_info/input/biodomain_info_good_input.csv
@@ -1,0 +1,7 @@
+﻿biodomain,abbr,label,color,go_id,goterm_name,ensembl_id
+Proteostasis,Pr,Proteostasis [Pr],#c8b269,GO:0048199,"vesicle targeting, to, from or within Golgi",ENSG00000170348
+Proteostasis,Pr,Proteostasis [Pr],#c8b269,GO:0007030,Golgi organization,ENSG00000243414
+Immune Response,IR,Immune Response [IR],#9ccdcc,GO:0006955,immune response,ENSG00000115008
+Immune Response,IR,Immune Response [IR],#9ccdcc,GO:0006955,immune response,ENSG00000278006
+Immune Response,IR,Immune Response [IR],#9ccdcc,GO:0006955,immune response,ENSG00000275313
+Tau Homeostasis,TH,Tau Homeostasis [TH],#cb97cb,GO:1902988,neurofibrillary tangle assembly,ENSG00000186868

--- a/tests/test_assets/biodomain_info/input/biodomain_info_imperfect_input.csv
+++ b/tests/test_assets/biodomain_info/input/biodomain_info_imperfect_input.csv
@@ -1,4 +1,4 @@
-﻿biodomain,abbr,label,color,go_id,goterm_name,ensembl_id
+﻿name,abbr,label,color,go_id,goterm_name,ensembl_id
 ,Pr,Proteostasis [Pr],#c8b269,GO:0048199,"vesicle targeting, to, from or within Golgi",ENSG00000170348
 Proteostasis,,Proteostasis [Pr],#c8b269,GO:0007030,Golgi organization,ENSG00000243414
 Immune Response,IR,,#9ccdcc,GO:0006955,immune response,

--- a/tests/test_assets/biodomain_info/input/biodomain_info_imperfect_input.csv
+++ b/tests/test_assets/biodomain_info/input/biodomain_info_imperfect_input.csv
@@ -1,0 +1,8 @@
+﻿biodomain,abbr,label,color,go_id,goterm_name,ensembl_id
+,Pr,Proteostasis [Pr],#c8b269,GO:0048199,"vesicle targeting, to, from or within Golgi",ENSG00000170348
+Proteostasis,,Proteostasis [Pr],#c8b269,GO:0007030,Golgi organization,ENSG00000243414
+Immune Response,IR,,#9ccdcc,GO:0006955,immune response,
+Immune Response,IR,Immune Response [IR],,GO:0006955,immune response,ENSG00000278006
+Immune Response,IR,Immune Response [IR],#9ccdcc,,immune response,ENSG00000275313
+Tau Homeostasis,TH,Tau Homeostasis [TH],#cb97cb,GO:1902988,,ENSG00000186868
+,Ap,Apoptosis [Ap],#673399,GO:0006915,apoptotic process,ENSG00000125538

--- a/tests/test_assets/biodomain_info/output/biodomain_info_good_output.json
+++ b/tests/test_assets/biodomain_info/output/biodomain_info_good_output.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Immune Response"
+  },
+  {
+    "name": "Proteostasis"
+  },
+  {
+    "name": "Tau Homeostasis"
+  }
+]

--- a/tests/test_assets/biodomain_info/output/biodomain_info_imperfect_output.json
+++ b/tests/test_assets/biodomain_info/output/biodomain_info_imperfect_output.json
@@ -1,0 +1,11 @@
+[
+  {
+    "name": "Immune Response"
+  },
+  {
+    "name": "Proteostasis"
+  },
+  {
+    "name": "Tau Homeostasis"
+  }
+]

--- a/tests/transform/test_biodomain_info.py
+++ b/tests/transform/test_biodomain_info.py
@@ -1,0 +1,57 @@
+import os
+import pandas as pd
+import pytest
+
+from agoradatatools.etl.transform import biodomain_info
+
+
+class TestTransformBiodomainInfo:
+    data_files_path = "tests/test_assets/biodomain_info"
+    pass_test_data = [
+        (  # Pass with good data
+            "biodomain_info_good_input.csv",
+            "biodomain_info_good_output.json",
+        ),
+        (  # Pass with values missing from each column
+            "biodomain_info_imperfect_input.csv",
+            "biodomain_info_imperfect_output.json",
+        ),
+    ]
+    pass_test_ids = [
+        "Pass with good data",
+        "Pass with missing values in each column",
+    ]
+    fail_test_data = [
+        # No failure cases for this transform
+    ]
+    fail_test_ids = [
+        # No failure cases for this transform
+    ]
+
+    @pytest.mark.parametrize(
+        "biodomain_info_file, expected_output_file", pass_test_data, ids=pass_test_ids
+    )
+    def test_transform_biodomain_info_should_pass(
+        self, biodomain_info_file, expected_output_file
+    ):
+        biodomain_info_df = pd.read_csv(
+            os.path.join(self.data_files_path, "input", biodomain_info_file)
+        )
+        output_df = biodomain_info.transform_biodomain_info(
+            datasets={"genes_biodomains": biodomain_info_df}
+        )
+        expected_df = pd.read_json(
+            os.path.join(self.data_files_path, "output", expected_output_file)
+        )
+        pd.testing.assert_frame_equal(output_df, expected_df)
+
+    """
+    # Leaving code stub for failure case, in case we want to add this in the future
+    @pytest.mark.parametrize("biodomain_info_file", fail_test_data, ids=fail_test_ids)
+    def test_transform_biodomain_info_should_fail(self, biodomain_info_file):
+        with pytest.raises(<Error type>):
+            biodomain_info_df = pd.read_csv(os.path.join(self.data_files_path, "input", biodomain_info_file))
+            biodomain_info.transform_biodomain_info(
+                datasets={"genes_biodomains": biodomain_info_df}
+            )
+    """


### PR DESCRIPTION
This transform takes the `genes_biodomains` source file and pulls out the unique values from the `biodomain` column only. This results in a single-column DataFrame with the column `name`, with 19 biodomains. It is set up this way so there is room to add more columns/info to this new DataFrame later if we want. 

The JSON output of this single-column DataFrame looks like this:
```
[
  {
    "name": "APP Metabolism"
  },
  {
    "name": "Apoptosis"
  },
...
```

*Tests for this transform*
2 tests are run: 1 with perfect input and no missing data, and 1 with missing data from at least one column, covering all columns. Both of these should pass. 

For the perfect data scenario, the biodomains are listed out of alphabetical order and have duplicate entries. We expect the end result to be unique biodomain names, sorted. 

For the imperfect data scenario, I've also added a line for biodomain "Apoptosis" which is missing the critical "biodomain" column, and is the only entry for Apoptosis. We expect that this biodomain will be skipped due to having an NA name, AND there shouldn't be any blank entries in the output file. 

The output files for perfect and imperfect data are currently identical, but may not always be so I've made them as 2 separate files. 

There is currently no failure case for this transform.