### PR TITLE
AG-1239: Bump team_info source version to pick up corrected data

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -159,7 +159,7 @@
     - team_info:
         files:
           - name: team_info
-            id: syn12615624.15
+            id: syn12615624.16
             format: csv
           - name: team_member_info
             id: syn12615633.16
@@ -167,7 +167,7 @@
         final_format: json
         custom_transformations: 1
         provenance:
-          - syn12615624.15
+          - syn12615624.16
           - syn12615633.16
         destination: *dest
 

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -159,7 +159,7 @@
     - team_info:
         files:
           - name: team_info
-            id: syn12615624.15
+            id: syn12615624.16
             format: csv
           - name: team_member_info
             id: syn12615633.16
@@ -167,7 +167,7 @@
         final_format: json
         custom_transformations: 1
         provenance:
-          - syn12615624.15
+          - syn12615624.16
           - syn12615633.16
         destination: *dest
 


### PR DESCRIPTION
Not much to see here, some leading spaces snuck into the data and were fixed in the new version of team_info.csv.