### PR TITLE
Bumped version of target_exp_validation_harmonized

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -114,11 +114,11 @@ datasets:
   - target_exp_validation_harmonized:
       files:
         - name: target_exp_validation_harmonized
-          id: syn24184512.8
+          id: syn24184512.9
           format: csv
       final_format: json
       provenance:
-        - syn24184512.8
+        - syn24184512.9
       destination: *dest
 
   - metabolomics:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -114,11 +114,11 @@ datasets:
   - target_exp_validation_harmonized:
       files:
         - name: target_exp_validation_harmonized
-          id: syn24184512.8
+          id: syn24184512.9
           format: csv
       final_format: json
       provenance:
-        - syn24184512.8
+        - syn24184512.9
       destination: *dest
 
   - metabolomics:


### PR DESCRIPTION
Removed the "n/A" gene from the target_exp_validation_harmonized file, uploaded the new file (v9), and updated the code to use the new file. 