### PR TITLE
[AG-1621] Adds `dataversion` Uploading & [AG-543] Fixes Manifest Version Bug

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,7 @@ destination: &dest syn12177492
 staging_path: ./staging
 gx_folder: syn52948668
 gx_table: syn60527066
+team_images_id: syn12861877
 sources:
   - genes_biodomains:
     genes_biodomains_files: &genes_biodomains_files

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -227,9 +227,9 @@ def process_dataset(
 
 
 def create_data_manifest(
-    syn: synapseclient.Synapse, parent: synapseclient.Folder = None
+    syn: synapseclient.Synapse, parent: Union[synapseclient.Folder, str] = None
 ) -> Union[DataFrame, None]:
-    """Creates data manifest (dataframe) that has the IDs and version numbers of child synapse folders
+    """Creates data manifest (dataframe) that has the IDs and version numbers of child synapse files
 
     Args:
         syn (synapseclient.Synapse): Synapse client session.
@@ -242,13 +242,21 @@ def create_data_manifest(
     if not parent:
         return None
 
-    folders = syn.getChildren(parent)
+    files = syn.getChildren(parent)
 
-    folder = [
-        {"id": folder["id"], "version": folder["versionNumber"]} for folder in folders
+    manifest_rows = [
+        {
+            "id": file["id"],
+            "version": (
+                file["versionNumber"]
+                if file["name"] != "data_manifest.csv"
+                else file["versionNumber"] + 1
+            ),
+        }
+        for file in files
     ]
 
-    return DataFrame(folder)
+    return DataFrame(manifest_rows)
 
 
 @log_time(func_name="process_all_files", logger=logger)

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Union
+from typing import Optional, Union
 
 import synapseclient
 from pandas import DataFrame
@@ -73,25 +73,28 @@ def upload_dataversion_metadata(
     syn: synapseclient.Synapse,
     file_id: str,
     file_version: str,
-    team_images_id: str,
     staging_path: str,
     destination: str,
+    team_images_id: Optional[str] = None,
 ) -> None:
-    """Uploads dataversion.json file to Synapse with metadata about the manifest file
+    """Uploads dataversion.json file to Synapse with metadata about the manifest file.
+    Model-AD runs do not have a team_images_id, which will be left out of the dataversion.json file.
 
     Args:
         syn (synapseclient.Synapse): Synapse client session
         file_id (str): Synapse ID of the manifest file
         file_version (str): Version number of the manifest file
-        team_images_id (str): Synapse ID of the team_images folder
         staging_path (str): Path to the staging directory
         destination (str): Synapse ID of the destination folder
+        team_images_id (str, optional): Synapse ID of the team_images folder if provided. Defaults to None.
     """
     dataversion_dict = {
         "data_file": file_id,
         "data_version": file_version,
-        "team_images_id": team_images_id,
     }
+    if team_images_id:
+        dataversion_dict["team_images_id"] = team_images_id
+
     dataversion_json_path = load.dict_to_json(
         df=dataversion_dict, staging_path=staging_path, filename="dataversion.json"
     )
@@ -340,7 +343,7 @@ def process_all_files(
             syn=syn,
             file_id=file_id,
             file_version=file_version,
-            team_images_id=config["team_images_id"],
+            team_images_id=config.get("team_images_id", None),
             staging_path=staging_path,
             destination=destination,
         )

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -248,9 +248,9 @@ def create_data_manifest(
         {
             "id": file["id"],
             "version": (
-                file["versionNumber"]
-                if file["name"] != "data_manifest.csv"
-                else file["versionNumber"] + 1
+                file["versionNumber"] + 1
+                if file["name"] == "data_manifest.csv"
+                else file["versionNumber"]
             ),
         }
         for file in files

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -69,6 +69,40 @@ def apply_custom_transformations(
         return None
 
 
+def upload_dataversion_metadata(
+    syn: synapseclient.Synapse,
+    file_id: str,
+    file_version: str,
+    team_images_id: str,
+    staging_path: str,
+    destination: str,
+) -> None:
+    """Uploads dataversion.json file to Synapse with metadata about the manifest file
+
+    Args:
+        syn (synapseclient.Synapse): Synapse client session
+        file_id (str): Synapse ID of the manifest file
+        file_version (str): Version number of the manifest file
+        team_images_id (str): Synapse ID of the team_images folder
+        staging_path (str): Path to the staging directory
+        destination (str): Synapse ID of the destination folder
+    """
+    dataversion_dict = {
+        "data_file": file_id,
+        "data_version": file_version,
+        "team_images_id": team_images_id,
+    }
+    dataversion_json_path = load.dict_to_json(
+        df=dataversion_dict, staging_path=staging_path, filename="dataversion.json"
+    )
+    load.load(
+        file_path=dataversion_json_path,
+        provenance=[file_id],
+        destination=destination,
+        syn=syn,
+    )
+
+
 @log_time(func_name="process_dataset", logger=logger)
 def process_dataset(
     dataset_obj: dict,
@@ -209,6 +243,7 @@ def create_data_manifest(
         return None
 
     folders = syn.getChildren(parent)
+
     folder = [
         {"id": folder["id"], "version": folder["versionNumber"]} for folder in folders
     ]
@@ -292,6 +327,16 @@ def process_all_files(
             destination=destination,
             syn=syn,
         )
+
+        upload_dataversion_metadata(
+            syn=syn,
+            file_id=file_id,
+            file_version=file_version,
+            team_images_id=config["team_images_id"],
+            staging_path=staging_path,
+            destination=destination,
+        )
+
         reporter.data_manifest_file = file_id
         reporter.data_manifest_version = file_version
         reporter.data_manifest_link = DatasetReport.format_link(

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -2,6 +2,7 @@ destination: &dest syn17015333
 staging_path: ./staging
 gx_folder: syn52948670
 gx_table: syn60527065
+team_images_id: syn12861877
 sources:
   - genes_biodomains:
     genes_biodomains_files: &genes_biodomains_files

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -16,6 +16,47 @@ STAGING_PATH = "./staging"
 GX_FOLDER = "test_folder"
 
 
+class TestUploadDataversionMetadata:
+    file_id = "syn1111111"
+    file_version = "1"
+    team_images_id = "syn12861877"
+    destination = "syn1111113"
+    dataversion_dict = {
+        "data_file": file_id,
+        "data_version": file_version,
+        "team_images_id": team_images_id,
+    }
+
+    def test_upload_dataversion_metadata(self, syn: Any):
+        with patch.object(
+            load, "dict_to_json", return_value="path/to/json"
+        ) as patch_dict_to_json, patch.object(
+            load, "load", return_value=("syn123", 1)
+        ) as patch_load:
+            # WHEN I call upload_dataversion_metadata with the correct arguments
+            process.upload_dataversion_metadata(
+                syn=syn,
+                file_id=self.file_id,
+                file_version=self.file_version,
+                team_images_id=self.team_images_id,
+                staging_path=STAGING_PATH,
+                destination=self.destination,
+            )
+            # THEN I expect the dict_to_json function to be called with the correct arguments
+            patch_dict_to_json.assert_called_once_with(
+                df=self.dataversion_dict,
+                staging_path=STAGING_PATH,
+                filename="dataversion.json",
+            )
+            # AND I expect the load function to be called with the correct arguments
+            patch_load.assert_called_once_with(
+                file_path="path/to/json",
+                provenance=[self.file_id],
+                destination=self.destination,
+                syn=syn,
+            )
+
+
 class TestProcessDataset:
     dataset_object = {
         "neuropath_corr": {

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -5,12 +5,15 @@ from unittest.mock import patch
 import pandas as pd
 import pytest
 
+from synapseclient import File
+
 from agoradatatools import process
 from agoradatatools.errors import ADTDataProcessingError
 from agoradatatools.etl import load, utils, extract
 from agoradatatools.reporter import DatasetReport, ADTGXReporter
 from agoradatatools.constants import Platform
 from agoradatatools.gx import GreatExpectationsRunner
+
 
 STAGING_PATH = "./staging"
 GX_FOLDER = "test_folder"
@@ -424,27 +427,40 @@ class TestProcessDataset:
 
 
 class TestCreateDataManifest:
+    files = [
+        File(id="syn123", name="not_a_manifest", versionNumber=1),
+        File(id="syn456", name="data_manifest.csv", versionNumber=1),
+    ]
+    manifest_rows = [
+        {"id": "syn123", "version": 1},
+        {"id": "syn456", "version": 2},
+    ]
+
     @pytest.fixture(scope="function", autouse=True)
     def setup_method(self, syn: Any):
-        self.patch_syn_login = patch.object(
-            utils, "_login_to_synapse", return_value=syn
-        ).start()
         self.patch_get_children = patch.object(
-            syn, "getChildren", return_value=[{"id": "123", "versionNumber": 1}]
+            syn, "getChildren", return_value=self.files
         ).start()
 
     def teardown_method(self):
         mock.patch.stopall()
 
     def test_create_data_manifest_parent_none(self, syn: Any):
-        assert process.create_data_manifest(syn=syn, parent=None) is None
-        self.patch_syn_login.assert_not_called()
+        # WHEN I call create_data_manifest with a parent of None
+        result = process.create_data_manifest(syn=syn, parent=None)
+        # THEN I expect the result to be None
+        assert result is None
+        # AND I expect the getChildren method to not be called
+        self.patch_get_children.assert_not_called()
 
-    def test_create_data_manifest_no_none(self, syn: Any):
-        df = process.create_data_manifest(syn=syn, parent="syn1111111")
+    def test_create_data_manifest_with_parent(self, syn: Any):
+        # WHEN I call create_data_manifest with a parent
+        result_df = process.create_data_manifest(syn=syn, parent="syn1111111")
+        # THEN I expect the getChildren method to be called with the parent
         self.patch_get_children.assert_called_once_with("syn1111111")
-        self.patch_syn_login.assert_not_called()
-        assert isinstance(df, pd.DataFrame)
+        # AND I expect the result to be a dataframe with the correct rows
+        # Including incrementing the version number for the data_manifest.csv file
+        pd.testing.assert_frame_equal(result_df, pd.DataFrame(self.manifest_rows))
 
 
 class TestProcessAllFiles:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -24,40 +24,70 @@ class TestUploadDataversionMetadata:
     file_version = "1"
     team_images_id = "syn12861877"
     destination = "syn1111113"
-    dataversion_dict = {
+    dataversion_dict_with_team_images_id = {
         "data_file": file_id,
         "data_version": file_version,
         "team_images_id": team_images_id,
     }
+    dataversion_dict_without_team_images_id = {
+        "data_file": file_id,
+        "data_version": file_version,
+    }
 
-    def test_upload_dataversion_metadata(self, syn: Any):
-        with patch.object(
+    @pytest.fixture(scope="function", autouse=True)
+    def setup_method(self):
+        self.patch_dict_to_json = patch.object(
             load, "dict_to_json", return_value="path/to/json"
-        ) as patch_dict_to_json, patch.object(
-            load, "load", return_value=("syn123", 1)
-        ) as patch_load:
-            # WHEN I call upload_dataversion_metadata with the correct arguments
-            process.upload_dataversion_metadata(
-                syn=syn,
-                file_id=self.file_id,
-                file_version=self.file_version,
-                team_images_id=self.team_images_id,
-                staging_path=STAGING_PATH,
-                destination=self.destination,
-            )
-            # THEN I expect the dict_to_json function to be called with the correct arguments
-            patch_dict_to_json.assert_called_once_with(
-                df=self.dataversion_dict,
-                staging_path=STAGING_PATH,
-                filename="dataversion.json",
-            )
-            # AND I expect the load function to be called with the correct arguments
-            patch_load.assert_called_once_with(
-                file_path="path/to/json",
-                provenance=[self.file_id],
-                destination=self.destination,
-                syn=syn,
-            )
+        ).start()
+        self.patch_load = patch.object(load, "load", return_value=("syn123", 1)).start()
+
+    def test_upload_dataversion_metadata_with_team_images_id(self, syn: Any):
+        # WHEN I call upload_dataversion_metadata with a team_images_id
+        process.upload_dataversion_metadata(
+            syn=syn,
+            file_id=self.file_id,
+            file_version=self.file_version,
+            team_images_id=self.team_images_id,
+            staging_path=STAGING_PATH,
+            destination=self.destination,
+        )
+        # THEN I expect the dict_to_json function to be called with the correct arguments
+        self.patch_dict_to_json.assert_called_once_with(
+            df=self.dataversion_dict_with_team_images_id,
+            staging_path=STAGING_PATH,
+            filename="dataversion.json",
+        )
+        # AND I expect the load function to be called with the correct arguments
+        self.patch_load.assert_called_once_with(
+            file_path="path/to/json",
+            provenance=[self.file_id],
+            destination=self.destination,
+            syn=syn,
+        )
+
+    def test_upload_dataversion_metadata_without_team_images_id(self, syn: Any):
+        # WHEN I call upload_dataversion_metadata without a team_images_id
+        process.upload_dataversion_metadata(
+            syn=syn,
+            file_id=self.file_id,
+            file_version=self.file_version,
+            staging_path=STAGING_PATH,
+            destination=self.destination,
+            team_images_id=None,
+        )
+        # THEN I expect the dict_to_json function to be called with the correct arguments
+        self.patch_dict_to_json.assert_called_once_with(
+            df=self.dataversion_dict_without_team_images_id,
+            staging_path=STAGING_PATH,
+            filename="dataversion.json",
+        )
+        # AND I expect the load function to be called with the correct arguments
+        self.patch_load.assert_called_once_with(
+            file_path="path/to/json",
+            provenance=[self.file_id],
+            destination=self.destination,
+            syn=syn,
+        )
 
 
 class TestProcessDataset:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -471,6 +471,7 @@ class TestProcessAllFiles:
                 "gx_folder": GX_FOLDER,
                 "gx_table": "syn321",
                 "staging_path": STAGING_PATH,
+                "team_images_id": "syn987",
                 "datasets": [{"a": {"b": "c"}}, {"d": {"e": "f"}}, {"g": {"h": "i"}}],
             },
         ).start()
@@ -496,6 +497,9 @@ class TestProcessAllFiles:
             load, "df_to_csv", return_value="path/to/csv"
         ).start()
         self.patch_load = patch.object(load, "load", return_value=("syn123", 1)).start()
+        self.patch_upload_dataversion_metadata = patch.object(
+            process, "upload_dataversion_metadata", return_value=None
+        ).start()
         self.patch_update_table = patch.object(
             ADTGXReporter,
             "update_table",
@@ -546,6 +550,7 @@ class TestProcessAllFiles:
             staging_path=STAGING_PATH,
             filename="data_manifest.csv",
         )
+        self.patch_upload_dataversion_metadata.assert_not_called()
         self.patch_load.assert_not_called()
         self.patch_format_link.assert_not_called()
         self.patch_update_table.assert_called_once()
@@ -591,6 +596,14 @@ class TestProcessAllFiles:
             df=self.patch_create_data_manifest.return_value,
             staging_path=STAGING_PATH,
             filename="data_manifest.csv",
+        )
+        self.patch_upload_dataversion_metadata.assert_called_once_with(
+            syn=syn,
+            file_id="syn123",
+            file_version=1,
+            team_images_id="syn987",
+            staging_path=STAGING_PATH,
+            destination="destination",
         )
         self.patch_load.assert_called_once_with(
             file_path="path/to/csv",
@@ -644,6 +657,7 @@ class TestProcessAllFiles:
             )
             self.patch_create_data_manifest.assert_not_called()
             self.patch_df_to_csv.assert_not_called()
+            self.patch_upload_dataversion_metadata.assert_not_called()
             self.patch_load.assert_not_called()
             self.patch_format_link.assert_not_called()
             self.patch_update_table.assert_called_once()
@@ -688,6 +702,7 @@ class TestProcessAllFiles:
             )
             self.patch_create_data_manifest.assert_not_called()
             self.patch_df_to_csv.assert_not_called()
+            self.patch_upload_dataversion_metadata.assert_not_called()
             self.patch_load.assert_not_called()
             self.patch_format_link.assert_not_called()
             self.patch_update_table.assert_called_once()


### PR DESCRIPTION
**[AG-1621]**

This PR adds a new `upload_dataversion_metadata` function to `process.py` which grabs the appropriate metadata for tracking the manifest version and team image location before creating the JSON structure described in the ticket and uploading it along with the other ADT datasets to Synapse. If the `upload` flag is enabled, this new function will be called right after the manifest is created and uploaded.

I added `team_images_id` to the config files for regular ADT runs so it wouldn't be hard-coded in the `process.py` script. If it is not provided, this field will not be present in the `dataversion.json` output file (I.e. for Model-AD runs). See comment thread [below](https://github.com/Sage-Bionetworks/agora-data-tools/pull/168#discussion_r1936158642) for discussion about this.

You can view the `dataversion.json` file generated in the test run [here](https://www.synapse.org/Synapse:syn64713183).

All relevant tests have been added/updated.

**[AG-543]**

Previously, the manifest file included a version for itself which was always 1 behind the newly uploaded version because the data for the manifest has to be generated before the upload (and therefore the new version is created). I patched this by incrementing the version for that file within `create_data_manifest`. I also cleaned up the function and docstring while I was at it.

See the testing manifest file [here](https://www.synapse.org/Synapse:syn17015333). You can see that the version in the file itself matches the most recent version number now.

All relevant tests have been added/updated.

[AG-1621]: https://sagebionetworks.jira.com/browse/AG-1621?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AG-543]: https://sagebionetworks.jira.com/browse/AG-543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ