### PR TITLE
[IBCDPE-792] Implement Great Expectations for the `proteomics_distribution_data` Dataset

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -281,3 +281,4 @@ datasets:
         - *agora_proteomics_tmt_provenance
         - *agora_proteomics_srm_provenance
       destination: *dest
+      gx_folder: syn53463345

--- a/gx_suite_definitions/neuropath_corr.ipynb
+++ b/gx_suite_definitions/neuropath_corr.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "overall_scores_data_file = syn.get(\"syn22130742\").path\n"
+    "neuropath_corr_data_file = syn.get(\"syn22130742\").path\n"
    ]
   },
   {
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df = pd.read_json(overall_scores_data_file)\n",
+    "df = pd.read_json(neuropath_corr_data_file)\n",
     "nested_columns = []\n",
     "df = GreatExpectationsRunner.convert_nested_columns_to_json(df, nested_columns)\n",
     "validator = context.sources.pandas_default.read_dataframe(df)\n",

--- a/gx_suite_definitions/proteomics_distribution_data.ipynb
+++ b/gx_suite_definitions/proteomics_distribution_data.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import synapseclient\n",
+    "\n",
+    "import pandas as pd\n",
+    "import great_expectations as gx\n",
+    "\n",
+    "from agoradatatools.gx import GreatExpectationsRunner\n",
+    "\n",
+    "context = gx.get_context(project_root_dir='../src/agoradatatools/great_expectations')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create Expectation Suite for Proteomics Distribution Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Get Example Data File"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "syn = synapseclient.Synapse()\n",
+    "syn.login()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proteomics_distribution_data_file = syn.get(\"syn31510062\").path\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Validator Object on Data File"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = pd.read_json(proteomics_distribution_data_file)\n",
+    "nested_columns = []\n",
+    "df = GreatExpectationsRunner.convert_nested_columns_to_json(df, nested_columns)\n",
+    "validator = context.sources.pandas_default.read_dataframe(df)\n",
+    "validator.expectation_suite_name = \"proteomics_distribution_data\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Add Expectations to Validator Object For Each Column"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# tissue\n",
+    "validator.expect_column_values_to_be_of_type(\"tissue\", \"str\")\n",
+    "validator.expect_column_values_to_not_be_null(\"tissue\")\n",
+    "validator.expect_column_values_to_be_in_set(\"tissue\", ['AntPFC', 'DLPFC', 'MFG', 'TCX'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# min\n",
+    "validator.expect_column_values_to_be_of_type(\"min\", \"float\")\n",
+    "validator.expect_column_values_to_be_between(\"min\", -0.5, 0)\n",
+    "validator.expect_column_values_to_not_be_null(\"min\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# max\n",
+    "validator.expect_column_values_to_be_of_type(\"max\", \"float\")\n",
+    "validator.expect_column_values_to_be_between(\"max\", 0, 0.5)\n",
+    "validator.expect_column_values_to_not_be_null(\"max\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# first_quartile\n",
+    "validator.expect_column_values_to_be_of_type(\"first_quartile\", \"float\")\n",
+    "validator.expect_column_values_to_be_between(\"first_quartile\", -0.2, 0)\n",
+    "validator.expect_column_values_to_not_be_null(\"first_quartile\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# median\n",
+    "validator.expect_column_values_to_be_of_type(\"median\", \"float\")\n",
+    "validator.expect_column_values_to_be_between(\"median\", -0.1, 0.1)\n",
+    "validator.expect_column_values_to_not_be_null(\"median\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# third_quartile\n",
+    "validator.expect_column_values_to_be_of_type(\"third_quartile\", \"float\")\n",
+    "validator.expect_column_values_to_be_between(\"third_quartile\", 0, 0.1)\n",
+    "validator.expect_column_values_to_not_be_null(\"third_quartile\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# type\n",
+    "validator.expect_column_values_to_be_of_type(\"type\", \"str\")\n",
+    "validator.expect_column_values_to_not_be_null(\"type\")\n",
+    "validator.expect_column_values_to_be_in_set(\"type\", ['SRM', 'TMT', 'LFQ'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# multi-field logical\n",
+    "validator.expect_column_pair_values_A_to_be_greater_than_B(\"max\", \"third_quartile\")\n",
+    "validator.expect_column_pair_values_A_to_be_greater_than_B(\"third_quartile\", \"median\")\n",
+    "validator.expect_column_pair_values_A_to_be_greater_than_B(\"median\", \"first_quartile\")\n",
+    "validator.expect_column_pair_values_A_to_be_greater_than_B(\"first_quartile\", \"min\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save Expectation Suite"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "validator.save_expectation_suite(discard_failed_expectations=False)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Create Checkpoint and View Results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "checkpoint = context.add_or_update_checkpoint(\n",
+    "    name=\"agora-test-checkpoint\",\n",
+    "    validator=validator,\n",
+    ")\n",
+    "checkpoint_result = checkpoint.run()\n",
+    "context.view_validation_result(checkpoint_result)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Build Data Docs - Click on Expectation Suite to View All Expectations"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "context.build_data_docs()\n",
+    "context.open_data_docs()\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "agora-data-tools-CK0oUlHB",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/src/agoradatatools/great_expectations/gx/expectations/proteomics_distribution_data.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/proteomics_distribution_data.json
@@ -1,0 +1,217 @@
+{
+  "data_asset_type": null,
+  "expectation_suite_name": "proteomics_distribution_data",
+  "expectations": [
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "tissue",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "tissue"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "tissue",
+        "value_set": [
+          "AntPFC",
+          "DLPFC",
+          "MFG",
+          "TCX"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "min",
+        "type_": "float"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "min",
+        "max_value": 0,
+        "min_value": -0.5
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "min"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "max",
+        "type_": "float"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "max",
+        "max_value": 0.5,
+        "min_value": 0
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "max"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "first_quartile",
+        "type_": "float"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "first_quartile",
+        "max_value": 0,
+        "min_value": -0.2
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "first_quartile"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "median",
+        "type_": "float"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "median",
+        "max_value": 0.1,
+        "min_value": -0.1
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "median"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "third_quartile",
+        "type_": "float"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_between",
+      "kwargs": {
+        "column": "third_quartile",
+        "max_value": 0.1,
+        "min_value": 0
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "third_quartile"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "type",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "type"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "type",
+        "value_set": [
+          "SRM",
+          "TMT",
+          "LFQ"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_pair_values_a_to_be_greater_than_b",
+      "kwargs": {
+        "column_A": "max",
+        "column_B": "third_quartile"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_pair_values_a_to_be_greater_than_b",
+      "kwargs": {
+        "column_A": "third_quartile",
+        "column_B": "median"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_pair_values_a_to_be_greater_than_b",
+      "kwargs": {
+        "column_A": "median",
+        "column_B": "first_quartile"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_pair_values_a_to_be_greater_than_b",
+      "kwargs": {
+        "column_A": "first_quartile",
+        "column_B": "min"
+      },
+      "meta": {}
+    }
+  ],
+  "ge_cloud_id": null,
+  "meta": {
+    "great_expectations_version": "0.18.1"
+  }
+}

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -281,3 +281,4 @@ datasets:
         - *agora_proteomics_tmt_provenance
         - *agora_proteomics_srm_provenance
       destination: *dest
+      gx_folder: syn53463344


### PR DESCRIPTION
Description:

This PR implements a GX expectation suite for the `proteomics_distribution_data` dataset.

Please let me know if there are any additional expectations I should add, or if there are any adjustments to be made to the expectations I have already implemented.

Notes:
- Values I have chosen for expectations like `expect_column_values_to_be_between` are based on looking at the example [dataset](https://www.synapse.org/#!Synapse:syn31510062) on Synapse.
- This change has been tested by running `adt test_config.yaml`. Example results can be downloaded from [here](https://www.synapse.org/#!Synapse:syn53463476).
- I also fixed a variable naming typo in the `neuropath_corr` notebook which was not affecting performance/proper functioning.