### PR TITLE
Bumps GH Runner Version

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   # test job includes unit tests and coverage
   pre-commit:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with: { fetch-depth: 0 } # deep clone for setuptools-scm


### PR DESCRIPTION
Our CI pipeline is pretty brittle at the moment due to the [planned deprecation of the Ubuntu 20.04 GH runner](https://github.com/actions/runner-images/issues/11101). We should bump up this runner version so our CI pipeline can run consistently.