### PR TITLE
[IBCDPE-1066] Updates `gx_enabled` logic

### DIFF
--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -127,7 +127,7 @@ def process_dataset(
             filename=dataset_name + "." + dataset_obj[dataset_name]["final_format"],
         )
 
-    gx_enabled = "gx_enabled" in dataset_obj[dataset_name].keys()
+    gx_enabled = dataset_obj[dataset_name].get("gx_enabled", False)
 
     if gx_enabled:
         gx_runner = GreatExpectationsRunner(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -66,7 +66,17 @@ class TestProcessDataset:
         }
     }
 
-    def setup_method(self, syn):
+    dataset_object_gx_disabled = {
+        "neuropath_corr": {
+            "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
+            "final_format": "json",
+            "provenance": ["syn1111111"],
+            "destination": "syn1111113",
+            "gx_enabled": False,
+        }
+    }
+
+    def setup_method(self):
         self.patch_get_entity_as_df = patch.object(
             extract, "get_entity_as_df", return_value=pd.DataFrame
         ).start()
@@ -114,7 +124,7 @@ class TestProcessDataset:
         self.patch_format_link.stop()
         mock.patch.stopall()
 
-    def test_process_dataset_upload_false_gx_disabled(self, syn: Any):
+    def test_process_dataset_upload_false_gx_not_specified(self, syn: Any):
         process.process_dataset(
             dataset_obj=self.dataset_object,
             staging_path=STAGING_PATH,
@@ -142,7 +152,9 @@ class TestProcessDataset:
         self.patch_format_link.assert_not_called()
         self.patch_load.assert_not_called()
 
-    def test_process_dataset_upload_false_gx_disabled_column_rename(self, syn: Any):
+    def test_process_dataset_upload_false_gx_not_specified_column_rename(
+        self, syn: Any
+    ):
         process.process_dataset(
             dataset_obj=self.dataset_object_col_rename,
             staging_path=STAGING_PATH,
@@ -172,7 +184,7 @@ class TestProcessDataset:
         self.patch_format_link.assert_not_called()
         self.patch_load.assert_not_called()
 
-    def test_process_dataset_upload_false_gx_disabled_custom_transformations(
+    def test_process_dataset_upload_false_gx_not_specified_custom_transformations(
         self, syn: Any
     ):
         process.process_dataset(
@@ -214,7 +226,9 @@ class TestProcessDataset:
 
     # This test looks like a duplicate of test_process_dataset_upload_false_gx_disabled
     # but it uses the agora_rename configuration with the same util function
-    def test_process_dataset_upload_false_gx_disabled_with_agora_rename(self, syn: Any):
+    def test_process_dataset_upload_false_gx_not_specified_with_agora_rename(
+        self, syn: Any
+    ):
         process.process_dataset(
             dataset_obj=self.dataset_object_col_rename,
             staging_path=STAGING_PATH,
@@ -244,7 +258,7 @@ class TestProcessDataset:
         self.patch_format_link.assert_not_called()
         self.patch_load.assert_not_called()
 
-    def test_process_dataset_upload_false_gx_disabled_type_dict(self, syn: Any):
+    def test_process_dataset_upload_false_gx_not_specified_type_dict(self, syn: Any):
         self.patch_standardize_values.return_value = dict()
         process.process_dataset(
             dataset_obj=self.dataset_object,
@@ -275,7 +289,7 @@ class TestProcessDataset:
 
     def test_process_dataset_upload_true_gx_disabled(self, syn: Any):
         process.process_dataset(
-            dataset_obj=self.dataset_object,
+            dataset_obj=self.dataset_object_gx_disabled,
             staging_path=STAGING_PATH,
             gx_folder=GX_FOLDER,
             syn=syn,


### PR DESCRIPTION
**Problem:**

Because of the way that the GX logic was initially implemented (by me), you need to completely remove the `gx_enabled` key from the config section for a dataset to prevent GX from running, rather than just being able to set it to `false`.

**Solution:**

This PR updates this logic to check for the `gx_enabled` key and handle the case where it does not exist by defaulting to `false` in those instances. This way, it is OK for `gx_enabled` to not be present in a data source config, and the pipeline also appropriately reacts to `false` values by not running GX validation for that dataset.

**Testing:**

I ran the pipeline with `gx_enabled` set to `false` for the `gene_info` dataset and the GX validation was not run for that dataset (record [table](https://www.synapse.org/Synapse:syn60209988/tables/#query/eyJzcWwiOiJTRUxFQ1QgKiBGUk9NIHN5bjYwMjA5OTg4IiwgImluY2x1ZGVFbnRpdHlFdGFnIjp0cnVlLCAibGltaXQiOjI1LCAic29ydCI6W3siY29sdW1uIjoidGltZXN0YW1wIiwgImRpcmVjdGlvbiI6IkFTQyJ9XX0=)). Everything else was validated as expected.