### PR TITLE
[AG-1092] change apply_custom_transformations method to be config driven 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,7 @@ This package has a `src/agoradatatools/etl/transform` submodule. This folder hou
 
 1. Create new script in the transform submodule that matches the dataset name and name the function `transform_...`. For example, if you have a dataset named `genome_variants`, your new script would be `src/agoradatatools/etl/transform/transform_genome_variants.py`.
 1. Register the new transform function in `src/agoradatatools/etl/transform/__init__.py`. Look in that file for examples.
-1. Add your transform function in `test_config.yaml`. As an example, the block here means that `transform_team_info` function will be applied to team_info dataset:
+1. Add your transform function in `test_config.yaml` and `config.yaml`. As an example, the block here means that `transform_team_info` function will be applied to team_info dataset:
 ```
   - team_info:
       files:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,7 +165,16 @@ This package has a `src/agoradatatools/etl/transform` submodule. This folder hou
 
 1. Create new script in the transform submodule that matches the dataset name and name the function `transform_...`. For example, if you have a dataset named `genome_variants`, your new script would be `src/agoradatatools/etl/transform/transform_genome_variants.py`.
 1. Register the new transform function in `src/agoradatatools/etl/transform/__init__.py`. Look in that file for examples.
-1. Modify the `apply_custom_transformations` in `src/agoradatatools/process.py` to include your new transform.
+1. Add your transform function in `test_config.yaml`. As an example, the block here means that `transform_team_info` function will be applied to team_info dataset:
+```
+  - team_info:
+      files:
+        - name: team_member_info
+          id: syn12615633.20
+          format: csv
+      final_format: json
+      custom_transformations: transform_team_info
+```
 1. Write a test for the transform:
    - For transform tests, we are using a [Data-Driven Testing](https://www.develer.com/en/blog/data-driven-testing-with-python/) strategy
    - To contribute new tests, assets in the form of input and output data files are needed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,8 @@ This package has a `src/agoradatatools/etl/transform` submodule. This folder hou
       final_format: json
       custom_transformations: transform_team_info
 ```
+Note: **Only one custom transform per dataset is supported at this time**
+
 1. Write a test for the transform:
    - For transform tests, we are using a [Data-Driven Testing](https://www.develer.com/en/blog/data-driven-testing-with-python/) strategy
    - To contribute new tests, assets in the form of input and output data files are needed.

--- a/config.yaml
+++ b/config.yaml
@@ -50,7 +50,7 @@ datasets:
   - biodomain_info:
       files: *genes_biodomains_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_biodomain_info
       provenance: *genes_biodomains_provenance
       column_rename:
         biodomain: name
@@ -60,7 +60,7 @@ datasets:
   - genes_biodomains:
       files: *genes_biodomains_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_genes_biodomains
       provenance: *genes_biodomains_provenance
       column_rename:
         ensembl_id: ensembl_gene_id
@@ -90,7 +90,7 @@ datasets:
   - proteomics:
       files: *agora_proteomics_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_proteomics
       provenance: *agora_proteomics_provenance
       column_rename:
         genename: hgnc_symbol
@@ -101,7 +101,7 @@ datasets:
   - proteomics_tmt:
       files: *agora_proteomics_tmt_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_proteomics
       provenance: *agora_proteomics_tmt_provenance
       column_rename:
         genename: hgnc_symbol
@@ -112,7 +112,7 @@ datasets:
   - proteomics_srm:
       files: *agora_proteomics_srm_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_proteomics
       provenance: *agora_proteomics_srm_provenance
       column_rename:
         genename: hgnc_symbol
@@ -175,8 +175,9 @@ datasets:
           format: csv
       final_format: json
       custom_transformations:
-        adjusted_p_value_threshold: 0.05
-        protein_level_threshold: 0.05
+        transform_gene_info:
+          adjusted_p_value_threshold: 0.05
+          protein_level_threshold: 0.05
       column_rename:
         ensg: ensembl_gene_id
         ensembl_id: ensembl_gene_id
@@ -225,7 +226,7 @@ datasets:
           id: syn12615633.20
           format: csv
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_team_info
       provenance:
         - syn12615624.18
         - syn12615633.20
@@ -237,7 +238,7 @@ datasets:
   - overall_scores:
       files: *overall_scores_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_overall_scores
       column_rename:
         genename: hgnc_gene_id
       provenance: *overall_scores_provenance
@@ -271,7 +272,7 @@ datasets:
   - rnaseq_differential_expression:
       files: *rna_diff_expr_data_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_rnaseq_differential_expression
       provenance: *rna_diff_expr_data_provenance
       destination: *dest
       gx_enabled: true
@@ -280,9 +281,10 @@ datasets:
       files: *overall_scores_files
       final_format: json
       custom_transformations:
-        overall_max_score: 5
-        genetics_max_score: 3
-        omics_max_score: 2
+        transform_distribution_data:
+            overall_max_score: 5
+            genetics_max_score: 3
+            omics_max_score: 2
       provenance: *overall_scores_provenance
       column_rename:
         overall: target_risk_score
@@ -298,7 +300,7 @@ datasets:
   - rna_distribution_data:
       files: *rna_diff_expr_data_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_rna_distribution_data
       provenance: *rna_diff_expr_data_provenance
       destination: *dest
       gx_enabled: true
@@ -309,7 +311,7 @@ datasets:
         - <<: *agora_proteomics_tmt_files
         - <<: *agora_proteomics_srm_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_proteomics_distribution_data
       provenance:
         - *agora_proteomics_provenance
         - *agora_proteomics_tmt_provenance

--- a/modelad_test_config.yaml
+++ b/modelad_test_config.yaml
@@ -12,7 +12,7 @@ datasets:
       provenance:
         - syn61250724
       destination: *dest
-      custom_transformations: 1
+      custom_transformations: immunohisto_transform
       column_rename:
         agedeath: age_death
       gx_enabled: true
@@ -28,7 +28,7 @@ datasets:
       provenance:
         - syn61357279
       destination: *dest
-      custom_transformations: 1
+      custom_transformations: immunohisto_transform
       column_rename:
         agedeath: age_death
       gx_enabled: true
@@ -60,7 +60,7 @@ datasets:
         - syn61250724
         - syn64846805
       destination: *dest
-      custom_transformations: 1
+      custom_transformations: transform_model_details
       column_rename:
         gene_symbol: gene
         ensembl_id: human_ensembl_id

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Dict, Any
 
 import numpy as np
 import pandas as pd
@@ -24,7 +24,7 @@ def _login_to_synapse(token: str = None) -> synapseclient.Synapse:
     return syn
 
 
-def _get_config(config_path: str = None) -> dict:
+def _get_config(config_path: str = None) -> Dict[str, Dict[str, Dict[str, Any]]]:
     """Takes config_path and opens yaml file path points to, loads configuration from file.
     If no config_path is supplied, defaults to "./config.yaml"
 

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -24,7 +24,9 @@ def _login_to_synapse(token: str = None) -> synapseclient.Synapse:
     return syn
 
 
-def _get_config(config_path: str = None) -> Dict[str, Dict[str, Dict[str, Any]]]:
+def _get_config(
+    config_path: str = None,
+) -> Dict[str, Any]:
     """Takes config_path and opens yaml file path points to, loads configuration from file.
     If no config_path is supplied, defaults to "./config.yaml"
 

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -24,7 +24,7 @@ def _login_to_synapse(token: str = None) -> synapseclient.Synapse:
     return syn
 
 
-def _get_config(config_path: str = None) -> list:
+def _get_config(config_path: str = None) -> dict:
     """Takes config_path and opens yaml file path points to, loads configuration from file.
     If no config_path is supplied, defaults to "./config.yaml"
 
@@ -32,7 +32,7 @@ def _get_config(config_path: str = None) -> list:
         config_path (str, optional): Path to config file. Defaults to None.
 
     Returns:
-        list: list of dictionaries containing configuration information for run.
+        dict: Dictionary containing configuration from yaml file
     """
     if config_path is None:
         config_path = "./config.yaml"
@@ -53,7 +53,10 @@ def _get_config(config_path: str = None) -> list:
         raise yaml.scanner.ScannerError(
             "YAML file unable to be scanned.  Please provide a valid YAML file."
         )
-
+    if not isinstance(config, dict):
+        raise ValueError(
+            "YAML file must be loaded as a single dictionary.  Please reformat your YAML file correctly."
+        )
     return config
 
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -53,7 +53,7 @@ def apply_custom_transformations(
         retrieved_function = getattr(transform, function_name)
     sig = inspect.signature(retrieved_function)
     key_word_parameters = {}
-    # Map known inputs like 'df' or 'datasets' to the expected parameters
+    # Map known inputs
     for name, _ in sig.parameters.items():
         if name == "df":
             df = datasets[dataset_name]

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -43,23 +43,18 @@ def apply_custom_transformations(
             )
         return None
     if isinstance(function_info, str):
-        try:
-            retrieved_function = getattr(transform, function_info)
-        except AttributeError:
-            raise AttributeError(
-                f"Function {function_info} not found in the transform module. Please provide the correct function name."
-            )
+        function_name = function_info
         config_defined_params = {}
     else:
         # Retrieve the function name and its parameters
         # Assumes a single function in the dict
         function_name, config_defined_params = next(iter(function_info.items()))
-        try:
-            retrieved_function = getattr(transform, function_name)
-        except AttributeError:
-            raise AttributeError(
-                f"Function {function_name} not found in the transform module. Please provide the correct function name."
-            )
+    try:
+        retrieved_function = getattr(transform, function_name)
+    except AttributeError:
+        raise AttributeError(
+            f"Function {function_name} not found in the transform module. Please provide the correct function name."
+        )
     sig = inspect.signature(retrieved_function)
     parameters = {}
     # Map known inputs

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Optional, Union
+from typing import Optional, Union, Dict, Any
 import inspect
 import synapseclient
 from pandas import DataFrame
@@ -17,9 +17,9 @@ logger = logging.getLogger(__name__)
 
 
 def apply_custom_transformations(
-    datasets: dict,
+    datasets: Dict[str, Any],
     dataset_name: str,
-    dataset_obj: dict,
+    dataset_obj: Dict[str, Any],
 ) -> Union[DataFrame, dict, None]:
     """Apply custom transformations to the dataset based on the provided function names and parameters.
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -48,7 +48,12 @@ def apply_custom_transformations(
         config_defined_params = {}
     else:
         # Retrieve the function name and its parameters
-        # Assumes a single function in the dict
+        # Assumes a single function in the dictionary
+        if not isinstance(function_info, dict):
+            raise TypeError(
+                f"Custom transformation in the config for dataset '{dataset_name}' should be mapped to a function name "
+                f"with custom parameters if needed. Received: {type(function_info).__name__}."
+            )
         if len(function_info.items()) != 1:
             warnings.warn(
                 "Please provide a single custom transformation function in the configuration file. Only the first function will be used if multiple are provided."
@@ -67,7 +72,6 @@ def apply_custom_transformations(
         "datasets": datasets,
         "dataset_name": dataset_name,
     }
-    function_params = inspect.signature(retrieved_function).parameters
     new_standard_params = {
         k: v for k, v in standard_params.items() if k in function_params
     }

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -45,11 +45,11 @@ def apply_custom_transformations(
         return None
     if isinstance(function_info, str):
         retrieved_function = getattr(transform, function_info)
-        extra_params = {}
+        config_defined_params = {}
     else:
         # Retrieve the function name and its parameters
         # Assumes a single function in the dict
-        function_name, extra_params = next(iter(function_info.items()))
+        function_name, config_defined_params = next(iter(function_info.items()))
         retrieved_function = getattr(transform, function_name)
     sig = inspect.signature(retrieved_function)
     key_word_parameters = {}
@@ -63,7 +63,7 @@ def apply_custom_transformations(
         elif name == "dataset_name":
             key_word_parameters["dataset_name"] = dataset_name
     # Merge parameters
-    combined_params = {**key_word_parameters, **extra_params}
+    combined_params = {**key_word_parameters, **config_defined_params}
     return retrieved_function(**combined_params)
 
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -30,14 +30,14 @@ def apply_custom_transformations(
         dataset_obj (dict): dataset object from the configuration file
 
     Returns:
-        Union[DataFrame, dict, None]: result of transformation. 
+        Union[DataFrame, dict, None]: result of transformation.
     """
     function_info = dataset_obj.get("custom_transformations", "")
     if (
         not isinstance(datasets, dict)
         or not isinstance(dataset_name, str)
         or not function_info
-    ): 
+    ):
         if not function_info:
             logger.warning(
                 f"No custom transformation function provided for dataset {dataset_name}. Skipping."
@@ -60,6 +60,8 @@ def apply_custom_transformations(
             key_word_parameters["df"] = df
         elif name == "datasets":
             key_word_parameters["datasets"] = datasets
+        elif name == "dataset_name":
+            key_word_parameters["dataset_name"] = dataset_name
     # Merge parameters
     combined_params = {**key_word_parameters, **extra_params}
     return retrieved_function(**combined_params)
@@ -411,6 +413,15 @@ def process(
     upload: bool = upload_opt,
     auth_token: str = synapse_auth_opt,
 ):
+    """Process the configuration file and execute the data processing pipeline based on options.
+
+    Args:
+        config_path (str): Path to the configuration file for the processing run.
+        platform (str): Platform that is running the process. Must be one of LOCAL, GITHUB, or NEXTFLOW.
+        run_id (str): Run ID of the process. Used to identify the run in the GX table.
+        upload (bool): Boolean value to toggle whether files will be uploaded to Synapse.
+        auth_token (str): Synapse authentication token. Defaults to environment variable SYNAPSE_AUTH_TOKEN.
+    """
     syn = utils._login_to_synapse(token=auth_token)
     platform_enum = Platform(platform)
     process_all_files(

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -181,11 +181,6 @@ def process_dataset(
             filename=dataset_name + "." + dataset_obj[dataset_name]["final_format"],
         )
     else:
-        if not isinstance(df, DataFrame):
-            raise TypeError(
-                f"The variable 'df' must be a DataFrame, but got {type(df)}."
-            )
-
         json_path = load.df_to_json(
             df=df,
             staging_path=staging_path,

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -16,7 +16,6 @@ from agoradatatools.constants import Platform
 logger = logging.getLogger(__name__)
 
 
-# TODO refactor to avoid so many if's - maybe some sort of mapping to callables
 def apply_custom_transformations(
     datasets: dict,
     dataset_name: str,

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -52,18 +52,18 @@ def apply_custom_transformations(
         function_name, config_defined_params = next(iter(function_info.items()))
         retrieved_function = getattr(transform, function_name)
     sig = inspect.signature(retrieved_function)
-    key_word_parameters = {}
+    parameters = {}
     # Map known inputs
     for name, _ in sig.parameters.items():
         if name == "df":
             df = datasets[dataset_name]
-            key_word_parameters["df"] = df
+            parameters["df"] = df
         elif name == "datasets":
-            key_word_parameters["datasets"] = datasets
+            parameters["datasets"] = datasets
         elif name == "dataset_name":
-            key_word_parameters["dataset_name"] = dataset_name
-    # Merge parameters
-    combined_params = {**key_word_parameters, **config_defined_params}
+            parameters["dataset_name"] = dataset_name
+    # Holds all the parameters to be passed to the transformation function
+    combined_params = {**parameters, **config_defined_params}
     return retrieved_function(**combined_params)
 
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -58,7 +58,7 @@ def apply_custom_transformations(
         raise AttributeError(
             f"Function {function_name} not found in the transform module. Please provide the correct function name."
         )
-    
+
     retrieved_function = getattr(transform, function_name)
     sig = inspect.signature(retrieved_function)
     parameters = {}

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -421,7 +421,7 @@ def process(
     run_id: str = run_id_opt,
     upload: bool = upload_opt,
     auth_token: str = synapse_auth_opt,
-):
+) -> None:
     """Process the configuration file and execute the data processing pipeline based on options.
 
     Args:

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -54,12 +54,12 @@ def apply_custom_transformations(
                 "Please provide a single custom transformation function in the configuration file. Only the first function will be used if multiple are provided."
             )
         function_name, config_defined_params = next(iter(function_info.items()))
-    try:
-        retrieved_function = getattr(transform, function_name)
-    except AttributeError:
+    if not hasattr(transform, function_name):
         raise AttributeError(
             f"Function {function_name} not found in the transform module. Please provide the correct function name."
         )
+    
+    retrieved_function = getattr(transform, function_name)
     sig = inspect.signature(retrieved_function)
     parameters = {}
     # Map known inputs

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -22,6 +22,16 @@ def apply_custom_transformations(
     dataset_name: str,
     dataset_obj: dict,
 ) -> Union[DataFrame, dict, None]:
+    """Apply custom transformations to the dataset based on the provided function names and parameters.
+
+    Args:
+        datasets (dict): datasets to be transformed
+        dataset_name (str): name of the datasets
+        dataset_obj (dict): dataset object from the configuration file
+
+    Returns:
+        Union[DataFrame, dict, None]: result of transformation. 
+    """
     function_info = dataset_obj.get("custom_transformations", "")
     if (
         not isinstance(datasets, dict)

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -27,7 +27,11 @@ def apply_custom_transformations(
         not isinstance(datasets, dict)
         or not isinstance(dataset_name, str)
         or not function_info
-    ):
+    ): 
+        if not function_info:
+            logger.warning(
+                f"No custom transformation function provided for dataset {dataset_name}. Skipping."
+            )
         return None
     if isinstance(function_info, str):
         retrieved_function = getattr(transform, function_info)

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -44,13 +44,23 @@ def apply_custom_transformations(
             )
         return None
     if isinstance(function_info, str):
-        retrieved_function = getattr(transform, function_info)
+        try:
+            retrieved_function = getattr(transform, function_info)
+        except AttributeError:
+            raise AttributeError(
+                f"Function {function_info} not found in the transform module. Please provide the correct function name."
+            )
         config_defined_params = {}
     else:
         # Retrieve the function name and its parameters
         # Assumes a single function in the dict
         function_name, config_defined_params = next(iter(function_info.items()))
-        retrieved_function = getattr(transform, function_name)
+        try:
+            retrieved_function = getattr(transform, function_name)
+        except AttributeError:
+            raise AttributeError(
+                f"Function {function_name} not found in the transform module. Please provide the correct function name."
+            )
     sig = inspect.signature(retrieved_function)
     parameters = {}
     # Map known inputs
@@ -171,6 +181,11 @@ def process_dataset(
             filename=dataset_name + "." + dataset_obj[dataset_name]["final_format"],
         )
     else:
+        if not isinstance(df, DataFrame):
+            raise TypeError(
+                f"The variable 'df' must be a DataFrame, but got {type(df)}."
+            )
+
         json_path = load.df_to_json(
             df=df,
             staging_path=staging_path,

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -18,10 +18,16 @@ logger = logging.getLogger(__name__)
 
 # TODO refactor to avoid so many if's - maybe some sort of mapping to callables
 def apply_custom_transformations(
-    datasets: dict, dataset_name: str, dataset_obj: dict,
+    datasets: dict,
+    dataset_name: str,
+    dataset_obj: dict,
 ) -> Union[DataFrame, dict, None]:
     function_info = dataset_obj.get("custom_transformations", "")
-    if not isinstance(datasets, dict) or not isinstance(dataset_name, str) or not function_info:
+    if (
+        not isinstance(datasets, dict)
+        or not isinstance(dataset_name, str)
+        or not function_info
+    ):
         return None
     if isinstance(function_info, str):
         retrieved_function = getattr(transform, function_info)
@@ -29,7 +35,7 @@ def apply_custom_transformations(
     else:
         # Retrieve the function name and its parameters
         # Assumes a single function in the dict
-        function_name, extra_params  = next(iter(function_info.items()))
+        function_name, extra_params = next(iter(function_info.items()))
         retrieved_function = getattr(transform, function_name)
     sig = inspect.signature(retrieved_function)
     key_word_parameters = {}
@@ -43,6 +49,7 @@ def apply_custom_transformations(
     # Merge parameters
     combined_params = {**key_word_parameters, **extra_params}
     return retrieved_function(**combined_params)
+
 
 def upload_dataversion_metadata(
     syn: synapseclient.Synapse,

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from typing import Optional, Union, Dict, Any
 import inspect
 import synapseclient
@@ -38,7 +39,7 @@ def apply_custom_transformations(
         or not function_info
     ):
         if not function_info:
-            logger.warning(
+            warnings.warn(
                 f"No custom transformation function provided for dataset {dataset_name}. Skipping."
             )
         return None
@@ -48,6 +49,10 @@ def apply_custom_transformations(
     else:
         # Retrieve the function name and its parameters
         # Assumes a single function in the dict
+        if len(function_info.items()) != 1:
+            warnings.warn(
+                "Please provide a single custom transformation function in the configuration file. Only the first function will be used if multiple are provided."
+            )
         function_name, config_defined_params = next(iter(function_info.items()))
     try:
         retrieved_function = getattr(transform, function_name)
@@ -60,7 +65,7 @@ def apply_custom_transformations(
     # Map known inputs
     for name, _ in sig.parameters.items():
         if name == "df":
-            df = datasets[dataset_name]
+            df = datasets.get(dataset_name, DataFrame())
             parameters["df"] = df
         elif name == "datasets":
             parameters["datasets"] = datasets

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -60,19 +60,20 @@ def apply_custom_transformations(
         )
 
     retrieved_function = getattr(transform, function_name)
-    sig = inspect.signature(retrieved_function)
-    parameters = {}
-    # Map known inputs
-    for name, _ in sig.parameters.items():
-        if name == "df":
-            df = datasets.get(dataset_name, DataFrame())
-            parameters["df"] = df
-        elif name == "datasets":
-            parameters["datasets"] = datasets
-        elif name == "dataset_name":
-            parameters["dataset_name"] = dataset_name
+    function_params = inspect.signature(retrieved_function).parameters
+
+    standard_params = {
+        "df": datasets.get(dataset_name, DataFrame()),
+        "datasets": datasets,
+        "dataset_name": dataset_name,
+    }
+    function_params = inspect.signature(retrieved_function).parameters
+    new_standard_params = {
+        k: v for k, v in standard_params.items() if k in function_params
+    }
+
     # Holds all the parameters to be passed to the transformation function
-    combined_params = {**parameters, **config_defined_params}
+    combined_params = {**new_standard_params, **config_defined_params}
     return retrieved_function(**combined_params)
 
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Optional, Union
-
+import inspect
 import synapseclient
 from pandas import DataFrame
 from typer import Argument, Option, Typer
@@ -18,58 +18,31 @@ logger = logging.getLogger(__name__)
 
 # TODO refactor to avoid so many if's - maybe some sort of mapping to callables
 def apply_custom_transformations(
-    datasets: dict, dataset_name: str, dataset_obj: dict
+    datasets: dict, dataset_name: str, dataset_obj: dict,
 ) -> Union[DataFrame, dict, None]:
-    if not isinstance(datasets, dict) or not isinstance(dataset_name, str):
+    function_info = dataset_obj.get("custom_transformations", "")
+    if not isinstance(datasets, dict) or not isinstance(dataset_name, str) or not function_info:
         return None
-    if dataset_name == "biodomain_info":
-        return transform.transform_biodomain_info(datasets=datasets)
-    if dataset_name == "genes_biodomains":
-        return transform.transform_genes_biodomains(datasets=datasets)
-    if dataset_name == "overall_scores":
-        df = datasets["overall_scores"]
-        return transform.transform_overall_scores(df=df)
-    if dataset_name == "distribution_data":
-        return transform.transform_distribution_data(
-            datasets=datasets,
-            overall_max_score=dataset_obj["custom_transformations"][
-                "overall_max_score"
-            ],
-            genetics_max_score=dataset_obj["custom_transformations"][
-                "genetics_max_score"
-            ],
-            omics_max_score=dataset_obj["custom_transformations"]["omics_max_score"],
-        )
-    if dataset_name == "team_info":
-        return transform.transform_team_info(datasets=datasets)
-    if dataset_name == "rnaseq_differential_expression":
-        return transform.transform_rnaseq_differential_expression(datasets=datasets)
-    if dataset_name == "gene_info":
-        return transform.transform_gene_info(
-            datasets=datasets,
-            adjusted_p_value_threshold=dataset_obj["custom_transformations"][
-                "adjusted_p_value_threshold"
-            ],
-            protein_level_threshold=dataset_obj["custom_transformations"][
-                "protein_level_threshold"
-            ],
-        )
-    if dataset_name == "rna_distribution_data":
-        return transform.transform_rna_distribution_data(datasets=datasets)
-    if dataset_name == "proteomics_distribution_data":
-        return transform.transform_proteomics_distribution_data(datasets=datasets)
-    if dataset_name in ["proteomics", "proteomics_tmt", "proteomics_srm"]:
-        df = datasets[dataset_name]
-        return transform.transform_proteomics(df=df)
-    if dataset_name in ["biomarkers", "pathology"]:
-        return transform.immunohisto_transform(
-            datasets=datasets, dataset_name=dataset_name
-        )
-    if dataset_name == "model_details":
-        return transform.transform_model_details(datasets=datasets)
+    if isinstance(function_info, str):
+        retrieved_function = getattr(transform, function_info)
+        extra_params = {}
     else:
-        return None
-
+        # Retrieve the function name and its parameters
+        # Assumes a single function in the dict
+        function_name, extra_params  = next(iter(function_info.items()))
+        retrieved_function = getattr(transform, function_name)
+    sig = inspect.signature(retrieved_function)
+    key_word_parameters = {}
+    # Map known inputs like 'df' or 'datasets' to the expected parameters
+    for name, _ in sig.parameters.items():
+        if name == "df":
+            df = datasets[dataset_name]
+            key_word_parameters["df"] = df
+        elif name == "datasets":
+            key_word_parameters["datasets"] = datasets
+    # Merge parameters
+    combined_params = {**key_word_parameters, **extra_params}
+    return retrieved_function(**combined_params)
 
 def upload_dataversion_metadata(
     syn: synapseclient.Synapse,

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -50,7 +50,7 @@ datasets:
   - biodomain_info:
       files: *genes_biodomains_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_biodomain_info
       provenance: *genes_biodomains_provenance
       column_rename:
         biodomain: name
@@ -60,7 +60,7 @@ datasets:
   - genes_biodomains:
       files: *genes_biodomains_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_genes_biodomains
       provenance: *genes_biodomains_provenance
       column_rename:
         ensembl_id: ensembl_gene_id
@@ -90,7 +90,7 @@ datasets:
   - proteomics:
       files: *agora_proteomics_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_proteomics
       provenance: *agora_proteomics_provenance
       column_rename:
         genename: hgnc_symbol
@@ -101,7 +101,7 @@ datasets:
   - proteomics_tmt:
       files: *agora_proteomics_tmt_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_proteomics
       provenance: *agora_proteomics_tmt_provenance
       column_rename:
         genename: hgnc_symbol
@@ -112,7 +112,7 @@ datasets:
   - proteomics_srm:
       files: *agora_proteomics_srm_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_proteomics
       provenance: *agora_proteomics_srm_provenance
       column_rename:
         genename: hgnc_symbol
@@ -175,8 +175,9 @@ datasets:
           format: csv
       final_format: json
       custom_transformations:
-        adjusted_p_value_threshold: 0.05
-        protein_level_threshold: 0.05
+        transform_gene_info:
+          adjusted_p_value_threshold: 0.05
+          protein_level_threshold: 0.05
       column_rename:
         ensg: ensembl_gene_id
         ensembl_id: ensembl_gene_id
@@ -225,7 +226,7 @@ datasets:
           id: syn12615633.20
           format: csv
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_team_info
       provenance:
         - syn12615624.18
         - syn12615633.20
@@ -237,7 +238,7 @@ datasets:
   - overall_scores:
       files: *overall_scores_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_overall_scores
       column_rename:
         genename: hgnc_gene_id
       provenance: *overall_scores_provenance
@@ -271,7 +272,7 @@ datasets:
   - rnaseq_differential_expression:
       files: *rna_diff_expr_data_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_rnaseq_differential_expression
       provenance: *rna_diff_expr_data_provenance
       destination: *dest
       gx_enabled: true
@@ -280,9 +281,10 @@ datasets:
       files: *overall_scores_files
       final_format: json
       custom_transformations:
-        overall_max_score: 5
-        genetics_max_score: 3
-        omics_max_score: 2
+        transform_distribution_data:
+            overall_max_score: 5
+            genetics_max_score: 3
+            omics_max_score: 2
       provenance: *overall_scores_provenance
       column_rename:
         overall: target_risk_score
@@ -298,7 +300,7 @@ datasets:
   - rna_distribution_data:
       files: *rna_diff_expr_data_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_rna_distribution_data
       provenance: *rna_diff_expr_data_provenance
       destination: *dest
       gx_enabled: true
@@ -309,7 +311,7 @@ datasets:
         - <<: *agora_proteomics_tmt_files
         - <<: *agora_proteomics_srm_files
       final_format: json
-      custom_transformations: 1
+      custom_transformations: transform_proteomics_distribution_data
       provenance:
         - *agora_proteomics_provenance
         - *agora_proteomics_tmt_provenance

--- a/tests/test_assets/bad_invalid_config.yaml
+++ b/tests/test_assets/bad_invalid_config.yaml
@@ -1,0 +1,7 @@
+- destination: &dest syn12345678
+- datasets:
+    - rnaseq_test_expression:
+        files:
+          - name: diff_exp_data
+            id: syn1234
+            format: tsv

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -91,6 +91,207 @@ class TestUploadDataversionMetadata:
         )
 
 
+class TestApplyCustomTransformations:
+    @pytest.fixture(scope="function", autouse=True)
+    def standard_transform_function(self):
+        """mock simple transform function"""
+
+        def _standard_transform_function(
+            df: pd.DataFrame, dataset_name: str, datasets: Dict[str, pd.DataFrame]
+        ) -> pd.DataFrame:
+            """mock simple transform function"""
+            return df.assign(test_col=2)
+
+        return _standard_transform_function
+
+    @pytest.fixture(scope="function", autouse=True)
+    def special_transform_function(self):
+        """mock transform function that takes test_threshold as an argument"""
+
+        def _mock_transform_with_args(
+            df: pd.DataFrame, test_threshold: int
+        ) -> pd.DataFrame:
+            """mock transform function that takes test_threshold as an argument"""
+            return df.assign(new_key=1)
+
+        return _mock_transform_with_args
+
+    @pytest.mark.parametrize(
+        "example_config_with_custom_transform,expectation",
+        [
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": {
+                            "mock_transform_function_false": {
+                                "test_threshold": 1,
+                                "test_p_value": 2,
+                            }
+                        },
+                    }
+                },
+                pytest.raises(AttributeError),
+            ),
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": "mock_transform_function_false",
+                    },
+                },
+                pytest.raises(AttributeError),
+            ),
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": 1,
+                    },
+                },
+                pytest.raises(AttributeError),
+            ),
+        ],
+    )
+    def test_apply_invalid_custom_transformations(
+        self,
+        example_config_with_custom_transform: Dict[str, Any],
+        expectation: Exception,
+    ) -> None:
+        """Test that invalid custom transformations raise an error."""
+        with expectation:
+            process.apply_custom_transformations(
+                datasets={"test_file_1": pd.DataFrame()},
+                dataset_name="neuropath_corr",
+                dataset_obj=example_config_with_custom_transform["neuropath_corr"],
+            )
+
+    def test_apply_invalid_multi_custom_transformations(
+        self,
+        special_transform_function: Callable[
+            [pd.DataFrame, str, Dict[str, pd.DataFrame]], pd.DataFrame
+        ],
+    ):
+        """Test that when the config file contains multiple custom transformations, the first one gets used and a warning is raised"""
+        example_config_with_custom_transform = {
+            "neuropath_corr": {
+                "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
+                "final_format": "json",
+                "provenance": ["syn1111111"],
+                "destination": "syn1111113",
+                "gx_enabled": False,
+                "custom_transformations": {
+                    "special_transform_function": {"test_threshold": 1},
+                    "mock_transform_function_false": {
+                        "test_threshold": 1,
+                        "test_p_value": 2,
+                    },
+                },
+            },
+        }
+        with pytest.warns(UserWarning):
+            with patch.object(
+                transform,
+                "special_transform_function",
+                special_transform_function,
+                create=True,
+            ):
+                process.apply_custom_transformations(
+                    datasets={"test_file_1": pd.DataFrame()},
+                    dataset_name="neuropath_corr",
+                    dataset_obj=example_config_with_custom_transform["neuropath_corr"],
+                )
+
+    @pytest.mark.parametrize(
+        "example_config_with_custom_transform, function_name, expectation, transformed_df",
+        [
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": "standard_transform_function",
+                    }
+                },
+                "standard_transform_function",
+                does_not_raise(),
+                pd.DataFrame({"test_key": ["test_value"], "test_col": [2]}),
+            ),
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": {
+                            "special_transform_function": {"test_threshold": 1}
+                        },
+                    }
+                },
+                "special_transform_function",
+                does_not_raise(),
+                pd.DataFrame({"test_key": ["test_value"], "new_key": [1]}),
+            ),
+        ],
+    )
+    def test_apply_valid_custom_transformations(
+        self,
+        standard_transform_function: Callable[
+            [pd.DataFrame, str, Dict[str, pd.DataFrame]], pd.DataFrame
+        ],
+        special_transform_function: Callable[
+            [pd.DataFrame, str, Dict[str, pd.DataFrame]], pd.DataFrame
+        ],
+        function_name: str,
+        example_config_with_custom_transform: Dict[str, Any],
+        expectation: ContextManager[None],
+        transformed_df: pd.DataFrame,
+    ) -> None:
+        """Test that transformations are applied correctly when a valid transformation function is provided."""
+
+        if function_name == "special_transform_function":
+            mocked_transform = special_transform_function
+        else:
+            mocked_transform = standard_transform_function
+        with patch.object(transform, function_name, mocked_transform, create=True):
+            with expectation:
+                df_transformed = process.apply_custom_transformations(
+                    datasets={
+                        "test_file_1": pd.DataFrame({"test_key": ["test_value"]})
+                    },
+                    dataset_name="test_file_1",
+                    dataset_obj=example_config_with_custom_transform["neuropath_corr"],
+                )
+                assert df_transformed.equals(transformed_df)
+
+
 class TestProcessDataset:
     dataset_object = {
         "neuropath_corr": {
@@ -202,172 +403,6 @@ class TestProcessDataset:
         self.patch_set_attributes.stop()
         self.patch_format_link.stop()
         mock.patch.stopall()
-
-    @pytest.fixture(scope="function", autouse=True)
-    def standard_transform_function(self):
-        """mock simple transform function"""
-
-        def _standard_transform_function(
-            df: pd.DataFrame, dataset_name: str, datasets: Dict[str, pd.DataFrame]
-        ) -> pd.DataFrame:
-            """mock simple transform function"""
-            return df.assign(test_col=2)
-
-        return _standard_transform_function
-
-    @pytest.fixture(scope="function", autouse=True)
-    def special_transform_function(self):
-        """mock transform function that takes test_threshold as an argument"""
-
-        def _mock_transform_with_args(
-            df: pd.DataFrame, test_threshold: int
-        ) -> pd.DataFrame:
-            """mock transform function that takes test_threshold as an argument"""
-            return df.assign(new_key=1)
-
-        return _mock_transform_with_args
-
-    @pytest.mark.parametrize(
-        "example_config_with_custom_transform,expectation",
-        [
-            (
-                {
-                    "neuropath_corr": {
-                        "files": [
-                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
-                        ],
-                        "final_format": "json",
-                        "provenance": ["syn1111111"],
-                        "destination": "syn1111113",
-                        "gx_enabled": False,
-                        "custom_transformations": {
-                            "mock_transform_function_false": {
-                                "test_threshold": 1,
-                                "test_p_value": 2,
-                            }
-                        },
-                    }
-                },
-                pytest.raises(AttributeError),
-            ),
-            (
-                {
-                    "neuropath_corr": {
-                        "files": [
-                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
-                        ],
-                        "final_format": "json",
-                        "provenance": ["syn1111111"],
-                        "destination": "syn1111113",
-                        "gx_enabled": False,
-                        "custom_transformations": "mock_transform_function_false",
-                    },
-                },
-                pytest.raises(AttributeError),
-            ),
-            (
-                {
-                    "neuropath_corr": {
-                        "files": [
-                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
-                        ],
-                        "final_format": "json",
-                        "provenance": ["syn1111111"],
-                        "destination": "syn1111113",
-                        "gx_enabled": False,
-                        "custom_transformations": 1,
-                    },
-                },
-                pytest.raises(AttributeError),
-            ),
-        ],
-    )
-    def test_apply_invalid_custom_transformations(
-        self,
-        example_config_with_custom_transform: Dict[str, Any],
-        expectation: Exception,
-    ) -> None:
-        """Test that invalid custom transformations raise an error."""
-        # disable the class level patcher
-        mock.patch.stopall()
-        with expectation:
-            process.apply_custom_transformations(
-                datasets={"test_file_1": pd.DataFrame()},
-                dataset_name="neuropath_corr",
-                dataset_obj=example_config_with_custom_transform["neuropath_corr"],
-            )
-
-    @pytest.mark.parametrize(
-        "example_config_with_custom_transform, function_name, expectation, transformed_df",
-        [
-            (
-                {
-                    "neuropath_corr": {
-                        "files": [
-                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
-                        ],
-                        "final_format": "json",
-                        "provenance": ["syn1111111"],
-                        "destination": "syn1111113",
-                        "gx_enabled": False,
-                        "custom_transformations": "standard_transform_function",
-                    }
-                },
-                "standard_transform_function",
-                does_not_raise(),
-                pd.DataFrame({"test_key": ["test_value"], "test_col": [2]}),
-            ),
-            (
-                {
-                    "neuropath_corr": {
-                        "files": [
-                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
-                        ],
-                        "final_format": "json",
-                        "provenance": ["syn1111111"],
-                        "destination": "syn1111113",
-                        "gx_enabled": False,
-                        "custom_transformations": {
-                            "special_transform_function": {"test_threshold": 1}
-                        },
-                    }
-                },
-                "special_transform_function",
-                does_not_raise(),
-                pd.DataFrame({"test_key": ["test_value"], "new_key": [1]}),
-            ),
-        ],
-    )
-    def test_apply_valid_custom_transformations(
-        self,
-        standard_transform_function: Callable[
-            [pd.DataFrame, str, Dict[str, pd.DataFrame]], pd.DataFrame
-        ],
-        special_transform_function: Callable[
-            [pd.DataFrame, str, Dict[str, pd.DataFrame]], pd.DataFrame
-        ],
-        function_name: str,
-        example_config_with_custom_transform: Dict[str, Any],
-        expectation: ContextManager[None],
-        transformed_df: pd.DataFrame,
-    ) -> None:
-        """Test that transformations are applied correctly when a valid transformation function is provided."""
-        # disable the class level patch
-        mock.patch.stopall()
-        if function_name == "special_transform_function":
-            mocked_transform = special_transform_function
-        else:
-            mocked_transform = standard_transform_function
-        with patch.object(transform, function_name, mocked_transform, create=True):
-            with expectation:
-                df_transformed = process.apply_custom_transformations(
-                    datasets={
-                        "test_file_1": pd.DataFrame({"test_key": ["test_value"]})
-                    },
-                    dataset_name="test_file_1",
-                    dataset_obj=example_config_with_custom_transform["neuropath_corr"],
-                )
-                assert df_transformed.equals(transformed_df)
 
     def test_process_dataset_upload_false_gx_not_specified(self, syn: Any):
         process.process_dataset(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -127,6 +127,7 @@ class TestApplyCustomTransformations:
 
     @pytest.mark.parametrize(
         "example_config_with_custom_transform,expectation",
+        # Fails because mock_transform_function_false doesn't exist
         [
             (
                 {
@@ -148,6 +149,7 @@ class TestApplyCustomTransformations:
                 },
                 pytest.raises(AttributeError),
             ),
+            # Fails because mock_transform_function_false doesn't exist
             (
                 {
                     "neuropath_corr": {
@@ -163,6 +165,7 @@ class TestApplyCustomTransformations:
                 },
                 pytest.raises(AttributeError),
             ),
+            # Fails because mock_transform_function_false is mapped to an integer
             (
                 {
                     "neuropath_corr": {
@@ -238,6 +241,7 @@ class TestApplyCustomTransformations:
         "example_config_with_custom_transform, function_name, expectation, transformed_df",
         [
             (
+                # valid custom transformations with standard parameters
                 {
                     "neuropath_corr": {
                         "files": [
@@ -262,6 +266,7 @@ class TestApplyCustomTransformations:
                 ),
             ),
             (
+                # valid custom transformations with additional parameters
                 {
                     "neuropath_corr": {
                         "files": [

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,7 +1,8 @@
-from typing import Any
+from typing import Any, Callable, ContextManager
 from unittest import mock
 from unittest.mock import patch
-
+from agoradatatools.etl import transform
+from contextlib import nullcontext as does_not_raise
 import pandas as pd
 import pytest
 
@@ -202,6 +203,168 @@ class TestProcessDataset:
         self.patch_format_link.stop()
         mock.patch.stopall()
 
+    @pytest.fixture(scope="function", autouse=True)
+    @staticmethod
+    def standard_transform_function():
+        """mock simple transform function"""
+
+        def _standard_transform_function(
+            df: pd.DataFrame, dataset_name: str, datasets: dict
+        ):
+            return df.assign(test_col=2)
+
+        return _standard_transform_function
+
+    @pytest.fixture(scope="function", autouse=True)
+    @staticmethod
+    def special_transform_function():
+        """mock transform function that takes test_threshold as an argument"""
+
+        def _mock_transform_with_args(df: pd.DataFrame, test_threshold: int):
+            return df.assign(new_key=1)
+
+        return _mock_transform_with_args
+
+    @pytest.mark.parametrize(
+        "example_config_with_custom_transform,expectation",
+        [
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": {
+                            "mock_transform_function_false": {
+                                "test_threshold": 1,
+                                "test_p_value": 2,
+                            }
+                        },
+                    }
+                },
+                pytest.raises(AttributeError),
+            ),
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": "mock_transform_function_false",
+                    },
+                },
+                pytest.raises(AttributeError),
+            ),
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": 1,
+                    },
+                },
+                pytest.raises(AttributeError),
+            ),
+        ],
+    )
+    def test_apply_invalid_custom_transformations(
+        self, example_config_with_custom_transform: dict, expectation: Exception
+    ) -> None:
+        """Test that invalid custom transformations raise an error."""
+        # disable the class level patcher
+        mock.patch.stopall()
+        with expectation:
+            process.apply_custom_transformations(
+                datasets={"test_file_1": pd.DataFrame()},
+                dataset_name="neuropath_corr",
+                dataset_obj=example_config_with_custom_transform["neuropath_corr"],
+            )
+
+    @pytest.mark.parametrize(
+        "example_config_with_custom_transform, function_name, expectation, transformed_df",
+        [
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": "standard_transform_function",
+                    }
+                },
+                "standard_transform_function",
+                does_not_raise(),
+                pd.DataFrame({"test_key": ["test_value"], "test_col": [2]}),
+            ),
+            (
+                {
+                    "neuropath_corr": {
+                        "files": [
+                            {"name": "test_file_1", "id": "syn1111111", "format": "csv"}
+                        ],
+                        "final_format": "json",
+                        "provenance": ["syn1111111"],
+                        "destination": "syn1111113",
+                        "gx_enabled": False,
+                        "custom_transformations": {
+                            "special_transform_function": {"test_threshold": 1}
+                        },
+                    }
+                },
+                "special_transform_function",
+                does_not_raise(),
+                pd.DataFrame({"test_key": ["test_value"], "new_key": [1]}),
+            ),
+        ],
+    )
+    def test_apply_valid_custom_transformations(
+        self,
+        standard_transform_function: Callable[
+            [pd.DataFrame, str, dict[str, pd.DataFrame]], pd.DataFrame
+        ],
+        special_transform_function: Callable[
+            [pd.DataFrame, str, dict[str, pd.DataFrame]], pd.DataFrame
+        ],
+        function_name: str,
+        example_config_with_custom_transform: dict,
+        expectation: ContextManager[None],
+        transformed_df: pd.DataFrame,
+    ) -> None:
+        """Test that transformations are applied correctly when a valid transformation function is provided."""
+        # disable the class level patch
+        mock.patch.stopall()
+        if function_name == "special_transform_function":
+            mocked_transform = special_transform_function
+        else:
+            mocked_transform = standard_transform_function
+        with patch.object(transform, function_name, mocked_transform, create=True):
+            with expectation:
+                df_transformed = process.apply_custom_transformations(
+                    datasets={
+                        "test_file_1": pd.DataFrame({"test_key": ["test_value"]})
+                    },
+                    dataset_name="test_file_1",
+                    dataset_obj=example_config_with_custom_transform["neuropath_corr"],
+                )
+                assert df_transformed.equals(transformed_df)
+
     def test_process_dataset_upload_false_gx_not_specified(self, syn: Any):
         process.process_dataset(
             dataset_obj=self.dataset_object,
@@ -231,8 +394,11 @@ class TestProcessDataset:
         self.patch_format_link.assert_not_called()
         self.patch_load.assert_not_called()
 
+    @patch(
+        "agoradatatools.process.apply_custom_transformations", return_value=pd.DataFrame
+    )
     def test_process_dataset_upload_false_gx_not_specified_column_rename(
-        self, syn: Any
+        self, patch_custom_transform, syn: Any
     ):
         process.process_dataset(
             dataset_obj=self.dataset_object_col_rename,
@@ -253,7 +419,7 @@ class TestProcessDataset:
         self.patch_rename_columns.assert_called_once_with(
             df=pd.DataFrame, column_map={"col_1": "new_col_1", "col_2": "new_col_2"}
         )
-        self.patch_custom_transform.assert_not_called()
+        patch_custom_transform.assert_not_called()
         self.patch_df_to_json.assert_called_once_with(
             df=pd.DataFrame, staging_path=STAGING_PATH, filename="neuropath_corr.json"
         )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -104,8 +104,10 @@ class TestApplyCustomTransformations:
             df: pd.DataFrame, dataset_name: str, datasets: Dict[str, pd.DataFrame]
         ) -> pd.DataFrame:
             """mock simple transform function"""
-            datasets["new_key"] = 2
-            return df.assign(test_col=2, new_key=dataset_name + "_new_key")
+            if dataset_name in datasets:
+                aggregated_value = datasets[dataset_name]["value_column"].sum()
+                df["aggregated_value"] = aggregated_value
+            return df.assign(new_key=dataset_name + "_new_key")
 
         return _standard_transform_function
 
@@ -252,9 +254,10 @@ class TestApplyCustomTransformations:
                 does_not_raise(),
                 pd.DataFrame(
                     {
-                        "test_key": ["test_value"],
-                        "test_col": [2],
-                        "new_key": "test_file_1_new_key",
+                        "test_key": ["test_value1", "test_value2"],
+                        "value_column": [1, 2],
+                        "aggregated_value": [3, 3],
+                        "new_key": ["test_file_1_new_key", "test_file_1_new_key"],
                     }
                 ),
             ),
@@ -275,7 +278,13 @@ class TestApplyCustomTransformations:
                 },
                 "special_transform_function",
                 does_not_raise(),
-                pd.DataFrame({"test_key": ["test_value"], "new_key": [1]}),
+                pd.DataFrame(
+                    {
+                        "test_key": ["test_value1", "test_value2"],
+                        "value_column": [1, 2],
+                        "new_key": [1, 1],
+                    }
+                ),
             ),
         ],
         ids=[
@@ -306,7 +315,12 @@ class TestApplyCustomTransformations:
             with expectation:
                 df_transformed = process.apply_custom_transformations(
                     datasets={
-                        "test_file_1": pd.DataFrame({"test_key": ["test_value"]})
+                        "test_file_1": pd.DataFrame(
+                            {
+                                "test_key": ["test_value1", "test_value2"],
+                                "value_column": [1, 2],
+                            }
+                        ),
                     },
                     dataset_name="test_file_1",
                     dataset_obj=example_config_with_custom_transform["neuropath_corr"],

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -177,6 +177,11 @@ class TestApplyCustomTransformations:
                 pytest.raises(AttributeError),
             ),
         ],
+        ids=[
+            "invalid_custom_transformations_with_special_params",
+            "invalid_custom_transformations_with_standard_params",
+            "invalid_type",
+        ],
     )
     def test_apply_invalid_custom_transformations(
         self,
@@ -272,6 +277,10 @@ class TestApplyCustomTransformations:
                 does_not_raise(),
                 pd.DataFrame({"test_key": ["test_value"], "new_key": [1]}),
             ),
+        ],
+        ids=[
+            "valid_custom_transformations_standard_params",
+            "valid_custom_transformations_special_params",
         ],
     )
     def test_apply_valid_custom_transformations(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, ContextManager
+from typing import Any, Callable, ContextManager, Dict
 from unittest import mock
 from unittest.mock import patch
 from agoradatatools.etl import transform
@@ -208,7 +208,7 @@ class TestProcessDataset:
         """mock simple transform function"""
 
         def _standard_transform_function(
-            df: pd.DataFrame, dataset_name: str, datasets: dict
+            df: pd.DataFrame, dataset_name: str, datasets: Dict[str, pd.DataFrame]
         ):
             return df.assign(test_col=2)
 
@@ -279,7 +279,9 @@ class TestProcessDataset:
         ],
     )
     def test_apply_invalid_custom_transformations(
-        self, example_config_with_custom_transform: dict, expectation: Exception
+        self,
+        example_config_with_custom_transform: Dict[str, Any],
+        expectation: Exception,
     ) -> None:
         """Test that invalid custom transformations raise an error."""
         # disable the class level patcher
@@ -335,13 +337,13 @@ class TestProcessDataset:
     def test_apply_valid_custom_transformations(
         self,
         standard_transform_function: Callable[
-            [pd.DataFrame, str, dict[str, pd.DataFrame]], pd.DataFrame
+            [pd.DataFrame, str, Dict[str, pd.DataFrame]], pd.DataFrame
         ],
         special_transform_function: Callable[
-            [pd.DataFrame, str, dict[str, pd.DataFrame]], pd.DataFrame
+            [pd.DataFrame, str, Dict[str, pd.DataFrame]], pd.DataFrame
         ],
         function_name: str,
-        example_config_with_custom_transform: dict,
+        example_config_with_custom_transform: Dict[str, Any],
         expectation: ContextManager[None],
         transformed_df: pd.DataFrame,
     ) -> None:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -126,7 +126,7 @@ class TestApplyCustomTransformations:
         return _mock_transform_with_args
 
     @pytest.mark.parametrize(
-        "example_config_with_custom_transform,expectation",
+        "example_config_with_custom_transform,expected_error",
         # Fails because mock_transform_function_false doesn't exist
         [
             (
@@ -147,7 +147,7 @@ class TestApplyCustomTransformations:
                         },
                     }
                 },
-                pytest.raises(AttributeError),
+                pytest.raises(AttributeError, match="mock_transform_function_false"),
             ),
             # Fails because mock_transform_function_false doesn't exist
             (
@@ -163,9 +163,9 @@ class TestApplyCustomTransformations:
                         "custom_transformations": "mock_transform_function_false",
                     },
                 },
-                pytest.raises(AttributeError),
+                pytest.raises(AttributeError, match="mock_transform_function_false"),
             ),
-            # Fails because mock_transform_function_false is mapped to an integer
+            # Fails because custom_transformation is mapped to an integer, not a function
             (
                 {
                     "neuropath_corr": {
@@ -179,7 +179,10 @@ class TestApplyCustomTransformations:
                         "custom_transformations": 1,
                     },
                 },
-                pytest.raises(AttributeError),
+                pytest.raises(
+                    TypeError,
+                    match="Custom transformation in the config for dataset 'neuropath_corr' should be mapped to a function name with custom parameters if needed. Received: int",
+                ),
             ),
         ],
         ids=[
@@ -191,10 +194,10 @@ class TestApplyCustomTransformations:
     def test_apply_invalid_custom_transformations(
         self,
         example_config_with_custom_transform: Dict[str, Any],
-        expectation: Exception,
+        expected_error: Exception,
     ) -> None:
         """Test that invalid custom transformations raise an error."""
-        with expectation:
+        with expected_error:
             process.apply_custom_transformations(
                 datasets={"test_file_1": pd.DataFrame()},
                 dataset_name="neuropath_corr",
@@ -224,7 +227,10 @@ class TestApplyCustomTransformations:
                 },
             },
         }
-        with pytest.warns(UserWarning):
+        with pytest.warns(
+            UserWarning,
+            match="Please provide a single custom transformation function in the configuration file. * ",
+        ):
             with patch.object(
                 transform,
                 "special_transform_function",

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -92,27 +92,34 @@ class TestUploadDataversionMetadata:
 
 
 class TestApplyCustomTransformations:
+    """Test the apply_custom_transformations function."""
+
     @pytest.fixture(scope="function", autouse=True)
-    def standard_transform_function(self):
-        """mock simple transform function"""
+    def standard_transform_function(
+        self,
+    ) -> Callable[[pd.DataFrame, str, Dict[str, pd.DataFrame]], pd.DataFrame]:
+        """mock simple transform function that uses standard parameters such as dataframe, dataset_name, datasets"""
 
         def _standard_transform_function(
             df: pd.DataFrame, dataset_name: str, datasets: Dict[str, pd.DataFrame]
         ) -> pd.DataFrame:
             """mock simple transform function"""
-            return df.assign(test_col=2)
+            datasets["new_key"] = 2
+            return df.assign(test_col=2, new_key=dataset_name + "_new_key")
 
         return _standard_transform_function
 
     @pytest.fixture(scope="function", autouse=True)
-    def special_transform_function(self):
-        """mock transform function that takes test_threshold as an argument"""
+    def special_transform_function(
+        self,
+    ) -> Callable[[pd.DataFrame, int, Dict[str, pd.DataFrame]], pd.DataFrame]:
+        """mock transform function that uses additional parameters"""
 
         def _mock_transform_with_args(
             df: pd.DataFrame, test_threshold: int
         ) -> pd.DataFrame:
             """mock transform function that takes test_threshold as an argument"""
-            return df.assign(new_key=1)
+            return df.assign(new_key=1, anoter_new_key=test_threshold)
 
         return _mock_transform_with_args
 
@@ -238,7 +245,13 @@ class TestApplyCustomTransformations:
                 },
                 "standard_transform_function",
                 does_not_raise(),
-                pd.DataFrame({"test_key": ["test_value"], "test_col": [2]}),
+                pd.DataFrame(
+                    {
+                        "test_key": ["test_value"],
+                        "test_col": [2],
+                        "new_key": "test_file_1_new_key",
+                    }
+                ),
             ),
             (
                 {
@@ -257,7 +270,9 @@ class TestApplyCustomTransformations:
                 },
                 "special_transform_function",
                 does_not_raise(),
-                pd.DataFrame({"test_key": ["test_value"], "new_key": [1]}),
+                pd.DataFrame(
+                    {"test_key": ["test_value"], "new_key": [1], "anoter_new_key": 1}
+                ),
             ),
         ],
     )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -209,7 +209,8 @@ class TestProcessDataset:
 
         def _standard_transform_function(
             df: pd.DataFrame, dataset_name: str, datasets: Dict[str, pd.DataFrame]
-        ):
+        ) -> pd.DataFrame:
+            """mock simple transform function"""
             return df.assign(test_col=2)
 
         return _standard_transform_function
@@ -218,7 +219,10 @@ class TestProcessDataset:
     def special_transform_function(self):
         """mock transform function that takes test_threshold as an argument"""
 
-        def _mock_transform_with_args(df: pd.DataFrame, test_threshold: int):
+        def _mock_transform_with_args(
+            df: pd.DataFrame, test_threshold: int
+        ) -> pd.DataFrame:
+            """mock transform function that takes test_threshold as an argument"""
             return df.assign(new_key=1)
 
         return _mock_transform_with_args
@@ -394,11 +398,8 @@ class TestProcessDataset:
         self.patch_format_link.assert_not_called()
         self.patch_load.assert_not_called()
 
-    @patch(
-        "agoradatatools.process.apply_custom_transformations", return_value=pd.DataFrame
-    )
     def test_process_dataset_upload_false_gx_not_specified_column_rename(
-        self, patch_custom_transform, syn: Any
+        self, syn: Any
     ):
         process.process_dataset(
             dataset_obj=self.dataset_object_col_rename,
@@ -419,7 +420,7 @@ class TestProcessDataset:
         self.patch_rename_columns.assert_called_once_with(
             df=pd.DataFrame, column_map={"col_1": "new_col_1", "col_2": "new_col_2"}
         )
-        patch_custom_transform.assert_not_called()
+        self.patch_custom_transform.assert_not_called()
         self.patch_df_to_json.assert_called_once_with(
             df=pd.DataFrame, staging_path=STAGING_PATH, filename="neuropath_corr.json"
         )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -204,8 +204,7 @@ class TestProcessDataset:
         mock.patch.stopall()
 
     @pytest.fixture(scope="function", autouse=True)
-    @staticmethod
-    def standard_transform_function():
+    def standard_transform_function(self):
         """mock simple transform function"""
 
         def _standard_transform_function(
@@ -216,8 +215,7 @@ class TestProcessDataset:
         return _standard_transform_function
 
     @pytest.fixture(scope="function", autouse=True)
-    @staticmethod
-    def special_transform_function():
+    def special_transform_function(self):
         """mock transform function that takes test_threshold as an argument"""
 
         def _mock_transform_with_args(df: pd.DataFrame, test_threshold: int):

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -119,7 +119,7 @@ class TestApplyCustomTransformations:
             df: pd.DataFrame, test_threshold: int
         ) -> pd.DataFrame:
             """mock transform function that takes test_threshold as an argument"""
-            return df.assign(new_key=1, anoter_new_key=test_threshold)
+            return df.assign(new_key=test_threshold)
 
         return _mock_transform_with_args
 
@@ -270,9 +270,7 @@ class TestApplyCustomTransformations:
                 },
                 "special_transform_function",
                 does_not_raise(),
-                pd.DataFrame(
-                    {"test_key": ["test_value"], "new_key": [1], "anoter_new_key": 1}
-                ),
+                pd.DataFrame({"test_key": ["test_value"], "new_key": [1]}),
             ),
         ],
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,6 +39,13 @@ def test_get_config_with_invalid_file_path():
         utils._get_config(config_path="this/is/a/bad/path")
 
 
+def test_get_config_invalid_config_file():
+    with pytest.raises(
+        ValueError, match="YAML file must be loaded as a single dictionary. *"
+    ):
+        utils._get_config(config_path="./tests/test_assets/bad_invalid_config.yaml")
+
+
 def test_get_config_with_parser_error():
     with pytest.raises(
         yaml.parser.ParserError, match="YAML file unable to be parsed. *"


### PR DESCRIPTION
## Problem 
The process.py/apply_custom_transformations method currently uses twelve if statements to map individual datasets to their respective custom transformation functions. This approach makes the logic overly complex and difficult to maintain, especially as new datasets are added.

## Test
Run `adt test_config.yaml` locally 
Run `adt modelad_test_config.yaml` locally 

## Error handling
* If an invalid function was mapped in the config, the following message would get raised: 
As an example, I provided an invalid function in the config: 
```
  - biodomain_info:
      files: *genes_biodomains_files
      final_format: json
      custom_transformations: transform_biodomain_info_wrong
```
the following message got raised: 
```
  File "/Users/lpeng/Documents/agora/agora-data-tools/src/agoradatatools/process.py", line 158, in process_dataset
    df = apply_custom_transformations(
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/lpeng/Documents/agora/agora-data-tools/src/agoradatatools/process.py", line 50, in apply_custom_transformations
    raise AttributeError(
AttributeError: Function transform_biodomain_info_wrong not found in the transform module. Please provide the correct function name.

```