### PR TITLE
[AG-1726] Display more detail in error messages

### DIFF
--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -317,7 +317,10 @@ def process_all_files(
                     raise ADTDataValidationError(dataset_report.gx_failure_message)
         except Exception as e:
             import traceback
-            error_message = f"{list(dataset.keys())[0]}:\n {str(e)}\n{traceback.format_exc()}"
+
+            error_message = (
+                f"{list(dataset.keys())[0]}:\n {str(e)}\n{traceback.format_exc()}"
+            )
             error_list.append(error_message)
 
     if error_list:

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -316,7 +316,9 @@ def process_all_files(
                 if dataset_report.gx_failures:
                     raise ADTDataValidationError(dataset_report.gx_failure_message)
         except Exception as e:
-            error_list.append(f"{list(dataset.keys())[0]}: " + str(e).replace("\n", ""))
+            import traceback
+            error_message = f"{list(dataset.keys())[0]}:\n {str(e)}\n{traceback.format_exc()}"
+            error_list.append(error_message)
 
     if error_list:
         reporter.update_table()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -663,7 +663,7 @@ class TestProcessAllFiles:
     def test_process_all_files_upload_false_gx_failure(self, syn: Any):
         with pytest.raises(
             ADTDataProcessingError,
-            match="\nData Processing has failed for one or more data sources. Refer to the list of errors below to address issues:\na: test_message\nd: test_message\ng: test_message",
+            match="\nData Processing has failed for one or more data sources. Refer to the list of errors below to address issues:",
         ):
             self.patch_process_dataset.return_value.gx_failures = True
             process.process_all_files(


### PR DESCRIPTION
# **Problem:**

The ADT pipeline uses a `try`/`except` block to process each dataset in a loop. This allows us to catch all errors that occur in a full run rather than stopping once the first is encountered. Previously, we have only captured the basic error message which lacks detail around what caused the error.

Example:
```
agoradatatools.errors.ADTDataProcessingError: 
Data Processing has failed for one or more data sources. Refer to the list of errors below to address issues:
rna_distribution_data: name 'blah' is not defined
proteomics_distribution_data: name 'blah' is not defined
```

# **Solution:**

With a small change, we can capture the full stack trace an addition to the simple error message and display them both in the terminal when errors are encountered.

Example:
```
agoradatatools.errors.ADTDataProcessingError: 
Data Processing has failed for one or more data sources. Refer to the list of errors below to address issues:
rna_distribution_data:
 name 'blah' is not defined
Traceback (most recent call last):
  File "/Users/bmacdonald/Development/repos/agora-data-tools/src/agoradatatools/process.py", line 317, in process_all_files
    blah
NameError: name 'blah' is not defined

proteomics_distribution_data:
 name 'blah' is not defined
Traceback (most recent call last):
  File "/Users/bmacdonald/Development/repos/agora-data-tools/src/agoradatatools/process.py", line 317, in process_all_files
    blah
NameError: name 'blah' is not defined
```

# **Testing:**

I adjusted one unit test to allow for the flexibility of capturing the full stack trace when reporting out errors.
