### PR TITLE
[AG-1557] Fixes ModelAD `File size must be at least one byte` Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Perform the following one-time steps to set up your local environment and obtain
       pipenv shell
       ```
 
-6. You can check if the package was isntalled correctly by running `adt --help` in the terminal. If it returns instructions about how to use the CLI, installation was successful and you can run the pipeline by providing the desired [config file](#config) as an argument. The following example command will execute the pipeline using ```test_config.yaml```:
+6. You can check if the package was isntalled correctly by running `adt --help` in the terminal. If it returns instructions about how to use the CLI, installation was successful and you can run the pipeline by providing the desired [config file](#config) as an argument. Be sure to review these instructions prior to executing a processing run. The following example command will execute the pipeline using ```test_config.yaml```:
 
     ```bash
     adt test_config.yaml

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -301,7 +301,9 @@ def process_all_files(
 
 app = Typer()
 
-input_path_arg = Argument(..., help="Path to configuration file for processing run (Required).")
+input_path_arg = Argument(
+    ..., help="Path to configuration file for processing run (Required)."
+)
 
 platform_opt = Option(
     "LOCAL",

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -301,27 +301,30 @@ def process_all_files(
 
 app = Typer()
 
-input_path_arg = Argument(..., help="Path to configuration file for processing run")
+input_path_arg = Argument(..., help="Path to configuration file for processing run (Required).")
 
 platform_opt = Option(
     "LOCAL",
     "--platform",
     "-p",
-    help="Platform that is running the process. Must be one of LOCAL, GITHUB, or NEXTFLOW.",
+    help="Platform that is running the process. Must be one of LOCAL, GITHUB, or NEXTFLOW (Optional).",
     show_default=True,
 )
 run_id_opt = Option(
     None,
     "--run_id",
     "-r",
-    help="Run ID of the process.",
+    help="Run ID of the process. This is used to identify the run in the GX table. (Optional)",
     show_default=True,
 )
 upload_opt = Option(
     False,
     "--upload",
     "-u",
-    help="Toggles whether or not files will be uploaded to Synapse.",
+    help="Toggles whether or not files will be uploaded to Synapse. The absence of this option means "
+    "that neither output data files nor GX reports will be uploaded to Synapse. Setting "
+    "`--upload` in the command will cause both to be uploaded. This option is used to control "
+    "the upload behavior of the process.",
     show_default=True,
 )
 synapse_auth_opt = Option(

--- a/src/agoradatatools/reporter.py
+++ b/src/agoradatatools/reporter.py
@@ -119,9 +119,8 @@ class ADTGXReporter:
 
     def update_table(self) -> None:
         """Updates the Synapse table adding one new row for each DatasetReport object if the platform is not LOCAL."""
-        if self.platform != Platform.LOCAL:
+        if self.platform != Platform.LOCAL and self.reports:
             self._update_reports_before_upload()
-
             self.syn.store(
                 synapseclient.Table(
                     self.table_id,

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -71,10 +71,11 @@ class TestADTGXReporter:
         mock_datetime.datetime.now.return_value.strftime.assert_called_once()
         assert self.test_reporter.reports[0] == self.upload_report
 
-    def test_update_table(self, syn):
+    def test_update_table_platform_not_local_and_reports_not_empty(self, syn):
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
+            self.test_reporter.reports = [self.test_report]
             self.test_reporter.update_table()
 
             mock_store.assert_called_once()
@@ -85,6 +86,15 @@ class TestADTGXReporter:
             self.test_reporter_local, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
             self.test_reporter_local.update_table()
+
+            mock_store.assert_not_called()
+            mock_update_reports_before_upload.assert_not_called()
+
+    def test_update_table_platform_not_local_and_reports_empty(self, syn):
+        with patch.object(syn, "store") as mock_store, patch.object(
+            self.test_reporter, "_update_reports_before_upload"
+        ) as mock_update_reports_before_upload:
+            self.test_reporter.update_table()
 
             mock_store.assert_not_called()
             mock_update_reports_before_upload.assert_not_called()


### PR DESCRIPTION
**Problem:**
With recent changes made in ADT adding support for ModelAD data processing, we encountered an [error](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/agora-project/watch/26w3vkx1g3KsQr) in processing when using the `platform` flag. This is caused because despite the fact that there is no GX data validation to run for ModelAD at the moment, the [ADTGXReporter](https://github.com/Sage-Bionetworks/agora-data-tools/blob/7f8eda19ecd249d61959434ef611d5c1c291174a/src/agoradatatools/reporter.py#L73) was still trying to update the GX report table. This caused an empty list of records to be passed to `syn.store` [here](https://github.com/Sage-Bionetworks/agora-data-tools/blob/7f8eda19ecd249d61959434ef611d5c1c291174a/src/agoradatatools/reporter.py#L124), causing the reported error.

**Solution:**
I added an additional condition to `ADTGXReporter.update_table` so that the update attempt is not made if there are no new records to update in the first place.

**Notes:**
- I added a new unit test to cover the new condition
- I went ahead and updated the descriptions for the CLI arguments and options to clarify how to use them and updated the README to tell users to use the `adt --help` command to learn how to use the package.