### PR TITLE
[AG-1386] Implement Error Catching for GX Data Validation

### DIFF
--- a/src/agoradatatools/errors.py
+++ b/src/agoradatatools/errors.py
@@ -11,3 +11,7 @@ class ADTDataProcessingError(ADTError):
     def __init__(self, message):
         super().__init__(message)
         self.message = message
+
+
+class ADTDataValidationError(ADTDataProcessingError):
+    """Error to be raised when Data Validation runs fail."""

--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -109,6 +109,15 @@ class GreatExpectationsRunner:
             ),
         )
 
+    @staticmethod
+    def convert_nested_columns_to_json(
+        df: pd.DataFrame, nested_columns: typing.List[str]
+    ) -> pd.DataFrame:
+        """Converts nested columns in a DataFrame to JSON-parseable strings"""
+        for column in nested_columns:
+            df[column] = df[column].apply(json.dumps)
+        return df
+
     def get_failed_expectations(self, checkpoint_result: CheckpointResult) -> str:
         """Gets the failed expectations from a CheckpointResult and returns them as a formatted string
 
@@ -144,15 +153,6 @@ class GreatExpectationsRunner:
 
         return fail_message
 
-    @staticmethod
-    def convert_nested_columns_to_json(
-        df: pd.DataFrame, nested_columns: typing.List[str]
-    ) -> pd.DataFrame:
-        """Converts nested columns in a DataFrame to JSON-parseable strings"""
-        for column in nested_columns:
-            df[column] = df[column].apply(json.dumps)
-        return df
-
     def run(self) -> typing.Union[typing.Dict[str, list], None]:
         """Run great expectations on a dataset and upload the results to Synapse"""
         if not self._check_if_expectation_suite_exists():
@@ -183,6 +183,6 @@ class GreatExpectationsRunner:
         latest_reults_path = self._get_results_path(checkpoint_result)
         self._upload_results_file_to_synapse(latest_reults_path)
 
-        if not checkpoint_result.success:
+        if not checkpoint_result["success"]:
             fail_message = self.get_failed_expectations(checkpoint_result)
             raise ADTDataValidationError(fail_message)

--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -128,10 +128,8 @@ class GreatExpectationsRunner:
             fail_message: String with information on which fields and expectations failed
         """
         fail_dict = {self.expectation_suite_name: {}}
-        run_name = list(checkpoint_result["run_results"].keys())[0]
-        for result in checkpoint_result["run_results"][run_name]["validation_result"][
-            "results"
-        ]:
+        expectation_results = checkpoint_result.list_validation_results()[0]["results"]
+        for result in expectation_results:
             if not result["success"]:
                 column = result["expectation_config"]["kwargs"]["column"]
                 failed_expectation = result["expectation_config"]["expectation_type"]
@@ -183,6 +181,6 @@ class GreatExpectationsRunner:
         latest_reults_path = self._get_results_path(checkpoint_result)
         self._upload_results_file_to_synapse(latest_reults_path)
 
-        if not checkpoint_result["success"]:
+        if not checkpoint_result.success:
             fail_message = self.get_failed_expectations(checkpoint_result)
             raise ADTDataValidationError(fail_message)

--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -151,7 +151,7 @@ class GreatExpectationsRunner:
 
         return fail_message
 
-    def run(self) -> typing.Union[typing.Dict[str, list], None]:
+    def run(self) -> None:
         """Run great expectations on a dataset and upload the results to Synapse"""
         if not self._check_if_expectation_suite_exists():
             return

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -69,7 +69,7 @@ datasets:
   - neuropath_corr:
       files:
         - name: neuropath_regression_results
-          id: syn22017882.5
+          id: syn53771485
           format: csv
       final_format: json
       provenance:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -54,7 +54,10 @@ datasets:
       destination: *dest
 
   - genes_biodomains:
-      files: *genes_biodomains_files
+      files: 
+          - name: genes_biodomains
+            id: syn53724080
+            format: csv
       final_format: json
       custom_transformations: 1
       provenance: *genes_biodomains_provenance
@@ -83,206 +86,206 @@ datasets:
       destination: *dest
       gx_folder: syn53461511
 
-  - proteomics:
-      files: *agora_proteomics_files
-      final_format: json
-      provenance: *agora_proteomics_provenance
-      column_rename:
-        genename: hgnc_symbol
-        ensg: ensembl_gene_id
-      destination: *dest
+  # - proteomics:
+  #     files: *agora_proteomics_files
+  #     final_format: json
+  #     provenance: *agora_proteomics_provenance
+  #     column_rename:
+  #       genename: hgnc_symbol
+  #       ensg: ensembl_gene_id
+  #     destination: *dest
 
-  - proteomics_tmt:
-      files: *agora_proteomics_tmt_files
-      final_format: json
-      provenance: *agora_proteomics_tmt_provenance
-      column_rename:
-        genename: hgnc_symbol
-        ensg: ensembl_gene_id
-      destination: *dest
-      gx_folder: syn53469659
+  # - proteomics_tmt:
+  #     files: *agora_proteomics_tmt_files
+  #     final_format: json
+  #     provenance: *agora_proteomics_tmt_provenance
+  #     column_rename:
+  #       genename: hgnc_symbol
+  #       ensg: ensembl_gene_id
+  #     destination: *dest
+  #     gx_folder: syn53469659
 
-  - proteomics_srm:
-      files: *agora_proteomics_srm_files
-      final_format: json
-      provenance: *agora_proteomics_srm_provenance
-      column_rename:
-        genename: hgnc_symbol
-        ensg: ensembl_gene_id
-      destination: *dest
+  # - proteomics_srm:
+  #     files: *agora_proteomics_srm_files
+  #     final_format: json
+  #     provenance: *agora_proteomics_srm_provenance
+  #     column_rename:
+  #       genename: hgnc_symbol
+  #       ensg: ensembl_gene_id
+  #     destination: *dest
 
-  - target_exp_validation_harmonized:
-      files:
-        - name: target_exp_validation_harmonized
-          id: syn24184512.8
-          format: csv
-      final_format: json
-      provenance:
-        - syn24184512.8
-      destination: *dest
+  # - target_exp_validation_harmonized:
+  #     files:
+  #       - name: target_exp_validation_harmonized
+  #         id: syn24184512.8
+  #         format: csv
+  #     final_format: json
+  #     provenance:
+  #       - syn24184512.8
+  #     destination: *dest
 
-  - metabolomics:
-      files:
-        - name: metabolomics
-          id: syn26064497.1
-          format: feather
-      final_format: json
-      provenance:
-        - syn26064497.1
-      destination: *dest
-      gx_folder: syn52948671
+  # - metabolomics:
+  #     files:
+  #       - name: metabolomics
+  #         id: syn26064497.1
+  #         format: feather
+  #     final_format: json
+  #     provenance:
+  #       - syn26064497.1
+  #     destination: *dest
+  #     gx_folder: syn52948671
 
-  - gene_info:
-      files:
-        - name: gene_metadata
-          id: syn25953363.12
-          format: feather
-        - name: igap
-          id: syn12514826.5
-          format: csv
-        - name: eqtl
-          id: syn12514912.3
-          format: csv
-        - <<: *agora_proteomics_files
-        - <<: *agora_proteomics_tmt_files
-        - <<: *agora_proteomics_srm_files
-        - <<: *rna_diff_expr_data_files
-        - name: target_list
-          id: syn12540368.47
-          format: csv
-        - name: median_expression
-          id: syn27211878.2
-          format: csv
-        - name: druggability
-          id: syn13363443.11
-          format: csv
-        - <<: *genes_biodomains_files
-        - name: tep_adi_info
-          id: syn51942280.2
-          format: csv
-      final_format: json
-      custom_transformations:
-        adjusted_p_value_threshold: 0.05
-        protein_level_threshold: 0.05
-      column_rename:
-        ensg: ensembl_gene_id
-        ensembl_id: ensembl_gene_id
-        geneid: ensembl_gene_id
-        has_eqtl: is_eqtl
-        minimumlogcpm: min
-        quartile1logcpm: first_quartile
-        medianlogcpm: median
-        meanlogcpm: mean
-        quartile3logcpm: third_quartile
-        maximumlogcpm: max
-        possible_replacement: ensembl_possible_replacements
-        permalink: ensembl_permalink
-      provenance:
-        - syn25953363.12
-        - syn12514826.5
-        - syn12514912.3
-        - *agora_proteomics_provenance
-        - *agora_proteomics_tmt_provenance
-        - *agora_proteomics_srm_provenance
-        - *rna_diff_expr_data_provenance
-        - syn12540368.47
-        - syn27211878.2
-        - syn13363443.11
-        - *genes_biodomains_provenance
-        - syn51942280.2
-      agora_rename:
-        symbol: hgnc_symbol
-      destination: *dest
+  # - gene_info:
+  #     files:
+  #       - name: gene_metadata
+  #         id: syn25953363.12
+  #         format: feather
+  #       - name: igap
+  #         id: syn12514826.5
+  #         format: csv
+  #       - name: eqtl
+  #         id: syn12514912.3
+  #         format: csv
+  #       - <<: *agora_proteomics_files
+  #       - <<: *agora_proteomics_tmt_files
+  #       - <<: *agora_proteomics_srm_files
+  #       - <<: *rna_diff_expr_data_files
+  #       - name: target_list
+  #         id: syn12540368.47
+  #         format: csv
+  #       - name: median_expression
+  #         id: syn27211878.2
+  #         format: csv
+  #       - name: druggability
+  #         id: syn13363443.11
+  #         format: csv
+  #       - <<: *genes_biodomains_files
+  #       - name: tep_adi_info
+  #         id: syn51942280.2
+  #         format: csv
+  #     final_format: json
+  #     custom_transformations:
+  #       adjusted_p_value_threshold: 0.05
+  #       protein_level_threshold: 0.05
+  #     column_rename:
+  #       ensg: ensembl_gene_id
+  #       ensembl_id: ensembl_gene_id
+  #       geneid: ensembl_gene_id
+  #       has_eqtl: is_eqtl
+  #       minimumlogcpm: min
+  #       quartile1logcpm: first_quartile
+  #       medianlogcpm: median
+  #       meanlogcpm: mean
+  #       quartile3logcpm: third_quartile
+  #       maximumlogcpm: max
+  #       possible_replacement: ensembl_possible_replacements
+  #       permalink: ensembl_permalink
+  #     provenance:
+  #       - syn25953363.12
+  #       - syn12514826.5
+  #       - syn12514912.3
+  #       - *agora_proteomics_provenance
+  #       - *agora_proteomics_tmt_provenance
+  #       - *agora_proteomics_srm_provenance
+  #       - *rna_diff_expr_data_provenance
+  #       - syn12540368.47
+  #       - syn27211878.2
+  #       - syn13363443.11
+  #       - *genes_biodomains_provenance
+  #       - syn51942280.2
+  #     agora_rename:
+  #       symbol: hgnc_symbol
+  #     destination: *dest
 
-  - team_info:
-      files:
-        - name: team_info
-          id: syn12615624.18
-          format: csv
-        - name: team_member_info
-          id: syn12615633.18
-          format: csv
-      final_format: json
-      custom_transformations: 1
-      provenance:
-        - syn12615624.18
-        - syn12615633.18
-      destination: *dest
-      gx_folder: syn53616774
-      gx_nested_columns:
-        - members
+  # - team_info:
+  #     files:
+  #       - name: team_info
+  #         id: syn12615624.18
+  #         format: csv
+  #       - name: team_member_info
+  #         id: syn12615633.18
+  #         format: csv
+  #     final_format: json
+  #     custom_transformations: 1
+  #     provenance:
+  #       - syn12615624.18
+  #       - syn12615633.18
+  #     destination: *dest
+  #     gx_folder: syn53616774
+  #     gx_nested_columns:
+  #       - members
 
-  - overall_scores:
-      files: *overall_scores_files
-      final_format: json
-      custom_transformations: 1
-      column_rename:
-        genename: hgnc_gene_id
-      provenance: *overall_scores_provenance
-      agora_rename:
-        ensg: ensembl_gene_id
-        hgnc_gene_id: hgnc_symbol
-        geneticsscore: genetics_score
-        overall: target_risk_score
-        omicsscore: multi_omics_score
-      destination: *dest
-      gx_folder: syn53453225
+  # - overall_scores:
+  #     files: *overall_scores_files
+  #     final_format: json
+  #     custom_transformations: 1
+  #     column_rename:
+  #       genename: hgnc_gene_id
+  #     provenance: *overall_scores_provenance
+  #     agora_rename:
+  #       ensg: ensembl_gene_id
+  #       hgnc_gene_id: hgnc_symbol
+  #       geneticsscore: genetics_score
+  #       overall: target_risk_score
+  #       omicsscore: multi_omics_score
+  #     destination: *dest
+  #     gx_folder: syn53453225
 
-  - network:
-      files:
-        - name: networks
-          id: syn11685347.1
-          format: csv
-      final_format: json
-      provenance:
-        - syn11685347.1
-        - syn27211942.1
-      agora_rename:
-        genea_ensembl_gene_id: geneA_ensembl_gene_id
-        genea_external_gene_name: geneA_external_gene_name
-        geneb_ensembl_gene_id: geneB_ensembl_gene_id
-        geneb_external_gene_name: geneB_external_gene_name
-        brainregion: brainRegion
-      destination: *dest
+  # - network:
+  #     files:
+  #       - name: networks
+  #         id: syn11685347.1
+  #         format: csv
+  #     final_format: json
+  #     provenance:
+  #       - syn11685347.1
+  #       - syn27211942.1
+  #     agora_rename:
+  #       genea_ensembl_gene_id: geneA_ensembl_gene_id
+  #       genea_external_gene_name: geneA_external_gene_name
+  #       geneb_ensembl_gene_id: geneB_ensembl_gene_id
+  #       geneb_external_gene_name: geneB_external_gene_name
+  #       brainregion: brainRegion
+  #     destination: *dest
 
-  - rnaseq_differential_expression:
-      files: *rna_diff_expr_data_files
-      final_format: json
-      custom_transformations: 1
-      provenance: *rna_diff_expr_data_provenance
-      destination: *dest
+  # - rnaseq_differential_expression:
+  #     files: *rna_diff_expr_data_files
+  #     final_format: json
+  #     custom_transformations: 1
+  #     provenance: *rna_diff_expr_data_provenance
+  #     destination: *dest
 
-  - distribution_data:
-      files: *overall_scores_files
-      final_format: json
-      custom_transformations:
-        overall_max_score: 5
-        genetics_max_score: 3
-        omics_max_score: 2
-      provenance: *overall_scores_provenance
-      column_rename:
-        overall: target_risk_score
-        geneticsscore: genetics_score
-        omicsscore: multi_omics_score
-      destination: *dest
+  # - distribution_data:
+  #     files: *overall_scores_files
+  #     final_format: json
+  #     custom_transformations:
+  #       overall_max_score: 5
+  #       genetics_max_score: 3
+  #       omics_max_score: 2
+  #     provenance: *overall_scores_provenance
+  #     column_rename:
+  #       overall: target_risk_score
+  #       geneticsscore: genetics_score
+  #       omicsscore: multi_omics_score
+  #     destination: *dest
 
-  - rna_distribution_data:
-      files: *rna_diff_expr_data_files
-      final_format: json
-      custom_transformations: 1
-      provenance: *rna_diff_expr_data_provenance
-      destination: *dest
+  # - rna_distribution_data:
+  #     files: *rna_diff_expr_data_files
+  #     final_format: json
+  #     custom_transformations: 1
+  #     provenance: *rna_diff_expr_data_provenance
+  #     destination: *dest
 
-  - proteomics_distribution_data:
-      files:
-        - <<: *agora_proteomics_files
-        - <<: *agora_proteomics_tmt_files
-        - <<: *agora_proteomics_srm_files
-      final_format: json
-      custom_transformations: 1
-      provenance:
-        - *agora_proteomics_provenance
-        - *agora_proteomics_tmt_provenance
-        - *agora_proteomics_srm_provenance
-      destination: *dest
-      gx_folder: syn53463344
+  # - proteomics_distribution_data:
+  #     files:
+  #       - <<: *agora_proteomics_files
+  #       - <<: *agora_proteomics_tmt_files
+  #       - <<: *agora_proteomics_srm_files
+  #     final_format: json
+  #     custom_transformations: 1
+  #     provenance:
+  #       - *agora_proteomics_provenance
+  #       - *agora_proteomics_tmt_provenance
+  #       - *agora_proteomics_srm_provenance
+  #     destination: *dest
+  #     gx_folder: syn53463344

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -54,10 +54,7 @@ datasets:
       destination: *dest
 
   - genes_biodomains:
-      files: 
-          - name: genes_biodomains
-            id: syn53724080
-            format: csv
+      files: *genes_biodomains_files
       final_format: json
       custom_transformations: 1
       provenance: *genes_biodomains_provenance
@@ -86,206 +83,206 @@ datasets:
       destination: *dest
       gx_folder: syn53461511
 
-  # - proteomics:
-  #     files: *agora_proteomics_files
-  #     final_format: json
-  #     provenance: *agora_proteomics_provenance
-  #     column_rename:
-  #       genename: hgnc_symbol
-  #       ensg: ensembl_gene_id
-  #     destination: *dest
+  - proteomics:
+      files: *agora_proteomics_files
+      final_format: json
+      provenance: *agora_proteomics_provenance
+      column_rename:
+        genename: hgnc_symbol
+        ensg: ensembl_gene_id
+      destination: *dest
 
-  # - proteomics_tmt:
-  #     files: *agora_proteomics_tmt_files
-  #     final_format: json
-  #     provenance: *agora_proteomics_tmt_provenance
-  #     column_rename:
-  #       genename: hgnc_symbol
-  #       ensg: ensembl_gene_id
-  #     destination: *dest
-  #     gx_folder: syn53469659
+  - proteomics_tmt:
+      files: *agora_proteomics_tmt_files
+      final_format: json
+      provenance: *agora_proteomics_tmt_provenance
+      column_rename:
+        genename: hgnc_symbol
+        ensg: ensembl_gene_id
+      destination: *dest
+      gx_folder: syn53469659
 
-  # - proteomics_srm:
-  #     files: *agora_proteomics_srm_files
-  #     final_format: json
-  #     provenance: *agora_proteomics_srm_provenance
-  #     column_rename:
-  #       genename: hgnc_symbol
-  #       ensg: ensembl_gene_id
-  #     destination: *dest
+  - proteomics_srm:
+      files: *agora_proteomics_srm_files
+      final_format: json
+      provenance: *agora_proteomics_srm_provenance
+      column_rename:
+        genename: hgnc_symbol
+        ensg: ensembl_gene_id
+      destination: *dest
 
-  # - target_exp_validation_harmonized:
-  #     files:
-  #       - name: target_exp_validation_harmonized
-  #         id: syn24184512.8
-  #         format: csv
-  #     final_format: json
-  #     provenance:
-  #       - syn24184512.8
-  #     destination: *dest
+  - target_exp_validation_harmonized:
+      files:
+        - name: target_exp_validation_harmonized
+          id: syn24184512.8
+          format: csv
+      final_format: json
+      provenance:
+        - syn24184512.8
+      destination: *dest
 
-  # - metabolomics:
-  #     files:
-  #       - name: metabolomics
-  #         id: syn26064497.1
-  #         format: feather
-  #     final_format: json
-  #     provenance:
-  #       - syn26064497.1
-  #     destination: *dest
-  #     gx_folder: syn52948671
+  - metabolomics:
+      files:
+        - name: metabolomics
+          id: syn26064497.1
+          format: feather
+      final_format: json
+      provenance:
+        - syn26064497.1
+      destination: *dest
+      gx_folder: syn52948671
 
-  # - gene_info:
-  #     files:
-  #       - name: gene_metadata
-  #         id: syn25953363.12
-  #         format: feather
-  #       - name: igap
-  #         id: syn12514826.5
-  #         format: csv
-  #       - name: eqtl
-  #         id: syn12514912.3
-  #         format: csv
-  #       - <<: *agora_proteomics_files
-  #       - <<: *agora_proteomics_tmt_files
-  #       - <<: *agora_proteomics_srm_files
-  #       - <<: *rna_diff_expr_data_files
-  #       - name: target_list
-  #         id: syn12540368.47
-  #         format: csv
-  #       - name: median_expression
-  #         id: syn27211878.2
-  #         format: csv
-  #       - name: druggability
-  #         id: syn13363443.11
-  #         format: csv
-  #       - <<: *genes_biodomains_files
-  #       - name: tep_adi_info
-  #         id: syn51942280.2
-  #         format: csv
-  #     final_format: json
-  #     custom_transformations:
-  #       adjusted_p_value_threshold: 0.05
-  #       protein_level_threshold: 0.05
-  #     column_rename:
-  #       ensg: ensembl_gene_id
-  #       ensembl_id: ensembl_gene_id
-  #       geneid: ensembl_gene_id
-  #       has_eqtl: is_eqtl
-  #       minimumlogcpm: min
-  #       quartile1logcpm: first_quartile
-  #       medianlogcpm: median
-  #       meanlogcpm: mean
-  #       quartile3logcpm: third_quartile
-  #       maximumlogcpm: max
-  #       possible_replacement: ensembl_possible_replacements
-  #       permalink: ensembl_permalink
-  #     provenance:
-  #       - syn25953363.12
-  #       - syn12514826.5
-  #       - syn12514912.3
-  #       - *agora_proteomics_provenance
-  #       - *agora_proteomics_tmt_provenance
-  #       - *agora_proteomics_srm_provenance
-  #       - *rna_diff_expr_data_provenance
-  #       - syn12540368.47
-  #       - syn27211878.2
-  #       - syn13363443.11
-  #       - *genes_biodomains_provenance
-  #       - syn51942280.2
-  #     agora_rename:
-  #       symbol: hgnc_symbol
-  #     destination: *dest
+  - gene_info:
+      files:
+        - name: gene_metadata
+          id: syn25953363.12
+          format: feather
+        - name: igap
+          id: syn12514826.5
+          format: csv
+        - name: eqtl
+          id: syn12514912.3
+          format: csv
+        - <<: *agora_proteomics_files
+        - <<: *agora_proteomics_tmt_files
+        - <<: *agora_proteomics_srm_files
+        - <<: *rna_diff_expr_data_files
+        - name: target_list
+          id: syn12540368.47
+          format: csv
+        - name: median_expression
+          id: syn27211878.2
+          format: csv
+        - name: druggability
+          id: syn13363443.11
+          format: csv
+        - <<: *genes_biodomains_files
+        - name: tep_adi_info
+          id: syn51942280.2
+          format: csv
+      final_format: json
+      custom_transformations:
+        adjusted_p_value_threshold: 0.05
+        protein_level_threshold: 0.05
+      column_rename:
+        ensg: ensembl_gene_id
+        ensembl_id: ensembl_gene_id
+        geneid: ensembl_gene_id
+        has_eqtl: is_eqtl
+        minimumlogcpm: min
+        quartile1logcpm: first_quartile
+        medianlogcpm: median
+        meanlogcpm: mean
+        quartile3logcpm: third_quartile
+        maximumlogcpm: max
+        possible_replacement: ensembl_possible_replacements
+        permalink: ensembl_permalink
+      provenance:
+        - syn25953363.12
+        - syn12514826.5
+        - syn12514912.3
+        - *agora_proteomics_provenance
+        - *agora_proteomics_tmt_provenance
+        - *agora_proteomics_srm_provenance
+        - *rna_diff_expr_data_provenance
+        - syn12540368.47
+        - syn27211878.2
+        - syn13363443.11
+        - *genes_biodomains_provenance
+        - syn51942280.2
+      agora_rename:
+        symbol: hgnc_symbol
+      destination: *dest
 
-  # - team_info:
-  #     files:
-  #       - name: team_info
-  #         id: syn12615624.18
-  #         format: csv
-  #       - name: team_member_info
-  #         id: syn12615633.18
-  #         format: csv
-  #     final_format: json
-  #     custom_transformations: 1
-  #     provenance:
-  #       - syn12615624.18
-  #       - syn12615633.18
-  #     destination: *dest
-  #     gx_folder: syn53616774
-  #     gx_nested_columns:
-  #       - members
+  - team_info:
+      files:
+        - name: team_info
+          id: syn12615624.18
+          format: csv
+        - name: team_member_info
+          id: syn12615633.18
+          format: csv
+      final_format: json
+      custom_transformations: 1
+      provenance:
+        - syn12615624.18
+        - syn12615633.18
+      destination: *dest
+      gx_folder: syn53616774
+      gx_nested_columns:
+        - members
 
-  # - overall_scores:
-  #     files: *overall_scores_files
-  #     final_format: json
-  #     custom_transformations: 1
-  #     column_rename:
-  #       genename: hgnc_gene_id
-  #     provenance: *overall_scores_provenance
-  #     agora_rename:
-  #       ensg: ensembl_gene_id
-  #       hgnc_gene_id: hgnc_symbol
-  #       geneticsscore: genetics_score
-  #       overall: target_risk_score
-  #       omicsscore: multi_omics_score
-  #     destination: *dest
-  #     gx_folder: syn53453225
+  - overall_scores:
+      files: *overall_scores_files
+      final_format: json
+      custom_transformations: 1
+      column_rename:
+        genename: hgnc_gene_id
+      provenance: *overall_scores_provenance
+      agora_rename:
+        ensg: ensembl_gene_id
+        hgnc_gene_id: hgnc_symbol
+        geneticsscore: genetics_score
+        overall: target_risk_score
+        omicsscore: multi_omics_score
+      destination: *dest
+      gx_folder: syn53453225
 
-  # - network:
-  #     files:
-  #       - name: networks
-  #         id: syn11685347.1
-  #         format: csv
-  #     final_format: json
-  #     provenance:
-  #       - syn11685347.1
-  #       - syn27211942.1
-  #     agora_rename:
-  #       genea_ensembl_gene_id: geneA_ensembl_gene_id
-  #       genea_external_gene_name: geneA_external_gene_name
-  #       geneb_ensembl_gene_id: geneB_ensembl_gene_id
-  #       geneb_external_gene_name: geneB_external_gene_name
-  #       brainregion: brainRegion
-  #     destination: *dest
+  - network:
+      files:
+        - name: networks
+          id: syn11685347.1
+          format: csv
+      final_format: json
+      provenance:
+        - syn11685347.1
+        - syn27211942.1
+      agora_rename:
+        genea_ensembl_gene_id: geneA_ensembl_gene_id
+        genea_external_gene_name: geneA_external_gene_name
+        geneb_ensembl_gene_id: geneB_ensembl_gene_id
+        geneb_external_gene_name: geneB_external_gene_name
+        brainregion: brainRegion
+      destination: *dest
 
-  # - rnaseq_differential_expression:
-  #     files: *rna_diff_expr_data_files
-  #     final_format: json
-  #     custom_transformations: 1
-  #     provenance: *rna_diff_expr_data_provenance
-  #     destination: *dest
+  - rnaseq_differential_expression:
+      files: *rna_diff_expr_data_files
+      final_format: json
+      custom_transformations: 1
+      provenance: *rna_diff_expr_data_provenance
+      destination: *dest
 
-  # - distribution_data:
-  #     files: *overall_scores_files
-  #     final_format: json
-  #     custom_transformations:
-  #       overall_max_score: 5
-  #       genetics_max_score: 3
-  #       omics_max_score: 2
-  #     provenance: *overall_scores_provenance
-  #     column_rename:
-  #       overall: target_risk_score
-  #       geneticsscore: genetics_score
-  #       omicsscore: multi_omics_score
-  #     destination: *dest
+  - distribution_data:
+      files: *overall_scores_files
+      final_format: json
+      custom_transformations:
+        overall_max_score: 5
+        genetics_max_score: 3
+        omics_max_score: 2
+      provenance: *overall_scores_provenance
+      column_rename:
+        overall: target_risk_score
+        geneticsscore: genetics_score
+        omicsscore: multi_omics_score
+      destination: *dest
 
-  # - rna_distribution_data:
-  #     files: *rna_diff_expr_data_files
-  #     final_format: json
-  #     custom_transformations: 1
-  #     provenance: *rna_diff_expr_data_provenance
-  #     destination: *dest
+  - rna_distribution_data:
+      files: *rna_diff_expr_data_files
+      final_format: json
+      custom_transformations: 1
+      provenance: *rna_diff_expr_data_provenance
+      destination: *dest
 
-  # - proteomics_distribution_data:
-  #     files:
-  #       - <<: *agora_proteomics_files
-  #       - <<: *agora_proteomics_tmt_files
-  #       - <<: *agora_proteomics_srm_files
-  #     final_format: json
-  #     custom_transformations: 1
-  #     provenance:
-  #       - *agora_proteomics_provenance
-  #       - *agora_proteomics_tmt_provenance
-  #       - *agora_proteomics_srm_provenance
-  #     destination: *dest
-  #     gx_folder: syn53463344
+  - proteomics_distribution_data:
+      files:
+        - <<: *agora_proteomics_files
+        - <<: *agora_proteomics_tmt_files
+        - <<: *agora_proteomics_srm_files
+      final_format: json
+      custom_transformations: 1
+      provenance:
+        - *agora_proteomics_provenance
+        - *agora_proteomics_tmt_provenance
+        - *agora_proteomics_srm_provenance
+      destination: *dest
+      gx_folder: syn53463344

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -69,7 +69,7 @@ datasets:
   - neuropath_corr:
       files:
         - name: neuropath_regression_results
-          id: syn53771485
+          id: syn22017882.5
           format: csv
       final_format: json
       provenance:

--- a/tests/test_assets/gx/checkpoint_result_fail.json
+++ b/tests/test_assets/gx/checkpoint_result_fail.json
@@ -1,0 +1,428 @@
+{
+    "run_id": {
+        "run_name": null,
+        "run_time": "2024-02-29T17:26:00.099052-07:00"
+    },
+    "run_results": {
+        "ValidationResultIdentifier::genes_biodomains/__null__/20240301T002600.099052Z/default_pandas_datasource-#ephemeral_pandas_asset": {
+            "validation_result": {
+                "success": false,
+                "results": [
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_be_of_type",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "type_": "str",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.0,
+                            "unexpected_percent_nonmissing": 0.0,
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_not_be_null",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": false,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_value_lengths_to_equal",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "value": 15,
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 1,
+                            "unexpected_percent": 0.006253517603652055,
+                            "partial_unexpected_list": [
+                                "ENSG00"
+                            ],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.006253517603652055,
+                            "unexpected_percent_nonmissing": 0.006253517603652055,
+                            "partial_unexpected_counts": [
+                                {
+                                    "value": "ENSG00",
+                                    "count": 1
+                                }
+                            ],
+                            "partial_unexpected_index_list": [
+                                0
+                            ]
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": false,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_match_regex",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "regex": "^ENSG\\d{11}$",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 1,
+                            "unexpected_percent": 0.006253517603652055,
+                            "partial_unexpected_list": [
+                                "ENSG00"
+                            ],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.006253517603652055,
+                            "unexpected_percent_nonmissing": 0.006253517603652055,
+                            "partial_unexpected_counts": [
+                                {
+                                    "value": "ENSG00",
+                                    "count": 1
+                                }
+                            ],
+                            "partial_unexpected_index_list": [
+                                0
+                            ]
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_be_unique",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.0,
+                            "unexpected_percent_nonmissing": 0.0,
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_be_of_type",
+                            "kwargs": {
+                                "column": "gene_biodomains",
+                                "type_": "str",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.0,
+                            "unexpected_percent_nonmissing": 0.0,
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_not_be_null",
+                            "kwargs": {
+                                "column": "gene_biodomains",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_match_json_schema",
+                            "kwargs": {
+                                "column": "gene_biodomains",
+                                "json_schema": {
+                                    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/genes_biodomains/gene_biodomains_schema.json",
+                                    "$schema": "https://json-schema.org/draft/2019-09/schema",
+                                    "default": [],
+                                    "items": {
+                                        "default": {},
+                                        "properties": {
+                                            "biodomain": {
+                                                "default": "",
+                                                "enum": [
+                                                    "Apoptosis",
+                                                    "Vasculature",
+                                                    "Lipid Metabolism",
+                                                    "Proteostasis",
+                                                    "Immune Response",
+                                                    "Autophagy",
+                                                    "Mitochondrial Metabolism",
+                                                    "Structural Stabilization",
+                                                    "Synapse",
+                                                    "Endolysosome",
+                                                    "Metal Binding and Homeostasis",
+                                                    "Oxidative Stress",
+                                                    "Epigenetic",
+                                                    "APP Metabolism",
+                                                    "Cell Cycle",
+                                                    "DNA Repair",
+                                                    "RNA Spliceosome",
+                                                    "Tau Homeostasis",
+                                                    "Myelination"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "go_terms": {
+                                                "default": [],
+                                                "items": {
+                                                    "UniqueItems": true,
+                                                    "type": "string"
+                                                },
+                                                "maxItems": 100,
+                                                "minItems": 1,
+                                                "type": "array"
+                                            },
+                                            "n_biodomain_terms": {
+                                                "default": 0,
+                                                "type": "integer"
+                                            },
+                                            "n_gene_biodomain_terms": {
+                                                "default": 0,
+                                                "type": "integer"
+                                            },
+                                            "pct_linking_terms": {
+                                                "maximum": 100,
+                                                "minimum": 0,
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "biodomain",
+                                            "go_terms",
+                                            "n_biodomain_terms",
+                                            "n_gene_biodomain_terms",
+                                            "pct_linking_terms"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "title": "Gene Biodomains",
+                                    "type": "array"
+                                },
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.0,
+                            "unexpected_percent_nonmissing": 0.0,
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    }
+                ],
+                "evaluation_parameters": {},
+                "statistics": {
+                    "evaluated_expectations": 8,
+                    "successful_expectations": 6,
+                    "unsuccessful_expectations": 2,
+                    "success_percent": 75.0
+                },
+                "meta": {
+                    "great_expectations_version": "0.18.1",
+                    "expectation_suite_name": "genes_biodomains",
+                    "run_id": {
+                        "run_name": null,
+                        "run_time": "2024-02-29T17:26:00.099052-07:00"
+                    },
+                    "batch_spec": {
+                        "batch_data": "PandasDataFrame"
+                    },
+                    "batch_markers": {
+                        "ge_load_time": "20240301T002600.106960Z",
+                        "pandas_data_fingerprint": "7ed3fc0aea4412bab0cddab57799abfd"
+                    },
+                    "active_batch_definition": {
+                        "datasource_name": "default_pandas_datasource",
+                        "data_connector_name": "fluent",
+                        "data_asset_name": "#ephemeral_pandas_asset",
+                        "batch_identifiers": {}
+                    },
+                    "validation_time": "20240301T002600.147524Z",
+                    "checkpoint_name": "genes_biodomains",
+                    "validation_id": null,
+                    "checkpoint_id": null
+                }
+            },
+            "actions_results": {
+                "store_validation_result": {
+                    "class": "StoreValidationResultAction"
+                },
+                "store_evaluation_params": {
+                    "class": "StoreEvaluationParametersAction"
+                },
+                "update_data_docs": {
+                    "local_site": "file:///Users/bmacdonald/Development/repos/agora-data-tools/src/agoradatatools/great_expectations/gx/uncommitted/data_docs/local_site/validations/genes_biodomains/__null__/20240301T002600.099052Z/default_pandas_datasource-%23ephemeral_pandas_asset.html",
+                    "class": "UpdateDataDocsAction"
+                }
+            }
+        }
+    },
+    "checkpoint_config": {
+        "default_validation_id": null,
+        "slack_webhook": null,
+        "validations": [
+            {
+                "id": null,
+                "batch_request": {
+                    "datasource_name": "default_pandas_datasource",
+                    "data_asset_name": "#ephemeral_pandas_asset",
+                    "options": {},
+                    "batch_slice": null
+                },
+                "expectation_suite_name": "genes_biodomains",
+                "name": null,
+                "expectation_suite_ge_cloud_id": null
+            }
+        ],
+        "notify_on": null,
+        "notify_with": null,
+        "expectation_suite_ge_cloud_id": null,
+        "module_name": "great_expectations.checkpoint",
+        "config_version": 1.0,
+        "batch_request": {},
+        "site_names": null,
+        "ge_cloud_id": null,
+        "run_name_template": null,
+        "template_name": null,
+        "action_list": [
+            {
+                "name": "store_validation_result",
+                "action": {
+                    "class_name": "StoreValidationResultAction"
+                }
+            },
+            {
+                "name": "store_evaluation_params",
+                "action": {
+                    "class_name": "StoreEvaluationParametersAction"
+                }
+            },
+            {
+                "name": "update_data_docs",
+                "action": {
+                    "class_name": "UpdateDataDocsAction"
+                }
+            }
+        ],
+        "expectation_suite_name": null,
+        "name": "genes_biodomains",
+        "evaluation_parameters": {},
+        "class_name": "Checkpoint",
+        "profilers": [],
+        "runtime_configuration": {}
+    },
+    "success": false
+}

--- a/tests/test_assets/gx/checkpoint_result_pass.json
+++ b/tests/test_assets/gx/checkpoint_result_pass.json
@@ -1,0 +1,428 @@
+{
+    "run_id": {
+        "run_name": null,
+        "run_time": "2024-02-29T17:26:00.099052-07:00"
+    },
+    "run_results": {
+        "ValidationResultIdentifier::genes_biodomains/__null__/20240301T002600.099052Z/default_pandas_datasource-#ephemeral_pandas_asset": {
+            "validation_result": {
+                "success": false,
+                "results": [
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_be_of_type",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "type_": "str",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.0,
+                            "unexpected_percent_nonmissing": 0.0,
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_not_be_null",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": false,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_value_lengths_to_equal",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "value": 15,
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 1,
+                            "unexpected_percent": 0.006253517603652055,
+                            "partial_unexpected_list": [
+                                "ENSG00"
+                            ],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.006253517603652055,
+                            "unexpected_percent_nonmissing": 0.006253517603652055,
+                            "partial_unexpected_counts": [
+                                {
+                                    "value": "ENSG00",
+                                    "count": 1
+                                }
+                            ],
+                            "partial_unexpected_index_list": [
+                                0
+                            ]
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": false,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_match_regex",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "regex": "^ENSG\\d{11}$",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 1,
+                            "unexpected_percent": 0.006253517603652055,
+                            "partial_unexpected_list": [
+                                "ENSG00"
+                            ],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.006253517603652055,
+                            "unexpected_percent_nonmissing": 0.006253517603652055,
+                            "partial_unexpected_counts": [
+                                {
+                                    "value": "ENSG00",
+                                    "count": 1
+                                }
+                            ],
+                            "partial_unexpected_index_list": [
+                                0
+                            ]
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_be_unique",
+                            "kwargs": {
+                                "column": "ensembl_gene_id",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.0,
+                            "unexpected_percent_nonmissing": 0.0,
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_be_of_type",
+                            "kwargs": {
+                                "column": "gene_biodomains",
+                                "type_": "str",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.0,
+                            "unexpected_percent_nonmissing": 0.0,
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_not_be_null",
+                            "kwargs": {
+                                "column": "gene_biodomains",
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    },
+                    {
+                        "success": true,
+                        "expectation_config": {
+                            "expectation_type": "expect_column_values_to_match_json_schema",
+                            "kwargs": {
+                                "column": "gene_biodomains",
+                                "json_schema": {
+                                    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/genes_biodomains/gene_biodomains_schema.json",
+                                    "$schema": "https://json-schema.org/draft/2019-09/schema",
+                                    "default": [],
+                                    "items": {
+                                        "default": {},
+                                        "properties": {
+                                            "biodomain": {
+                                                "default": "",
+                                                "enum": [
+                                                    "Apoptosis",
+                                                    "Vasculature",
+                                                    "Lipid Metabolism",
+                                                    "Proteostasis",
+                                                    "Immune Response",
+                                                    "Autophagy",
+                                                    "Mitochondrial Metabolism",
+                                                    "Structural Stabilization",
+                                                    "Synapse",
+                                                    "Endolysosome",
+                                                    "Metal Binding and Homeostasis",
+                                                    "Oxidative Stress",
+                                                    "Epigenetic",
+                                                    "APP Metabolism",
+                                                    "Cell Cycle",
+                                                    "DNA Repair",
+                                                    "RNA Spliceosome",
+                                                    "Tau Homeostasis",
+                                                    "Myelination"
+                                                ],
+                                                "type": "string"
+                                            },
+                                            "go_terms": {
+                                                "default": [],
+                                                "items": {
+                                                    "UniqueItems": true,
+                                                    "type": "string"
+                                                },
+                                                "maxItems": 100,
+                                                "minItems": 1,
+                                                "type": "array"
+                                            },
+                                            "n_biodomain_terms": {
+                                                "default": 0,
+                                                "type": "integer"
+                                            },
+                                            "n_gene_biodomain_terms": {
+                                                "default": 0,
+                                                "type": "integer"
+                                            },
+                                            "pct_linking_terms": {
+                                                "maximum": 100,
+                                                "minimum": 0,
+                                                "type": "number"
+                                            }
+                                        },
+                                        "required": [
+                                            "biodomain",
+                                            "go_terms",
+                                            "n_biodomain_terms",
+                                            "n_gene_biodomain_terms",
+                                            "pct_linking_terms"
+                                        ],
+                                        "type": "object"
+                                    },
+                                    "title": "Gene Biodomains",
+                                    "type": "array"
+                                },
+                                "batch_id": "default_pandas_datasource-#ephemeral_pandas_asset"
+                            },
+                            "meta": {}
+                        },
+                        "result": {
+                            "element_count": 15991,
+                            "unexpected_count": 0,
+                            "unexpected_percent": 0.0,
+                            "partial_unexpected_list": [],
+                            "missing_count": 0,
+                            "missing_percent": 0.0,
+                            "unexpected_percent_total": 0.0,
+                            "unexpected_percent_nonmissing": 0.0,
+                            "partial_unexpected_counts": [],
+                            "partial_unexpected_index_list": []
+                        },
+                        "meta": {},
+                        "exception_info": {
+                            "raised_exception": false,
+                            "exception_traceback": null,
+                            "exception_message": null
+                        }
+                    }
+                ],
+                "evaluation_parameters": {},
+                "statistics": {
+                    "evaluated_expectations": 8,
+                    "successful_expectations": 6,
+                    "unsuccessful_expectations": 2,
+                    "success_percent": 75.0
+                },
+                "meta": {
+                    "great_expectations_version": "0.18.1",
+                    "expectation_suite_name": "genes_biodomains",
+                    "run_id": {
+                        "run_name": null,
+                        "run_time": "2024-02-29T17:26:00.099052-07:00"
+                    },
+                    "batch_spec": {
+                        "batch_data": "PandasDataFrame"
+                    },
+                    "batch_markers": {
+                        "ge_load_time": "20240301T002600.106960Z",
+                        "pandas_data_fingerprint": "7ed3fc0aea4412bab0cddab57799abfd"
+                    },
+                    "active_batch_definition": {
+                        "datasource_name": "default_pandas_datasource",
+                        "data_connector_name": "fluent",
+                        "data_asset_name": "#ephemeral_pandas_asset",
+                        "batch_identifiers": {}
+                    },
+                    "validation_time": "20240301T002600.147524Z",
+                    "checkpoint_name": "genes_biodomains",
+                    "validation_id": null,
+                    "checkpoint_id": null
+                }
+            },
+            "actions_results": {
+                "store_validation_result": {
+                    "class": "StoreValidationResultAction"
+                },
+                "store_evaluation_params": {
+                    "class": "StoreEvaluationParametersAction"
+                },
+                "update_data_docs": {
+                    "local_site": "file:///Users/bmacdonald/Development/repos/agora-data-tools/src/agoradatatools/great_expectations/gx/uncommitted/data_docs/local_site/validations/genes_biodomains/__null__/20240301T002600.099052Z/default_pandas_datasource-%23ephemeral_pandas_asset.html",
+                    "class": "UpdateDataDocsAction"
+                }
+            }
+        }
+    },
+    "checkpoint_config": {
+        "default_validation_id": null,
+        "slack_webhook": null,
+        "validations": [
+            {
+                "id": null,
+                "batch_request": {
+                    "datasource_name": "default_pandas_datasource",
+                    "data_asset_name": "#ephemeral_pandas_asset",
+                    "options": {},
+                    "batch_slice": null
+                },
+                "expectation_suite_name": "genes_biodomains",
+                "name": null,
+                "expectation_suite_ge_cloud_id": null
+            }
+        ],
+        "notify_on": null,
+        "notify_with": null,
+        "expectation_suite_ge_cloud_id": null,
+        "module_name": "great_expectations.checkpoint",
+        "config_version": 1.0,
+        "batch_request": {},
+        "site_names": null,
+        "ge_cloud_id": null,
+        "run_name_template": null,
+        "template_name": null,
+        "action_list": [
+            {
+                "name": "store_validation_result",
+                "action": {
+                    "class_name": "StoreValidationResultAction"
+                }
+            },
+            {
+                "name": "store_evaluation_params",
+                "action": {
+                    "class_name": "StoreEvaluationParametersAction"
+                }
+            },
+            {
+                "name": "update_data_docs",
+                "action": {
+                    "class_name": "UpdateDataDocsAction"
+                }
+            }
+        ],
+        "expectation_suite_name": null,
+        "name": "genes_biodomains",
+        "evaluation_parameters": {},
+        "class_name": "Checkpoint",
+        "profilers": [],
+        "runtime_configuration": {}
+    },
+    "success": true
+}

--- a/tests/test_assets/gx/checkpoint_result_pass.json
+++ b/tests/test_assets/gx/checkpoint_result_pass.json
@@ -6,7 +6,7 @@
     "run_results": {
         "ValidationResultIdentifier::genes_biodomains/__null__/20240301T002600.099052Z/default_pandas_datasource-#ephemeral_pandas_asset": {
             "validation_result": {
-                "success": false,
+                "success": true,
                 "results": [
                     {
                         "success": true,
@@ -64,7 +64,7 @@
                         }
                     },
                     {
-                        "success": false,
+                        "success": true,
                         "expectation_config": {
                             "expectation_type": "expect_column_value_lengths_to_equal",
                             "kwargs": {
@@ -103,7 +103,7 @@
                         }
                     },
                     {
-                        "success": false,
+                        "success": true,
                         "expectation_config": {
                             "expectation_type": "expect_column_values_to_match_regex",
                             "kwargs": {

--- a/tests/test_gx.py
+++ b/tests/test_gx.py
@@ -135,7 +135,8 @@ class TestGreatExpectationsRunner:
     def test_get_failed_expectations_with_failed_checkpoint_result(self):
         expected = (
             "Great Expectations data validation has failed: "
-            "ensembl_gene_id has failed expectations expect_column_value_lengths_to_equal, expect_column_values_to_match_regex"
+            "ensembl_gene_id has failed expectations expect_column_value_lengths_to_equal, "
+            "expect_column_values_to_match_regex"
         )
         fail_message = self.good_runner.get_failed_expectations(
             self.failed_checkpoint_result

--- a/tests/test_gx.py
+++ b/tests/test_gx.py
@@ -6,8 +6,11 @@ from unittest.mock import patch
 
 import pandas as pd
 
+from agoradatatools.errors import ADTDataValidationError
+
 import pytest
 from great_expectations.checkpoint.types.checkpoint_result import CheckpointResult
+from great_expectations.checkpoint import Checkpoint
 from great_expectations.data_context import FileDataContext
 from great_expectations.data_context.types.resource_identifiers import (
     ValidationResultIdentifier,
@@ -123,6 +126,17 @@ class TestGreatExpectationsRunner:
         result = self.good_runner.convert_nested_columns_to_json(df, [])
         pd.testing.assert_frame_equal(result, df)
 
+    def test_get_failed_expectations_with_failed_checkpoint_result(self):
+        expected = (
+            "Great Expectations data validation has failed: "
+            "ensembl_gene_id has failed expectations expect_column_value_lengths_to_equal, expect_column_values_to_match_regex"
+        )
+        checkpoint_result = json.load(
+            open("./tests/test_assets/gx/checkpoint_result_fail.json")
+        )
+        fail_message = self.good_runner.get_failed_expectations(checkpoint_result)
+        assert fail_message == expected
+
     def test_run_when_expectation_suite_exists_and_nested_columns(
         self,
     ):
@@ -138,7 +152,13 @@ class TestGreatExpectationsRunner:
             self.good_runner, "_get_results_path", return_value="test_path"
         ) as patch_get_results_path, patch.object(
             self.good_runner, "_upload_results_file_to_synapse", return_value=None
-        ) as patch_upload_results_file_to_synapse:
+        ) as patch_upload_results_file_to_synapse, patch.object(
+            Checkpoint,
+            "run",
+            return_value=json.load(
+                open("./tests/test_assets/gx/checkpoint_result_pass.json")
+            ),
+        ) as patch_checkpoint_run:
             self.good_runner.nested_columns = ["a"]
             self.good_runner.run()
             patch_read_json.assert_called_once_with(
@@ -147,6 +167,7 @@ class TestGreatExpectationsRunner:
             patch_convert_nested_columns_to_json.assert_called_once()
             patch_get_results_path.assert_called_once()
             patch_upload_results_file_to_synapse.assert_called_once_with("test_path")
+            patch_checkpoint_run.assert_called_once()
 
     def test_run_when_expectation_suite_exists_and_no_nested_columns(
         self,
@@ -163,7 +184,13 @@ class TestGreatExpectationsRunner:
             self.good_runner, "_get_results_path", return_value="test_path"
         ) as patch_get_results_path, patch.object(
             self.good_runner, "_upload_results_file_to_synapse", return_value=None
-        ) as patch_upload_results_file_to_synapse:
+        ) as patch_upload_results_file_to_synapse, patch.object(
+            Checkpoint,
+            "run",
+            return_value=json.load(
+                open("./tests/test_assets/gx/checkpoint_result_pass.json")
+            ),
+        ) as patch_checkpoint_run:
             self.good_runner.run()
             patch_read_json.assert_called_once_with(
                 self.good_runner.dataset_path,
@@ -171,6 +198,7 @@ class TestGreatExpectationsRunner:
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_get_results_path.assert_called_once()
             patch_upload_results_file_to_synapse.assert_called_once_with("test_path")
+            patch_checkpoint_run.assert_called_once()
 
     def test_that_run_does_not_complete_when_check_if_expectation_suite_exists_is_false(
         self,
@@ -187,9 +215,50 @@ class TestGreatExpectationsRunner:
             self.good_runner, "_get_results_path", return_value="test_path"
         ) as patch_get_results_path, patch.object(
             self.good_runner, "_upload_results_file_to_synapse", return_value=None
-        ) as patch_upload_results_file_to_synapse:
+        ) as patch_upload_results_file_to_synapse, patch.object(
+            Checkpoint,
+            "run",
+        ) as patch_checkpoint_run:
             self.good_runner.run()
             patch_read_json.assert_not_called()
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_get_results_path.assert_not_called()
             patch_upload_results_file_to_synapse.assert_not_called()
+            patch_checkpoint_run.assert_not_called()
+
+    def test_run_raises_error_when_validation_fails(
+        self,
+    ):
+        with patch.object(
+            self.good_runner, "_check_if_expectation_suite_exists", return_value=True
+        ), patch.object(
+            pd, "read_json", return_value=pd.DataFrame()
+        ) as patch_read_json, patch.object(
+            self.good_runner,
+            "convert_nested_columns_to_json",
+            return_value=pd.DataFrame(),
+        ) as patch_convert_nested_columns_to_json, patch.object(
+            self.good_runner, "_get_results_path", return_value="test_path"
+        ) as patch_get_results_path, patch.object(
+            self.good_runner, "_upload_results_file_to_synapse", return_value=None
+        ) as patch_upload_results_file_to_synapse, patch.object(
+            Checkpoint,
+            "run",
+            return_value=json.load(
+                open("./tests/test_assets/gx/checkpoint_result_fail.json")
+            ),
+        ) as patch_checkpoint_run, patch.object(
+            self.good_runner, "get_failed_expectations", return_value="test"
+        ) as patch_get_failed_expectations:
+            with pytest.raises(ADTDataValidationError, match="test"):
+                self.good_runner.run()
+                patch_read_json.assert_called_once_with(self.good_runner.dataset_path)
+                patch_convert_nested_columns_to_json.assert_not_called()
+                patch_get_results_path.assert_called_once()
+                patch_upload_results_file_to_synapse.assert_called_once_with(
+                    "test_path"
+                )
+                patch_checkpoint_run.assert_called_once()
+                patch_get_failed_expectations.assert_called_once_with(
+                    patch_upload_results_file_to_synapse.return_value
+                )

--- a/tests/test_gx.py
+++ b/tests/test_gx.py
@@ -162,7 +162,9 @@ class TestGreatExpectationsRunner:
             Checkpoint,
             "run",
             return_value=self.passed_checkpoint_result,
-        ) as patch_checkpoint_run:
+        ) as patch_checkpoint_run, patch.object(
+            self.good_runner, "get_failed_expectations", return_value="test"
+        ) as patch_get_failed_expectations:
             self.good_runner.nested_columns = ["a"]
             self.good_runner.run()
             patch_read_json.assert_called_once_with(
@@ -172,6 +174,7 @@ class TestGreatExpectationsRunner:
             patch_get_results_path.assert_called_once()
             patch_upload_results_file_to_synapse.assert_called_once_with("test_path")
             patch_checkpoint_run.assert_called_once()
+            patch_get_failed_expectations.assert_not_called()
 
     def test_run_when_expectation_suite_exists_and_no_nested_columns(
         self,
@@ -192,7 +195,9 @@ class TestGreatExpectationsRunner:
             Checkpoint,
             "run",
             return_value=self.passed_checkpoint_result,
-        ) as patch_checkpoint_run:
+        ) as patch_checkpoint_run, patch.object(
+            self.good_runner, "get_failed_expectations", return_value="test"
+        ) as patch_get_failed_expectations:
             self.good_runner.run()
             patch_read_json.assert_called_once_with(
                 self.good_runner.dataset_path,
@@ -201,6 +206,7 @@ class TestGreatExpectationsRunner:
             patch_get_results_path.assert_called_once()
             patch_upload_results_file_to_synapse.assert_called_once_with("test_path")
             patch_checkpoint_run.assert_called_once()
+            patch_get_failed_expectations.assert_not_called()
 
     def test_that_run_does_not_complete_when_check_if_expectation_suite_exists_is_false(
         self,
@@ -220,13 +226,16 @@ class TestGreatExpectationsRunner:
         ) as patch_upload_results_file_to_synapse, patch.object(
             Checkpoint,
             "run",
-        ) as patch_checkpoint_run:
+        ) as patch_checkpoint_run, patch.object(
+            self.good_runner, "get_failed_expectations", return_value="test"
+        ) as patch_get_failed_expectations:
             self.good_runner.run()
             patch_read_json.assert_not_called()
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_get_results_path.assert_not_called()
             patch_upload_results_file_to_synapse.assert_not_called()
             patch_checkpoint_run.assert_not_called()
+            patch_get_failed_expectations.assert_not_called()
 
     def test_run_raises_error_when_validation_fails(
         self,

--- a/tests/test_gx.py
+++ b/tests/test_gx.py
@@ -37,6 +37,12 @@ class TestGreatExpectationsRunner:
             upload_folder="test_folder",
             nested_columns=None,
         )
+        self.passed_checkpoint_result = CheckpointResult(
+            **json.load(open("./tests/test_assets/gx/checkpoint_result_pass.json"))
+        )
+        self.failed_checkpoint_result = CheckpointResult(
+            **json.load(open("./tests/test_assets/gx/checkpoint_result_fail.json"))
+        )
 
     def test_that_an_initialized_runner_has_the_attributes_it_should(self, syn):
         assert (
@@ -131,10 +137,9 @@ class TestGreatExpectationsRunner:
             "Great Expectations data validation has failed: "
             "ensembl_gene_id has failed expectations expect_column_value_lengths_to_equal, expect_column_values_to_match_regex"
         )
-        checkpoint_result = json.load(
-            open("./tests/test_assets/gx/checkpoint_result_fail.json")
+        fail_message = self.good_runner.get_failed_expectations(
+            self.failed_checkpoint_result
         )
-        fail_message = self.good_runner.get_failed_expectations(checkpoint_result)
         assert fail_message == expected
 
     def test_run_when_expectation_suite_exists_and_nested_columns(
@@ -155,9 +160,7 @@ class TestGreatExpectationsRunner:
         ) as patch_upload_results_file_to_synapse, patch.object(
             Checkpoint,
             "run",
-            return_value=json.load(
-                open("./tests/test_assets/gx/checkpoint_result_pass.json")
-            ),
+            return_value=self.passed_checkpoint_result,
         ) as patch_checkpoint_run:
             self.good_runner.nested_columns = ["a"]
             self.good_runner.run()
@@ -187,9 +190,7 @@ class TestGreatExpectationsRunner:
         ) as patch_upload_results_file_to_synapse, patch.object(
             Checkpoint,
             "run",
-            return_value=json.load(
-                open("./tests/test_assets/gx/checkpoint_result_pass.json")
-            ),
+            return_value=self.passed_checkpoint_result,
         ) as patch_checkpoint_run:
             self.good_runner.run()
             patch_read_json.assert_called_once_with(
@@ -244,9 +245,7 @@ class TestGreatExpectationsRunner:
         ) as patch_upload_results_file_to_synapse, patch.object(
             Checkpoint,
             "run",
-            return_value=json.load(
-                open("./tests/test_assets/gx/checkpoint_result_fail.json")
-            ),
+            return_value=self.failed_checkpoint_result,
         ) as patch_checkpoint_run, patch.object(
             self.good_runner, "get_failed_expectations", return_value="test"
         ) as patch_get_failed_expectations:


### PR DESCRIPTION
**Problem:**

Previously, failures in GX data validation were not causing pipeline failures. As a result, visibility for these failures is poor and our data validation pipeline is relatively ineffective.

**Solution:**

Leverage our existing error-catching strategy to capture data validation failures by introducing a new error type which is triggered during GX data validation if validation for a dataset fails.

**Notes:**
- `ADTDataValidationError` is raised when data validation fails. This is caught by the try/except logic in `process_all_files` and a formatted string is printed when the pipeline concludes. [Example](https://github.com/Sage-Bionetworks/agora-data-tools/actions/runs/8163813039/job/22317927561#step:6:571).
- Needed tests are added for `GreatExpectationsRunner.run` and the new_function `GreatExpectationsRunner.get_failed_expectations` which is used to parse out which expectations failed and produce the error message.