### PR TITLE
[IBCDPE-386] Adds CI step to publish GHCR container

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -5,7 +5,8 @@ name: CI
 on:
   push:
     branches: ["dev"]
-    tags: ['v[0-9]*', '[0-9]+.[0-9]+*']  # Match tags that resemble a version
+    # Match tags that resemble a version
+    tags: ['v[0-9]*', '[0-9]+.[0-9]+*']
   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,7 +4,7 @@ name: CI
 
 on:
   push:
-    branches: ["dev", "bwmac/IBCDPE-386/ghcr_ci"]
+    branches: ["dev"]
     tags: ['v[0-9]*', '[0-9]+.[0-9]+*']  # Match tags that resemble a version
   pull_request:
 

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -58,7 +58,7 @@ jobs:
       - run: pip install .
       - run: adt test_config.yaml -t ${{secrets.SYNAPSE_PAT}}
 
-  docker-publish:
+  ghcr-publish:
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: ["dev"]
     # Match tags that resemble a version
-    tags: ['v[0-9]*', '[0-9]+.[0-9]+*']
+    tags: ['[0-9]+\.[0-9]+\.[0-9]+']
   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,7 +4,8 @@ name: CI
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "bwmac/IBCDPE-386/ghcr_ci"]
+    tags: ['v[0-9]*', '[0-9]+.[0-9]+*']  # Match tags that resemble a version
   pull_request:
 
   # Allows you to run this workflow manually from the Actions tab
@@ -56,3 +57,36 @@ jobs:
       - run: pip install -U setuptools
       - run: pip install .
       - run: adt test_config.yaml -t ${{secrets.SYNAPSE_PAT}}
+
+  docker-publish:
+    needs: [build, test]
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v2
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - id: meta
+      uses: docker/metadata-action@v4
+      with:
+        images: |
+          ghcr.io/${{ github.repository }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=ref,event=branch
+          type=sha
+          latest
+    - name: Publish Docker Image
+      uses: docker/build-push-action@v3
+      with:
+        context: .
+        build-args: |
+          TARBALL_PATH=${{ needs.prepare.outputs.tarball-path }}
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This PR adds the `ghcr-publish` step to our CI GitHub Action to publish a container to GHCR each time new changes are pushed to the `dev` branch. It also will apply the `latest` tag to the container so that the `nf-agora` pulls the most up-to-date version (once we update it).

I have tested this in GitHub Actions and the most recent version of the container that I published can be found [here](https://github.com/Sage-Bionetworks/agora-data-tools/pkgs/container/agora-data-tools/136092379?tag=latest). The new container was tested [on tower](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/agora-project/watch/1ANvhUU99XUN9m) successfully as well.