### PR TITLE
AG-1161 Updated gene_info transform with renamed columns

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -132,6 +132,14 @@
         column_rename:
           ensg: ensembl_gene_id
           ensembl_id: ensembl_gene_id
+          geneid: ensembl_gene_id
+          has_eqtl: is_eqtl
+          minimumlogcpm: min
+          quartile1logcpm: first_quartile
+          medianlogcpm: median
+          meanlogcpm: mean
+          quartile3logcpm: third_quartile
+          maximumlogcpm: max
         provenance:
           - syn25953363.6
           - syn12514826.4
@@ -145,13 +153,7 @@
           - syn44151254.1
           - syn51942280.2
         agora_rename:
-          has_eqtl: haseqtl
-          is_igap: isIGAP
           symbol: hgnc_symbol
-          protein_in_ad_brain_change: isAnyProteinChangedInADBrain
-          rna_in_ad_brain_change: isAnyRNAChangedInADBrain
-          median_expression: medianexpression
-          nominated_target: nominatedtarget
         destination: *dest
 
     - team_info:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -132,6 +132,14 @@
         column_rename:
           ensg: ensembl_gene_id
           ensembl_id: ensembl_gene_id
+          geneid: ensembl_gene_id
+          has_eqtl: is_eqtl
+          minimumlogcpm: min
+          quartile1logcpm: first_quartile
+          medianlogcpm: median
+          meanlogcpm: mean
+          quartile3logcpm: third_quartile
+          maximumlogcpm: max
         provenance:
           - syn25953363.6
           - syn12514826.4
@@ -145,13 +153,7 @@
           - syn44151254.1
           - syn51942280.2
         agora_rename:
-          has_eqtl: haseqtl
-          is_igap: isIGAP
           symbol: hgnc_symbol
-          protein_in_ad_brain_change: isAnyProteinChangedInADBrain
-          rna_in_ad_brain_change: isAnyRNAChangedInADBrain
-          median_expression: medianexpression
-          nominated_target: nominatedtarget
         destination: *dest
 
     - team_info:


### PR DESCRIPTION
This addresses [AG-1161](https://sagebionetworks.jira.com/browse/AG-1161): multiple columns in the `gene_info` transform needed to be updated to use snake case or have more precise names. Where possible I used `column_rename` to accomplish the renaming and only updated the transform when it directly used or created the old name inside the transform. 

[This comment](https://sagebionetworks.jira.com/browse/AG-1161?focusedCommentId=181944) in the JIRA task lists what changed in order to rename each field.

[AG-1161]: https://sagebionetworks.jira.com/browse/AG-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ