### PR TITLE
[IBCDPE-946] Adds Optional Uploading

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -68,7 +68,7 @@ jobs:
           python-version: "3.9"
       - run: pip install -U setuptools
       - run: pip install .
-      - run: adt test_config.yaml -t ${{secrets.SYNAPSE_PAT}}
+      - run: adt test_config.yaml --upload --platform GITHUB --token ${{secrets.SYNAPSE_PAT}}
 
   ghcr-publish:
     needs: [build, test]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing
 
-We welcome all contributions!  That said, this is a Sage Bionetworks owned project, and we use JIRA ([AG](https://sagebionetworks.jira.com/jira/software/c/projects/AG/boards/91)/[IBCDPE](https://sagebionetworks.jira.com/jira/software/c/projects/IBCDPE/boards/189)) to track any bug/feature requests. This guide will be more focussed on a Sage Bio employee's development workflow.  If you are a Sage Bio employee, make sure to assign yourself the JIRA ticket if you decide to work on it.
+We welcome all contributions! That said, this is a Sage Bionetworks owned project, and we use JIRA ([AG](https://sagebionetworks.jira.com/jira/software/c/projects/AG/boards/91)/[IBCDPE](https://sagebionetworks.jira.com/jira/software/c/projects/IBCDPE/boards/189)) to track any bug/feature requests. This guide will be more focussed on a Sage Bio employee's development workflow. If you are a Sage Bio employee, make sure to assign yourself the JIRA ticket if you decide to work on it.
 
 ## Coding Style
 
@@ -23,7 +23,7 @@ The code in this package is also automatically formatted by `black` for consiste
 
 ### Install development dependencies
 
-Please follow the [README.md](README.md) to install the package for development purposes.  Be sure you run this:
+Please follow the [README.md](README.md) to install the package for development purposes. Be sure you run this:
 
 ```
 pipenv install --dev
@@ -32,41 +32,42 @@ pipenv install --dev
 ### Developing at Sage Bio
 
 The agora-data-tools project follows the standard [trunk based development](https://trunkbaseddevelopment.com/) development strategy.
+
 > To ensure the most fluid development, do not push to `dev`!
 
 1. Please ask for write permissions to contribute directly to this repository.
 1. Make sure you are always creating feature branches from the `dev` branch. We use branches instead of forks, because CI/CD cannot access secrets across Github forks.
 
-    ```shell
-    git checkout dev
-    git pull
-    ```
+   ```shell
+   git checkout dev
+   git pull
+   ```
 
 1. Create a feature branch from the `dev` branch. Use the Id of the JIRA issue that you are addressing and name the branch after the issue with some more detail like `{user}/{JIRA}-123/add-some-new-feature`.
 
-    ```shell
-    git checkout dev
-    git checkout -b tyu/JIRA-123/some-new-feature
-    ```
+   ```shell
+   git checkout dev
+   git checkout -b tyu/JIRA-123/some-new-feature
+   ```
 
 1. At this point, you have only created the branch locally, you need to push this to your fork on GitHub.
 
-    ```shell
-    git push --set-upstream origin tyu/JIRA-123/some-new-feature
-    ```
+   ```shell
+   git push --set-upstream origin tyu/JIRA-123/some-new-feature
+   ```
 
-    You should now be able to see the branch on GitHub. Make commits as you deem necessary. It helps to provide useful commit messages - a commit message saying 'Update' is a lot less helpful than saying 'Remove X parameter because it was unused'.
+   You should now be able to see the branch on GitHub. Make commits as you deem necessary. It helps to provide useful commit messages - a commit message saying 'Update' is a lot less helpful than saying 'Remove X parameter because it was unused'.
 
-    ```shell
-    git commit changed_file.txt -m "Remove X parameter because it was unused"
-    git push
-    ```
+   ```shell
+   git commit changed_file.txt -m "Remove X parameter because it was unused"
+   git push
+   ```
 
-1. Once you have made your additions or changes, make sure you write tests and run the test suite.  More information on testing below.
+1. Once you have made your additions or changes, make sure you write tests and run the test suite. More information on testing below.
 
-    ```shell
-    pytest -vs tests/
-    ```
+   ```shell
+   pytest -vs tests/
+   ```
 
 1. Make sure to run the auto python code formatter, black.
 
@@ -88,9 +89,9 @@ adt my_dev_config.yaml --upload
 
 1. Once you have completed all the steps above, create a pull request from the feature branch to the `dev` branch of the Sage-Bionetworks/agora-data-tools repo.
 
-> *A code maintainer must review and accept your pull request.* Most code reviews can be done asyncronously.  For more complex code updates, an "in-person" or zoom code review can happen between the reviewer(s) and contributor.
+> _A code maintainer must review and accept your pull request._ Most code reviews can be done asyncronously. For more complex code updates, an "in-person" or zoom code review can happen between the reviewer(s) and contributor.
 
-This package uses [semantic versioning](https://semver.org/) for releasing new versions. A github release should occur at least once a quarter to capture the changes between releases.  Currently releases are minted by admins of this repo, but there is no formal process of when releases are minted except for more freqeunt releases leading to smaller changelogs.
+This package uses [semantic versioning](https://semver.org/) for releasing new versions. A github release should occur at least once a quarter to capture the changes between releases. Currently releases are minted by admins of this repo, but there is no formal process of when releases are minted except for more freqeunt releases leading to smaller changelogs.
 
 <!-- This package uses [semantic versioning](https://semver.org/) for releasing new versions. The version should be updated on the `dev` branch as changes are reviewed and merged in by a code maintainer. The version for the package is maintained in the [agoradatatools/__init__.py](agoradatatools/__init__.py) file.  A github release should also occur every time `dev` is pushed into `main` and it should match the version for the package. -->
 
@@ -145,28 +146,29 @@ Follow gitflow best practices as linked above.
 
 ### Transforms
 
-This package has a `src/agoradatatools/etl/transform` submodule.  This folder houses all the individual transform modules required for the package.  Here are the steps to add more transforms:
+This package has a `src/agoradatatools/etl/transform` submodule. This folder houses all the individual transform modules required for the package. Here are the steps to add more transforms:
 
-1. Create new script in the transform submodule that matches the dataset name and name the function `transform_...`.  For example, if you have a dataset named `genome_variants`, your new script would be `src/agoradatatools/etl/transform/transform_genome_variants.py`.
+1. Create new script in the transform submodule that matches the dataset name and name the function `transform_...`. For example, if you have a dataset named `genome_variants`, your new script would be `src/agoradatatools/etl/transform/transform_genome_variants.py`.
 1. Register the new transform function in `src/agoradatatools/etl/transform/__init__.py`. Look in that file for examples.
 1. Modify the `apply_custom_transformations` in `src/agoradatatools/process.py` to include your new transform.
 1. Write a test for the transform:
-    - For transform tests, we are using a [Data-Driven Testing](https://www.develer.com/en/blog/data-driven-testing-with-python/) strategy
-    - To contribute new tests, assets in the form of input and output data files are needed.
-        - The input file is loaded to serve as the data fed into the transform function, while the output file is loaded in to check the function output against.
-    - These tests should include multiple ways of evaluating the transform function, including one test that should pass (good input data) and at least one that should fail (bad input data).
-    - For some functions, it may be appropriate to include multiple passing datasets (e.g. for functions that are written to handle imperfect data) and/or multiple failing datasets (e.g. for transforms operating on datasets that can be unclean in multiple distinct ways).
-    - Each transform function should have its own folder in `test_assets` to hold its input and output data files. Inputs should be in CSV form and outputs in JSON form.
-    - Use `pytest.mark.parameterize` to loop through multiple datasets in a single test.
-    - The class `TestTransformGenesBiodomains` can be used as an example for future tests contibuted.
+   - For transform tests, we are using a [Data-Driven Testing](https://www.develer.com/en/blog/data-driven-testing-with-python/) strategy
+   - To contribute new tests, assets in the form of input and output data files are needed.
+     - The input file is loaded to serve as the data fed into the transform function, while the output file is loaded in to check the function output against.
+   - These tests should include multiple ways of evaluating the transform function, including one test that should pass (good input data) and at least one that should fail (bad input data).
+   - For some functions, it may be appropriate to include multiple passing datasets (e.g. for functions that are written to handle imperfect data) and/or multiple failing datasets (e.g. for transforms operating on datasets that can be unclean in multiple distinct ways).
+   - Each transform function should have its own folder in `test_assets` to hold its input and output data files. Inputs should be in CSV form and outputs in JSON form.
+   - Use `pytest.mark.parameterize` to loop through multiple datasets in a single test.
+   - The class `TestTransformGenesBiodomains` can be used as an example for future tests contibuted.
 
 ### Great Expectations
 
-This package uses [Great Expectations](https://greatexpectations.io/) to validate output data.  The `src/agoradatatools/great_expectations` folder houses our file system data context and Great Expectations-specific configuration files. Eventually, our goal is for each `agora-data-tools` dataset to be convered by an expectation suite. To add data validation for more datasets, follow these steps:
+This package uses [Great Expectations](https://greatexpectations.io/) to validate output data. The `src/agoradatatools/great_expectations` folder houses our file system data context and Great Expectations-specific configuration files. Eventually, our goal is for each `agora-data-tools` dataset to be convered by an expectation suite. To add data validation for more datasets, follow these steps:
 
 1. Create a new expectation suite by defining the expectations for the dataset in a Jupyter Notebook inside the `gx_suite_definitions` folder. Use `metabolomics.ipynb` as an example. You can find a catalog of existing expectations [here](https://greatexpectations.io/expectations/).
 1. Run the notebook to generate the new expectation suite. It should populate as a JSON file in the `/great_expectations/expectations` folder.
-1. Add support for running Great Expectations on a dataset by adding `gx_enabled: true`  to the configuration for the datatset in both `test_config.yaml` and `config.yaml`. After updating the config files reports should be uploaded in the proper locations ([Prod](https://www.synapse.org/#!Synapse:syn52948668), [Testing](https://www.synapse.org/#!Synapse:syn52948670)) when data processing is complete.
+1. Add support for running Great Expectations on a dataset by adding `gx_enabled: true` to the configuration for the datatset in both `test_config.yaml` and `config.yaml`. After updating the config files reports should be uploaded in the proper locations ([Prod](https://www.synapse.org/#!Synapse:syn52948668), [Testing](https://www.synapse.org/#!Synapse:syn52948670)) when data processing is complete.
+   - You can prevent Great Expectations from running for a dataset by removing the `gx_enabled: true` from the configuration for the dataset.
 1. Test data processing by running `adt test_config.yaml` and ensure that HTML reports with all expectations are generated and uploaded to the proper folder in Synapse.
 
 #### Custom Expectations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 ## Contributing
 
 We welcome all contributions!  That said, this is a Sage Bionetworks owned project, and we use JIRA ([AG](https://sagebionetworks.jira.com/jira/software/c/projects/AG/boards/91)/[IBCDPE](https://sagebionetworks.jira.com/jira/software/c/projects/IBCDPE/boards/189)) to track any bug/feature requests. This guide will be more focussed on a Sage Bio employee's development workflow.  If you are a Sage Bio employee, make sure to assign yourself the JIRA ticket if you decide to work on it.
@@ -71,9 +70,21 @@ The agora-data-tools project follows the standard [trunk based development](http
 
 1. Make sure to run the auto python code formatter, black.
 
-    ```shell
-    black ./
-    ```
+   ```shell
+   black ./
+   ```
+
+1. Test your changes by running `agora-data-tools` locally.
+
+```
+adt test_config.yaml
+```
+
+If your changes have to do with the way that files are uploaded to Synapse, create a new configuration file by copying `test_config.yaml` and changing the `destination` and `gx_folder` fields to testing locations that you own. The command will change to be:
+
+```
+adt my_dev_config.yaml --upload
+```
 
 1. Once you have completed all the steps above, create a pull request from the feature branch to the `dev` branch of the Sage-Bionetworks/agora-data-tools repo.
 

--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -25,7 +25,7 @@ class GreatExpectationsRunner:
         syn: Synapse,
         dataset_path: str,
         dataset_name: str,
-        upload_folder: str,
+        upload_folder: str = None,
         nested_columns: typing.List[str] = None,
     ):
         """Initialize the class"""
@@ -180,7 +180,9 @@ class GreatExpectationsRunner:
             f"Data validation complete for {self.expectation_suite_name}. Uploading results to Synapse."
         )
         latest_reults_path = self._get_results_path(checkpoint_result)
-        self._upload_results_file_to_synapse(latest_reults_path)
+
+        if self.upload_folder:
+            self._upload_results_file_to_synapse(latest_reults_path)
 
         if not checkpoint_result.success:
             fail_message = self.get_failed_expectations(checkpoint_result)

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -71,7 +71,7 @@ def process_dataset(
     gx_folder: str,
     syn: synapseclient.Synapse,
     upload: bool = True,
-) -> tuple:
+) -> None:
     """Takes in a dataset from the configuration file and passes it through the ETL process
 
     Args:
@@ -80,9 +80,6 @@ def process_dataset(
         gx_folder (str): Synapse ID of the folder where Great Expectations reports should be uploaded
         syn (synapseclient.Synapse): synapseclient.Synapse session.
         upload (bool, optional): Whether or not to upload the data to Synapse. Defaults to True.
-
-    Returns:
-        syn_obj (tuple): Tuple containing the id and version number of the uploaded file.
     """
 
     dataset_name = list(dataset_obj.keys())[0]
@@ -254,7 +251,7 @@ app = Typer()
 
 input_path_arg = Argument(..., help="Path to configuration file for processing run")
 
-platform_arg = Option(
+platform_opt = Option(
     "LOCAL",
     "--platform",
     "-p",
@@ -280,7 +277,7 @@ synapse_auth_opt = Option(
 @app.command()
 def process(
     config_path: str = input_path_arg,
-    platform: str = platform_arg,
+    platform: str = platform_opt,
     upload: bool = upload_opt,
     auth_token: str = synapse_auth_opt,
 ):

--- a/tests/test_gx.py
+++ b/tests/test_gx.py
@@ -276,3 +276,34 @@ class TestGreatExpectationsRunner:
                 patch_get_failed_expectations.assert_called_once_with(
                     patch_upload_results_file_to_synapse.return_value
                 )
+
+    def test_that_that_files_are_not_uploaded_when_upload_folder_is_none(
+        self,
+    ):
+        with patch.object(
+            self.good_runner, "_check_if_expectation_suite_exists", return_value=True
+        ), patch.object(
+            pd, "read_json", return_value=pd.DataFrame()
+        ) as patch_read_json, patch.object(
+            self.good_runner,
+            "convert_nested_columns_to_json",
+            return_value=pd.DataFrame(),
+        ) as patch_convert_nested_columns_to_json, patch.object(
+            self.good_runner, "_get_results_path", return_value="test_path"
+        ) as patch_get_results_path, patch.object(
+            self.good_runner, "_upload_results_file_to_synapse", return_value=None
+        ) as patch_upload_results_file_to_synapse, patch.object(
+            Checkpoint,
+            "run",
+            return_value=self.passed_checkpoint_result,
+        ) as patch_checkpoint_run, patch.object(
+            self.good_runner, "get_failed_expectations", return_value="test"
+        ) as patch_get_failed_expectations:
+            self.good_runner.upload_folder = None
+            self.good_runner.run()
+            patch_read_json.assert_called_once_with(self.good_runner.dataset_path)
+            patch_convert_nested_columns_to_json.assert_not_called()
+            patch_get_results_path.assert_called_once()
+            patch_upload_results_file_to_synapse.assert_not_called()
+            patch_checkpoint_run.assert_called_once()
+            patch_get_failed_expectations.assert_not_called()


### PR DESCRIPTION
**Problem:**

Every time the `agora-data-tools` processing pipeline is run, new output data files and GX report files are produced and uploaded to Synapse. This even happens when developers run the pipeline locally for testing. This causes an unnecessarily large number of files to be added to Synapse making it harder than it needs to be to find the output files from a particular run.

**Solution:**

Add an `upload` option to the CLI command and make it so that files are not uploaded by default. Additionally, add a `platform` argument to the CLI command so that the user can indicate whether their run is `LOCAL` or being executed on `GITHUB` or `NEXTFLOW` (Defaults to `LOCAL`).

The idea now is that when the pipeline is being run locally, it can be run exactly as before:
```
adt test_config.yaml
```
This command does not change at all because the default behavior is `platform = LOCAL` and `upload = False`

When we want file uploading to occur for testing purposes, we can make the following changes:
```
adt my_dev_config.yaml --upload
```
Note that I have provided a different configuration file this time. That is because in this instance I am a developer who needs to test the file uploading capabilities of the pipeline and I am providing a different configuration file with the `destination` and `gx_folder` fields pointing to a testing Synapse project that I have so that my test runs do not create new versions of the files in the Agora Synapse project.

Finally, for the Nextflow Tower execution, the command will look like (`nf-agora` [PR](https://github.com/Sage-Bionetworks-Workflows/nf-agora/pull/5)):
```
adt {config} --upload --platform NEXTFLOW
```
and the GitHub Action command is now (this PR):
```
adt test_config.yaml --upload --platform GITHUB --token ${{secrets.SYNAPSE_PAT}}
```

**Notes:**

- I considered using a `destination` argument where a developer could change the upload destination on Synapse without changing the configuration file, but this way is simpler to implement and sticks with our current paradigm where the configuration file dictates pipeline behavior.
- Right now, the `platform` argument is only used to throw a warning if you have `platform` set to `LOCAL` and `upload` is `True` to remind users to not upload files from a local run unnecessarily. This will be used more extensively in [IBCDPE-947](https://sagebionetworks.jira.com/browse/IBCDPE-947).
- Tests are updated/added as needed.
- Documentation is updated as needed.
- Apologies for the large formatting diff on `CONTRIBUTING.md`. The actual change I made is lines 78-88.

[IBCDPE-947]: https://sagebionetworks.jira.com/browse/IBCDPE-947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ