### PR TITLE
AG-1366: Use biodomains source v3

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,10 +4,10 @@ sources:
   - genes_biodomains:
     genes_biodomains_files: &genes_biodomains_files
       - name: genes_biodomains
-        id: syn44151254.1
+        id: syn44151254.3
         format: csv
     genes_biodomains_provenance: &genes_biodomains_provenance
-      - syn44151254.1
+      - syn44151254.3
   - overall_scores:
     overall_scores_files: &overall_scores_files
       - name: overall_scores

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -4,10 +4,10 @@ sources:
   - genes_biodomains:
     genes_biodomains_files: &genes_biodomains_files
       - name: genes_biodomains
-        id: syn44151254.1
+        id: syn44151254.3
         format: csv
     genes_biodomains_provenance: &genes_biodomains_provenance
-      - syn44151254.1
+      - syn44151254.3
   - overall_scores:
     overall_scores_files: &overall_scores_files
       - name: overall_scores


### PR DESCRIPTION
We want to pull the latest version of the biodomains source file to pick up minor updates, e.g. clean up of deprecated terms. 