### PR TITLE
Updated nest_fields util function

### DIFF
--- a/src/agoradatatools/etl/transform/gene_info.py
+++ b/src/agoradatatools/etl/transform/gene_info.py
@@ -119,6 +119,7 @@ def transform_gene_info(
         grouping="ensembl_gene_id",
         new_column="ensembl_info",
         drop_columns=["ensembl_gene_id"],
+        nested_field_is_list=False,
     )
 
     # Merge all the datasets

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -119,7 +119,7 @@ def nest_fields(
     df: pd.DataFrame,
     grouping: str,
     new_column: str,
-    drop_columns: list[str] = [],
+    drop_columns: list = [],
     nested_field_is_list: bool = True,
 ) -> pd.DataFrame:
     """Collapses the provided DataFrame into 2 columns:

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -119,7 +119,7 @@ def nest_fields(
     df: pd.DataFrame,
     grouping: str,
     new_column: str,
-    drop_columns: list = [],
+    drop_columns: list[str] = [],
     nested_field_is_list: bool = True,
 ) -> pd.DataFrame:
     """Collapses the provided DataFrame into 2 columns:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -161,6 +161,9 @@ class TestRenameColumns:
 
 
 class TestNestFields:
+    """Tests the nest_fields function using a dataframe that has multiple rows per group and
+    one that only has one row per group.
+    """
     df_multirow = pd.DataFrame(
         {
             "a": ["group_1", "group_1", "group_2", "group_2", "group_3", "group_3"],

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -164,6 +164,7 @@ class TestNestFields:
     """Tests the nest_fields function using a dataframe that has multiple rows per group and
     one that only has one row per group.
     """
+
     df_multirow = pd.DataFrame(
         {
             "a": ["group_1", "group_1", "group_2", "group_2", "group_3", "group_3"],


### PR DESCRIPTION
Per [AG-1306](https://sagebionetworks.jira.com/browse/AG-1306), this PR adds a boolean argument to the `nest_fields` function to allow it to output in two different formats. 
When `nested_field_is_list` is True (default), the function behaves as it always has: multiple rows in a group are collapsed to a list of dictionaries. If there is only one row in the group, the output is a list containing exactly 1 dict. 
When `nested_field_is_list` is False, which will only work if there is only one row per group for every group, the function outputs the single dict instead of a list of length 1. 

I also added to the test suite to test this functionality. 

[AG-1306]: https://sagebionetworks.jira.com/browse/AG-1306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ