### PR TITLE
[IBCDPE-1171] Update CI to publish `latest` Docker Container On push to `dev`

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,7 +4,7 @@ name: CI
 
 on:
   push:
-    branches: ["dev"]
+    branches: ["dev", "bwmac/CI-update-dev-publish"]
     # Match tags that resemble a version
     tags: ['[0-9]+\.[0-9]+\.[0-9]+']
   pull_request:
@@ -72,7 +72,7 @@ jobs:
 
   ghcr-publish:
     needs: [build, test]
-    if: ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
+    if: ${{ github.event_name == 'push' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -4,7 +4,7 @@ name: CI
 
 on:
   push:
-    branches: ["dev", "bwmac/CI-update-dev-publish"]
+    branches: ["dev"]
     # Match tags that resemble a version
     tags: ['[0-9]+\.[0-9]+\.[0-9]+']
   pull_request:


### PR DESCRIPTION
To make sure that our Nextflow runs that use the `latest` tagged docker image from this repo are always up-to-date, we should automatically publish a new container with the `latest` tag whenever code is merged into `dev`. Containers will still be published and tagged when releases are made too, and we will still be able to run specific versions of ADT as well if needed.