### PR TITLE
AG-1196: Update transform_gene_info to sort biodomains alphabetically

### DIFF
--- a/src/agoradatatools/etl/transform/gene_info.py
+++ b/src/agoradatatools/etl/transform/gene_info.py
@@ -79,8 +79,10 @@ def transform_gene_info(
         .rename(columns={"biodomain": "biodomains"})
     )
 
-    # Merge all the datasets
+    # sort biodomains list alphabetically
+    biodomains['biodomains'] = biodomains['biodomains'].apply(sorted)
 
+    # Merge all the datasets
     gene_info = gene_metadata
 
     for dataset in [


### PR DESCRIPTION
The gene_info.biodomains list is generated with indeterminate ordering, making data validation more difficult. This PR sorts the biodomains alphabetically so that we don't get differently ordered lists across runs.