### PR TITLE
Bugfix: Change ensembl_id to ensembl_gene_id in model details

### DIFF
--- a/modelad_test_config.yaml
+++ b/modelad_test_config.yaml
@@ -62,7 +62,8 @@ datasets:
       destination: *dest
       custom_transformations: transform_model_details
       column_rename:
-        gene_symbol: gene
+        gene: modified_gene
+        gene_symbol: modified_gene
         ensembl_id: human_ensembl_id
 
   - ui_config:

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -96,7 +96,7 @@ def process_genetic_info(
     )
     return (
         merged_df[["gene", "ensembl_id", "allele", "allele_type", "mgi_allele_id"]]
-        .rename(columns={"gene": "modified_gene"})
+        .rename(columns={"gene": "modified_gene", "ensembl_id": "ensembl_gene_id"})
         .to_dict(orient="records")
     )
 

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -85,18 +85,17 @@ def process_genetic_info(
 
     # Merge the dataframes on mgi_allele_id and gene
     merged_df = model_alleles.merge(
-        human_transgene_allele_map_df[["mgi_allele_id", "gene", "human_ensembl_id"]],
-        on=["mgi_allele_id", "gene"],
+        human_transgene_allele_map_df[["mgi_allele_id", "modified_gene", "human_ensembl_id"]],
+        on=["mgi_allele_id", "modified_gene"],
         how="left",
     )
 
     # Create the genetic info list using vectorized operations
-    merged_df["ensembl_id"] = merged_df["human_ensembl_id"].fillna(
+    merged_df["ensembl_gene_id"] = merged_df["human_ensembl_id"].fillna(
         merged_df["gene_ensembl_id"]
     )
     return (
-        merged_df[["gene", "ensembl_id", "allele", "allele_type", "mgi_allele_id"]]
-        .rename(columns={"gene": "modified_gene", "ensembl_id": "ensembl_gene_id"})
+        merged_df[["modified_gene", "ensembl_gene_id", "allele", "allele_type", "mgi_allele_id"]]
         .to_dict(orient="records")
     )
 
@@ -150,7 +149,7 @@ def transform_model_details(datasets: Dict[str, pd.DataFrame]) -> List[Dict[str,
     required_columns = {
         "allele_info": [
             "model",
-            "gene",
+            "modified_gene",
             "gene_ensembl_id",
             "allele",
             "allele_type",
@@ -168,7 +167,7 @@ def transform_model_details(datasets: Dict[str, pd.DataFrame]) -> List[Dict[str,
             "genotype",
             "aliases",
         ],
-        "human_transgene_allele_map": ["mgi_allele_id", "gene", "human_ensembl_id"],
+        "human_transgene_allele_map": ["mgi_allele_id", "modified_gene", "human_ensembl_id"],
         "biomarkers": [
             "model",
             "type",

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -85,7 +85,9 @@ def process_genetic_info(
 
     # Merge the dataframes on mgi_allele_id and gene
     merged_df = model_alleles.merge(
-        human_transgene_allele_map_df[["mgi_allele_id", "modified_gene", "human_ensembl_id"]],
+        human_transgene_allele_map_df[
+            ["mgi_allele_id", "modified_gene", "human_ensembl_id"]
+        ],
         on=["mgi_allele_id", "modified_gene"],
         how="left",
     )
@@ -94,10 +96,9 @@ def process_genetic_info(
     merged_df["ensembl_gene_id"] = merged_df["human_ensembl_id"].fillna(
         merged_df["gene_ensembl_id"]
     )
-    return (
-        merged_df[["modified_gene", "ensembl_gene_id", "allele", "allele_type", "mgi_allele_id"]]
-        .to_dict(orient="records")
-    )
+    return merged_df[
+        ["modified_gene", "ensembl_gene_id", "allele", "allele_type", "mgi_allele_id"]
+    ].to_dict(orient="records")
 
 
 def transform_model_details(datasets: Dict[str, pd.DataFrame]) -> List[Dict[str, Any]]:
@@ -167,7 +168,11 @@ def transform_model_details(datasets: Dict[str, pd.DataFrame]) -> List[Dict[str,
             "genotype",
             "aliases",
         ],
-        "human_transgene_allele_map": ["mgi_allele_id", "modified_gene", "human_ensembl_id"],
+        "human_transgene_allele_map": [
+            "mgi_allele_id",
+            "modified_gene",
+            "human_ensembl_id",
+        ],
         "biomarkers": [
             "model",
             "type",

--- a/tests/test_assets/model_details/input/model_details_allele_info_good_test_input.csv
+++ b/tests/test_assets/model_details/input/model_details_allele_info_good_test_input.csv
@@ -1,4 +1,4 @@
-model,gene,mgi_gene_id,gene_ensembl_id,allele,allele_type,mgi_allele_id
+model,modified_gene,mgi_gene_id,gene_ensembl_id,allele,allele_type,mgi_allele_id
 3xTg-AD,App,11820,ENSMUSG00000022892,APP K670_M671delinsNL (Swedish),Transgenic,2672831
 3xTg-AD,Mapt,17762,ENSMUSG00000018411,MAPT P301L,Transgenic,2672831
 3xTg-AD,Psen1,19164,ENSMUSG00000019969,Psen1<sup>tm1Mpm</sup>,Targeted,1930937

--- a/tests/test_assets/model_details/input/model_details_allele_info_missing_data_input.csv
+++ b/tests/test_assets/model_details/input/model_details_allele_info_missing_data_input.csv
@@ -1,4 +1,4 @@
-model,gene,mgi_gene_id,gene_ensembl_id,allele,allele_type,mgi_allele_id
+model,modified_gene,mgi_gene_id,gene_ensembl_id,allele,allele_type,mgi_allele_id
 ,App,11820,ENSMUSG00000022892,APP K670_M671delinsNL (Swedish),Transgenic,2672831
 3xTg-AD,,17762,ENSMUSG00000018411,MAPT P301L,Transgenic,2672831
 3xTg-AD,Psen1,,ENSMUSG00000019969,Psen1<sup>tm1Mpm</sup>,Targeted,1930937

--- a/tests/test_assets/model_details/input/model_details_allele_info_missing_models_test.csv
+++ b/tests/test_assets/model_details/input/model_details_allele_info_missing_models_test.csv
@@ -1,4 +1,4 @@
-model,gene,gene_ensembl_id,allele,allele_type,mgi_allele_id
+model,modified_gene,gene_ensembl_id,allele,allele_type,mgi_allele_id
 3xTg-AD,App,ENSMUSG00000022892,APP K670_M671delinsNL (Swedish),Transgenic,2672831
 3xTg-AD,Mapt,ENSMUSG00000018411,MAPT P301L,Transgenic,2672831
 3xTg-AD,Psen1,ENSMUSG00000019969,Psen1<sup>tm1Mpm</sup>,Targeted,1930937

--- a/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_good_test_input.csv
+++ b/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_good_test_input.csv
@@ -1,4 +1,4 @@
-mgi_allele_id,gene,human_ensembl_id
+mgi_allele_id,modified_gene,human_ensembl_id
 2672831,App,ENSG00000142192
 3057560,MAPT,ENSG00000186868
 1930937,Psen1,ENSG00000080815

--- a/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_missing_models_test.csv
+++ b/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_missing_models_test.csv
@@ -1,4 +1,4 @@
-mgi_allele_id,gene,human_ensembl_id
+mgi_allele_id,modified_gene,human_ensembl_id
 2672831,APP,ENSG00000142192
 1926153,MAPT,ENSG00000186868
 3057560,MAPT,ENSG00000186868

--- a/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_no_match_input.csv
+++ b/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_no_match_input.csv
@@ -1,4 +1,4 @@
-mgi_allele_id,gene,human_ensembl_id
+mgi_allele_id,modified_gene,human_ensembl_id
 9999999,App,ENSG00000142192
 8888888,MAPT,ENSG00000186868
 7777777,Psen1,ENSG00000080815

--- a/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
@@ -17,21 +17,21 @@
     "genetic_info": [
       {
         "modified_gene": "App",
-        "ensembl_id": "ENSG00000142192",
+        "ensembl_gene_id": "ENSG00000142192",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "MAPT P301L",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Psen1",
-        "ensembl_id": "ENSG00000080815",
+        "ensembl_gene_id": "ENSG00000080815",
         "allele": "Psen1<sup>tm1Mpm</sup>",
         "allele_type": "Targeted",
         "mgi_allele_id": 1930937
@@ -59,14 +59,14 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153
       },
       {
         "modified_gene": "MAPT",
-        "ensembl_id": "ENSG00000186868",
+        "ensembl_gene_id": "ENSG00000186868",
         "allele": "MAPT",
         "allele_type": "Transgenic",
         "mgi_allele_id": 3057560

--- a/tests/test_assets/model_details/output/model_details_transform_extra_column_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_extra_column_output.json
@@ -17,21 +17,21 @@
     "genetic_info": [
       {
         "modified_gene": "App",
-        "ensembl_id": "ENSG00000142192",
+        "ensembl_gene_id": "ENSG00000142192",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "MAPT P301L",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Psen1",
-        "ensembl_id": "ENSG00000080815",
+        "ensembl_gene_id": "ENSG00000080815",
         "allele": "Psen1<sup>tm1Mpm</sup>",
         "allele_type": "Targeted",
         "mgi_allele_id": 1930937
@@ -193,14 +193,14 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153
       },
       {
         "modified_gene": "MAPT",
-        "ensembl_id": "ENSG00000186868",
+        "ensembl_gene_id": "ENSG00000186868",
         "allele": "MAPT",
         "allele_type": "Transgenic",
         "mgi_allele_id": 3057560

--- a/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
@@ -17,21 +17,21 @@
     "genetic_info": [
       {
         "modified_gene": "App",
-        "ensembl_id": "ENSG00000142192",
+        "ensembl_gene_id": "ENSG00000142192",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "MAPT P301L",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Psen1",
-        "ensembl_id": "ENSG00000080815",
+        "ensembl_gene_id": "ENSG00000080815",
         "allele": "Psen1<sup>tm1Mpm</sup>",
         "allele_type": "Targeted",
         "mgi_allele_id": 1930937
@@ -193,14 +193,14 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153
       },
       {
         "modified_gene": "MAPT",
-        "ensembl_id": "ENSG00000186868",
+        "ensembl_gene_id": "ENSG00000186868",
         "allele": "MAPT",
         "allele_type": "Transgenic",
         "mgi_allele_id": 3057560

--- a/tests/test_assets/model_details/output/model_details_transform_missing_allele_info_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_allele_info_output.json
@@ -17,14 +17,14 @@
     "genetic_info": [
       {
         "modified_gene": "",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "MAPT P301L",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Psen1",
-        "ensembl_id": "ENSG00000080815",
+        "ensembl_gene_id": "ENSG00000080815",
         "allele": "Psen1<sup>tm1Mpm</sup>",
         "allele_type": "Targeted",
         "mgi_allele_id": 1930937
@@ -186,14 +186,14 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "",
+        "ensembl_gene_id": "",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153
       },
       {
         "modified_gene": "MAPT",
-        "ensembl_id": "ENSG00000186868",
+        "ensembl_gene_id": "ENSG00000186868",
         "allele": "",
         "allele_type": "Transgenic",
         "mgi_allele_id": 3057560

--- a/tests/test_assets/model_details/output/model_details_transform_missing_data_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_data_output.json
@@ -15,21 +15,21 @@
     "genetic_info": [
       {
         "modified_gene": "App",
-        "ensembl_id": "ENSG00000142192",
+        "ensembl_gene_id": "ENSG00000142192",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "MAPT P301L",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Psen1",
-        "ensembl_id": "ENSG00000080815",
+        "ensembl_gene_id": "ENSG00000080815",
         "allele": "Psen1<sup>tm1Mpm</sup>",
         "allele_type": "Targeted",
         "mgi_allele_id": 1930937
@@ -171,14 +171,14 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153
       },
       {
         "modified_gene": "MAPT",
-        "ensembl_id": "ENSG00000186868",
+        "ensembl_gene_id": "ENSG00000186868",
         "allele": "MAPT",
         "allele_type": "Transgenic",
         "mgi_allele_id": 3057560

--- a/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
@@ -17,21 +17,21 @@
     "genetic_info": [
       {
         "modified_gene": "App",
-        "ensembl_id": "ENSMUSG00000022892",
+        "ensembl_gene_id": "ENSMUSG00000022892",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "MAPT P301L",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Psen1",
-        "ensembl_id": "ENSMUSG00000019969",
+        "ensembl_gene_id": "ENSMUSG00000019969",
         "allele": "Psen1<sup>tm1Mpm</sup>",
         "allele_type": "Targeted",
         "mgi_allele_id": 1930937
@@ -193,14 +193,14 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153
       },
       {
         "modified_gene": "MAPT",
-        "ensembl_id": "ENSG00000186868",
+        "ensembl_gene_id": "ENSG00000186868",
         "allele": "MAPT",
         "allele_type": "Transgenic",
         "mgi_allele_id": 3057560
@@ -301,7 +301,7 @@
     "genetic_info": [
       {
         "modified_gene": "App",
-        "ensembl_id": "ENSMUSG00000022892",
+        "ensembl_gene_id": "ENSMUSG00000022892",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
@@ -344,7 +344,7 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153

--- a/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
@@ -17,21 +17,21 @@
     "genetic_info": [
       {
         "modified_gene": "App",
-        "ensembl_id": "ENSMUSG00000022892",
+        "ensembl_gene_id": "ENSMUSG00000022892",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "MAPT P301L",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },
       {
         "modified_gene": "Psen1",
-        "ensembl_id": "ENSMUSG00000019969",
+        "ensembl_gene_id": "ENSMUSG00000019969",
         "allele": "Psen1<sup>tm1Mpm</sup>",
         "allele_type": "Targeted",
         "mgi_allele_id": 1930937
@@ -193,14 +193,14 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153
       },
       {
         "modified_gene": "MAPT",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "MAPT",
         "allele_type": "Transgenic",
         "mgi_allele_id": 3057560

--- a/tests/transform/test_model_details.py
+++ b/tests/transform/test_model_details.py
@@ -432,21 +432,21 @@ class TestTransformModelDetails:
         expected_output = [
             {
                 "modified_gene": "App",
-                "ensembl_id": "ENSG00000142192",  # Human Ensembl ID
+                "ensembl_gene_id": "ENSG00000142192",  # Human Ensembl ID
                 "allele": "APP K670_M671delinsNL (Swedish)",
                 "allele_type": "Transgenic",
                 "mgi_allele_id": 2672831,
             },
             {
                 "modified_gene": "Mapt",
-                "ensembl_id": "ENSMUSG00000018411",  # Mouse Ensembl ID (no human match)
+                "ensembl_gene_id": "ENSMUSG00000018411",  # Mouse Ensembl ID (no human match)
                 "allele": "MAPT P301L",
                 "allele_type": "Transgenic",
                 "mgi_allele_id": 2672831,
             },
             {
                 "modified_gene": "Psen1",
-                "ensembl_id": "ENSG00000080815",  # Human Ensembl ID
+                "ensembl_gene_id": "ENSG00000080815",  # Human Ensembl ID
                 "allele": "Psen1<sup>tm1Mpm</sup>",
                 "allele_type": "Targeted",
                 "mgi_allele_id": 1930937,
@@ -491,21 +491,21 @@ class TestTransformModelDetails:
         expected_output = [
             {
                 "modified_gene": "App",
-                "ensembl_id": "ENSMUSG00000022892",
+                "ensembl_gene_id": "ENSMUSG00000022892",
                 "allele": "APP K670_M671delinsNL (Swedish)",
                 "allele_type": "Transgenic",
                 "mgi_allele_id": 2672831,
             },
             {
                 "modified_gene": "Mapt",
-                "ensembl_id": "ENSMUSG00000018411",
+                "ensembl_gene_id": "ENSMUSG00000018411",
                 "allele": "MAPT P301L",
                 "allele_type": "Transgenic",
                 "mgi_allele_id": 2672831,
             },
             {
                 "modified_gene": "Psen1",
-                "ensembl_id": "ENSMUSG00000019969",
+                "ensembl_gene_id": "ENSMUSG00000019969",
                 "allele": "Psen1<sup>tm1Mpm</sup>",
                 "allele_type": "Targeted",
                 "mgi_allele_id": 1930937,

--- a/tests/transform/test_model_details.py
+++ b/tests/transform/test_model_details.py
@@ -405,14 +405,14 @@ class TestTransformModelDetails:
         human_transgene_allele_map_df = pd.DataFrame(
             {
                 "mgi_allele_id": [2672831, 1930937],
-                "gene": ["App", "Psen1"],
+                "modified_gene": ["App", "Psen1"],
                 "human_ensembl_id": ["ENSG00000142192", "ENSG00000080815"],
             }
         )
 
         model_alleles = pd.DataFrame(
             {
-                "gene": ["App", "Mapt", "Psen1"],
+                "modified_gene": ["App", "Mapt", "Psen1"],
                 "gene_ensembl_id": [
                     "ENSMUSG00000022892",
                     "ENSMUSG00000018411",
@@ -464,14 +464,14 @@ class TestTransformModelDetails:
         human_transgene_allele_map_df = pd.DataFrame(
             {
                 "mgi_allele_id": [9999999],  # Different MGI ID
-                "gene": ["DifferentGene"],
+                "modified_gene": ["DifferentGene"],
                 "human_ensembl_id": ["ENSG00000000000"],
             }
         )
 
         model_alleles = pd.DataFrame(
             {
-                "gene": ["App", "Mapt", "Psen1"],
+                "modified_gene": ["App", "Mapt", "Psen1"],
                 "gene_ensembl_id": [
                     "ENSMUSG00000022892",
                     "ENSMUSG00000018411",
@@ -521,11 +521,11 @@ class TestTransformModelDetails:
     def test_process_genetic_info_with_empty_input(self):
         # Create empty test input DataFrames
         human_transgene_allele_map_df = pd.DataFrame(
-            columns=["mgi_allele_id", "gene", "human_ensembl_id"]
+            columns=["mgi_allele_id", "modified_gene", "human_ensembl_id"]
         )
         model_alleles = pd.DataFrame(
             columns=[
-                "gene",
+                "modified_gene",
                 "gene_ensembl_id",
                 "allele",
                 "allele_type",


### PR DESCRIPTION
[Jira Ticket](https://sagebionetworks.jira.com/browse/MG-228)
## Problem
The model details transformation was using an inconsistent field name `ensembl_id` in the genetic information output, while the rest of the codebase has standardized on using `ensembl_gene_id`. This inconsistency could cause issues with downstream data integration.

## Solution
- Updated the field name in the `process_genetic_info` function to use `ensembl_gene_id` instead of `ensembl_id`
- The change maintains the same functionality but ensures consistency with the rest of the codebase's naming conventions
- The transformation still correctly handles both human transgene and regular gene cases, just with the standardized field name

## Testing
The changes were tested to ensure:
1. The genetic information transformation still correctly processes both human transgene and regular gene cases
2. The field name change doesn't affect any downstream processing
3. The output format remains consistent with the expected schema
4. All existing data transformations continue to work as expected

## Impact
This is a low-risk change that only affects the field name in the output, not the underlying data or transformation logic.