### PR TITLE
Bugfix: Fixed allele mapping problem in model details caused by case sensitivity

### DIFF
--- a/modelad_test_config.yaml
+++ b/modelad_test_config.yaml
@@ -63,7 +63,6 @@ datasets:
       custom_transformations: transform_model_details
       column_rename:
         gene: modified_gene
-        gene_symbol: modified_gene
         ensembl_id: human_ensembl_id
 
   - ui_config:

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -84,6 +84,8 @@ def process_genetic_info(
         List[Dict[str, Any]]: A list of dictionaries containing the processed gene information.
     """
     # Copy dataframes to avoid modifying originals
+    # Using copy() to avoid warning: A value is trying to be set on a copy of a slice from a DataFrame.
+    # Warning appears even if using .loc to set the value.
     model_alleles = model_alleles.copy()
     human_transgene_allele_map_df = human_transgene_allele_map_df.copy()
 

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -82,21 +82,39 @@ def process_genetic_info(
     Returns:
         List[Dict[str, Any]]: A list of dictionaries containing the processed gene information.
     """
+    # Copy dataframes to avoid modifying originals
+    model_alleles = model_alleles.copy()
+    human_transgene_allele_map_df = human_transgene_allele_map_df.copy()
 
-    # Merge the dataframes on mgi_allele_id and gene
+    # Store original gene names
+    model_alleles["gene_original"] = model_alleles["gene"]
+
+    # Normalize gene columns to uppercase for consistent merging
+    model_alleles["gene_upper"] = model_alleles["gene"].str.upper()
+    human_transgene_allele_map_df["gene_upper"] = human_transgene_allele_map_df[
+        "gene"
+    ].str.upper()
+
+    # Merge on mgi_allele_id and gene_upper
     merged_df = model_alleles.merge(
-        human_transgene_allele_map_df[["mgi_allele_id", "gene", "human_ensembl_id"]],
-        on=["mgi_allele_id", "gene"],
+        human_transgene_allele_map_df[
+            ["mgi_allele_id", "gene_upper", "human_ensembl_id"]
+        ],
+        on=["mgi_allele_id", "gene_upper"],
         how="left",
     )
 
-    # Create the genetic info list using vectorized operations
+    # Override ensembl_id if mapping exists
     merged_df["ensembl_id"] = merged_df["human_ensembl_id"].fillna(
         merged_df["gene_ensembl_id"]
     )
+
+    # Use the original gene name for output
     return (
-        merged_df[["gene", "ensembl_id", "allele", "allele_type", "mgi_allele_id"]]
-        .rename(columns={"gene": "modified_gene"})
+        merged_df[
+            ["gene_original", "ensembl_id", "allele", "allele_type", "mgi_allele_id"]
+        ]
+        .rename(columns={"gene_original": "modified_gene"})
         .to_dict(orient="records")
     )
 

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -86,9 +86,6 @@ def process_genetic_info(
     model_alleles = model_alleles.copy()
     human_transgene_allele_map_df = human_transgene_allele_map_df.copy()
 
-    # Store original gene names
-    model_alleles["gene_original"] = model_alleles["gene"]
-
     # Normalize gene columns to uppercase for consistent merging
     model_alleles["gene_upper"] = model_alleles["gene"].str.upper()
     human_transgene_allele_map_df["gene_upper"] = human_transgene_allele_map_df[
@@ -112,9 +109,9 @@ def process_genetic_info(
     # Use the original gene name for output
     return (
         merged_df[
-            ["gene_original", "ensembl_id", "allele", "allele_type", "mgi_allele_id"]
+            ["gene", "ensembl_id", "allele", "allele_type", "mgi_allele_id"]
         ]
-        .rename(columns={"gene_original": "modified_gene"})
+        .rename(columns={"gene": "modified_gene"})
         .to_dict(orient="records")
     )
 

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -73,7 +73,8 @@ def process_genetic_info(
 ) -> List[Dict[str, Any]]:
     """
     Processes the gene information DataFrame. If the allele is a human transgene,
-    replace the ensembl_id with the human one.
+    replace the ensembl_id with the human one. Each model's alleles are processed independently.
+    Multiple entries are preserved for different alleles of the same gene.
 
     Args:
         human_transgene_allele_map_df (pd.DataFrame): The DataFrame containing the human transgene allele information.
@@ -92,7 +93,7 @@ def process_genetic_info(
         "modified_gene"
     ].str.upper()
 
-    # Merge on mgi_allele_id and gene_upper
+    # Merge on mgi_allele_id and gene_upper to ensure we preserve different alleles
     merged_df = model_alleles.merge(
         human_transgene_allele_map_df[
             ["mgi_allele_id", "gene_upper", "human_ensembl_id"]
@@ -101,9 +102,17 @@ def process_genetic_info(
         how="left",
     )
 
-    # Override ensembl_id if mapping exists
-    merged_df["ensembl_gene_id"] = merged_df["human_ensembl_id"].fillna(
-        merged_df["gene_ensembl_id"]
+    # Only override ensembl_id if we have a valid human_ensembl_id
+    merged_df["ensembl_gene_id"] = merged_df.apply(
+        lambda row: row["human_ensembl_id"]
+        if pd.notna(row["human_ensembl_id"])
+        else row["gene_ensembl_id"],
+        axis=1,
+    )
+
+    # Drop duplicates to ensure we don't have exact duplicates of the same allele
+    merged_df = merged_df.drop_duplicates(
+        subset=["modified_gene", "allele", "mgi_allele_id"]
     )
 
     return merged_df[

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -90,13 +90,13 @@ def process_genetic_info(
     # Normalize gene columns to uppercase for consistent merging
     model_alleles["gene_upper"] = model_alleles["modified_gene"].str.upper()
     human_transgene_allele_map_df["gene_upper"] = human_transgene_allele_map_df[
-        "modified_gene"
+        "gene_symbol"
     ].str.upper()
 
     # Merge on mgi_allele_id and gene_upper to ensure we preserve different alleles
     merged_df = model_alleles.merge(
         human_transgene_allele_map_df[
-            ["mgi_allele_id", "gene_upper", "human_ensembl_id"]
+            ["mgi_allele_id", "gene_upper", "human_ensembl_id", "gene_symbol"]
         ],
         on=["mgi_allele_id", "gene_upper"],
         how="left",
@@ -189,7 +189,7 @@ def transform_model_details(datasets: Dict[str, pd.DataFrame]) -> List[Dict[str,
         ],
         "human_transgene_allele_map": [
             "mgi_allele_id",
-            "modified_gene",
+            "gene_symbol",
             "human_ensembl_id",
         ],
         "biomarkers": [

--- a/tests/test_assets/model_details/input/model_details_allele_info_good_test_input.csv
+++ b/tests/test_assets/model_details/input/model_details_allele_info_good_test_input.csv
@@ -1,5 +1,7 @@
 model,modified_gene,mgi_gene_id,gene_ensembl_id,allele,allele_type,mgi_allele_id
-3xTg-AD,App,11820,ENSMUSG00000022892,APP K670_M671delinsNL (Swedish),Transgenic,2672831
+3xTg-AD,App,11820,ENSMUSG00000022892,Allele1,Transgenic,2672831
+3xTg-AD,App,11820,ENSMUSG00000022892,Allele2,Transgenic,2672831
+3xTg-AD,App,11820,ENSMUSG00000022892,Allele3,Transgenic,2672831
 3xTg-AD,Mapt,17762,ENSMUSG00000018411,MAPT P301L,Transgenic,2672831
 3xTg-AD,Psen1,19164,ENSMUSG00000019969,Psen1<sup>tm1Mpm</sup>,Targeted,1930937
 hTau,Mapt,17762,ENSMUSG00000018411,Mapttm1(EGFP)Klt,Targeted,1926153

--- a/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_good_test_input.csv
+++ b/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_good_test_input.csv
@@ -1,4 +1,4 @@
-mgi_allele_id,modified_gene,human_ensembl_id
+mgi_allele_id,gene_symbol,human_ensembl_id
 2672831,App,ENSG00000142192
 3057560,MAPT,ENSG00000186868
 1930937,Psen1,ENSG00000080815

--- a/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_missing_models_test.csv
+++ b/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_missing_models_test.csv
@@ -1,4 +1,4 @@
-mgi_allele_id,modified_gene,human_ensembl_id
+mgi_allele_id,gene_symbol,human_ensembl_id
 2672831,APP,ENSG00000142192
 1926153,MAPT,ENSG00000186868
 3057560,MAPT,ENSG00000186868

--- a/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_no_match_input.csv
+++ b/tests/test_assets/model_details/input/model_details_human_transgene_allele_map_no_match_input.csv
@@ -1,4 +1,4 @@
-mgi_allele_id,modified_gene,human_ensembl_id
+mgi_allele_id,gene_symbol,human_ensembl_id
 9999999,App,ENSG00000142192
 8888888,MAPT,ENSG00000186868
 7777777,Psen1,ENSG00000080815

--- a/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
@@ -18,7 +18,21 @@
       {
         "modified_gene": "App",
         "ensembl_gene_id": "ENSG00000142192",
-        "allele": "APP K670_M671delinsNL (Swedish)",
+        "allele": "Allele1",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSG00000142192",
+        "allele": "Allele2",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSG00000142192",
+        "allele": "Allele3",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },

--- a/tests/test_assets/model_details/output/model_details_transform_extra_column_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_extra_column_output.json
@@ -18,7 +18,21 @@
       {
         "modified_gene": "App",
         "ensembl_gene_id": "ENSG00000142192",
-        "allele": "APP K670_M671delinsNL (Swedish)",
+        "allele": "Allele1",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSG00000142192",
+        "allele": "Allele2",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSG00000142192",
+        "allele": "Allele3",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },

--- a/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
@@ -18,7 +18,21 @@
       {
         "modified_gene": "App",
         "ensembl_gene_id": "ENSG00000142192",
-        "allele": "APP K670_M671delinsNL (Swedish)",
+        "allele": "Allele1",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSG00000142192",
+        "allele": "Allele2",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSG00000142192",
+        "allele": "Allele3",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },

--- a/tests/test_assets/model_details/output/model_details_transform_missing_data_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_data_output.json
@@ -16,7 +16,21 @@
       {
         "modified_gene": "App",
         "ensembl_gene_id": "ENSG00000142192",
-        "allele": "APP K670_M671delinsNL (Swedish)",
+        "allele": "Allele1",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSG00000142192",
+        "allele": "Allele2",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSG00000142192",
+        "allele": "Allele3",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },

--- a/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
@@ -23,13 +23,6 @@
         "mgi_allele_id": 2672831
       },
       {
-        "modified_gene": "App",
-        "ensembl_gene_id": "ENSG00000142192",
-        "allele": "APP K670_M671delinsNL (Swedish)",
-        "allele_type": "Transgenic",
-        "mgi_allele_id": 2672831
-      },
-      {
         "modified_gene": "Mapt",
         "ensembl_gene_id": "ENSMUSG00000018411",
         "allele": "MAPT P301L",
@@ -206,13 +199,6 @@
         "mgi_allele_id": 1926153
       },
       {
-        "modified_gene": "Mapt",
-        "ensembl_gene_id": "ENSG00000186868",
-        "allele": "Mapttm1(EGFP)Klt",
-        "allele_type": "Targeted",
-        "mgi_allele_id": 1926153
-      },
-      {
         "modified_gene": "MAPT",
         "ensembl_gene_id": "ENSG00000186868",
         "allele": "MAPT",
@@ -319,13 +305,6 @@
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
-      },
-      {
-        "modified_gene": "App",
-        "ensembl_gene_id": "ENSG00000142192",
-        "allele": "APP K670_M671delinsNL (Swedish)",
-        "allele_type": "Transgenic",
-        "mgi_allele_id": 2672831
       }
     ],
     "biomarkers": [],
@@ -363,13 +342,6 @@
       "New2"
     ],
     "genetic_info": [
-      {
-        "modified_gene": "Mapt",
-        "ensembl_gene_id": "ENSG00000186868",
-        "allele": "Mapttm1(EGFP)Klt",
-        "allele_type": "Targeted",
-        "mgi_allele_id": 1926153
-      },
       {
         "modified_gene": "Mapt",
         "ensembl_gene_id": "ENSG00000186868",

--- a/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
@@ -17,7 +17,14 @@
     "genetic_info": [
       {
         "modified_gene": "App",
-        "ensembl_id": "ENSMUSG00000022892",
+        "ensembl_id": "ENSG00000142192",
+        "allele": "APP K670_M671delinsNL (Swedish)",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_id": "ENSG00000142192",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
@@ -193,7 +200,14 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_id": "ENSG00000186868",
+        "allele": "Mapttm1(EGFP)Klt",
+        "allele_type": "Targeted",
+        "mgi_allele_id": 1926153
+      },
+      {
+        "modified_gene": "Mapt",
+        "ensembl_id": "ENSG00000186868",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153
@@ -301,7 +315,14 @@
     "genetic_info": [
       {
         "modified_gene": "App",
-        "ensembl_id": "ENSMUSG00000022892",
+        "ensembl_id": "ENSG00000142192",
+        "allele": "APP K670_M671delinsNL (Swedish)",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_id": "ENSG00000142192",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
@@ -344,7 +365,14 @@
     "genetic_info": [
       {
         "modified_gene": "Mapt",
-        "ensembl_id": "ENSMUSG00000018411",
+        "ensembl_id": "ENSG00000186868",
+        "allele": "Mapttm1(EGFP)Klt",
+        "allele_type": "Targeted",
+        "mgi_allele_id": 1926153
+      },
+      {
+        "modified_gene": "Mapt",
+        "ensembl_id": "ENSG00000186868",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
         "mgi_allele_id": 1926153

--- a/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
@@ -18,7 +18,21 @@
       {
         "modified_gene": "App",
         "ensembl_gene_id": "ENSMUSG00000022892",
-        "allele": "APP K670_M671delinsNL (Swedish)",
+        "allele": "Allele1",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSMUSG00000022892",
+        "allele": "Allele2",
+        "allele_type": "Transgenic",
+        "mgi_allele_id": 2672831
+      },
+      {
+        "modified_gene": "App",
+        "ensembl_gene_id": "ENSMUSG00000022892",
+        "allele": "Allele3",
         "allele_type": "Transgenic",
         "mgi_allele_id": 2672831
       },

--- a/tests/transform/test_model_details.py
+++ b/tests/transform/test_model_details.py
@@ -406,7 +406,7 @@ class TestTransformModelDetails:
         human_transgene_allele_map_df = pd.DataFrame(
             {
                 "mgi_allele_id": [2672831, 1930937],
-                "modified_gene": ["App", "Psen1"],
+                "gene_symbol": ["App", "Psen1"],
                 "human_ensembl_id": ["ENSG00000142192", "ENSG00000080815"],
             }
         )
@@ -465,7 +465,7 @@ class TestTransformModelDetails:
         human_transgene_allele_map_df = pd.DataFrame(
             {
                 "mgi_allele_id": [9999999],  # Different MGI ID
-                "modified_gene": ["DifferentGene"],
+                "gene_symbol": ["DifferentGene"],
                 "human_ensembl_id": ["ENSG00000000000"],
             }
         )
@@ -522,7 +522,7 @@ class TestTransformModelDetails:
     def test_process_genetic_info_with_empty_input(self):
         # Create empty test input DataFrames
         human_transgene_allele_map_df = pd.DataFrame(
-            columns=["mgi_allele_id", "modified_gene", "human_ensembl_id"]
+            columns=["mgi_allele_id", "gene_symbol", "human_ensembl_id"]
         )
         model_alleles = pd.DataFrame(
             columns=[
@@ -548,7 +548,7 @@ class TestTransformModelDetails:
         human_transgene_allele_map_df = pd.DataFrame(
             {
                 "mgi_allele_id": [1234567, 1234567],
-                "modified_gene": ["APP", "mapt"],  # Upper and lower case in mapping
+                "gene_symbol": ["APP", "mapt"],  # Upper and lower case in mapping
                 "human_ensembl_id": ["ENSG00000123456", "ENSG00000987654"],
             }
         )

--- a/tests/transform/test_model_details.py
+++ b/tests/transform/test_model_details.py
@@ -541,3 +541,53 @@ class TestTransformModelDetails:
 
         # Compare output with expected
         assert output == expected_output
+
+    def test_process_genetic_info_case_insensitive_mapping(self):
+        # Create test input DataFrames with different gene casing
+        human_transgene_allele_map_df = pd.DataFrame(
+            {
+                "mgi_allele_id": [1234567, 1234567],
+                "gene": ["APP", "mapt"],  # Upper and lower case in mapping
+                "human_ensembl_id": ["ENSG00000123456", "ENSG00000987654"],
+            }
+        )
+
+        model_alleles = pd.DataFrame(
+            {
+                "gene": ["App", "Mapt"],  # Title case in alleles
+                "gene_ensembl_id": [
+                    "ENSMUSG00000011111",
+                    "ENSMUSG00000022222",
+                ],
+                "allele": [
+                    "APP Example Allele",
+                    "MAPT Example Allele",
+                ],
+                "allele_type": ["Transgenic", "Transgenic"],
+                "mgi_allele_id": [1234567, 1234567],
+            }
+        )
+
+        # Expected output: ENSG IDs should be mapped, gene names should keep original case
+        expected_output = [
+            {
+                "modified_gene": "App",
+                "ensembl_id": "ENSG00000123456",
+                "allele": "APP Example Allele",
+                "allele_type": "Transgenic",
+                "mgi_allele_id": 1234567,
+            },
+            {
+                "modified_gene": "Mapt",
+                "ensembl_id": "ENSG00000987654",
+                "allele": "MAPT Example Allele",
+                "allele_type": "Transgenic",
+                "mgi_allele_id": 1234567,
+            },
+        ]
+
+        # Transform data
+        output = process_genetic_info(human_transgene_allele_map_df, model_alleles)
+
+        # Compare output with expected
+        assert output == expected_output

--- a/tests/transform/test_model_details.py
+++ b/tests/transform/test_model_details.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 import pandas as pd
 import pytest
@@ -158,15 +159,15 @@ class TestTransformModelDetails:
 
         # Transform data
         output_data = transform_model_details(datasets=datasets)
-        output_df = pd.DataFrame(output_data)
 
         # Load expected output
-        expected_df = pd.read_json(
-            os.path.join(self.data_files_path, "output", expected_output_file),
-        )
+        with open(
+            os.path.join(self.data_files_path, "output", expected_output_file)
+        ) as f:
+            expected_data = json.load(f)
 
         # Compare output with expected
-        pd.testing.assert_frame_equal(output_df, expected_df)
+        assert output_data == expected_data
 
     @pytest.mark.parametrize(
         "input_files, error_type",


### PR DESCRIPTION
[Jira Ticket](https://sagebionetworks.jira.com/browse/MG-227)

## Problem

The `model_details` ETL pipeline was not correctly applying human Ensembl gene (ENSG) overrides for certain MGI alleles as specified in the `human_transgene_allele_map.csv` mapping file. Specifically, for alleles present in the mapping file, the output was still using the default mouse Ensembl gene IDs (ENSMUSG), rather than the expected human ENSG values.

The mapping logic was case-sensitive, causing failures to match gene symbols when the case differed between the mapping file and the allele info input.

## Solution

- **Case-Insensitive Mapping:**  
  The `process_genetic_info` function was updated to perform a case-insensitive merge between the allele info and the mapping file by temporarily converting gene symbols to uppercase for the join. The original gene symbol casing is preserved in the output.
- **Override Logic:**  
  After merging, the function now correctly overrides the `ensembl_id` with the human ENSG value from the mapping file when a match is found, otherwise it falls back to the default mouse Ensembl ID.
- **Test Robustness:**  
  The test suite was updated to compare outputs in a way that is robust to nested structures (lists/dicts), avoiding issues with unhashable types in DataFrame comparisons.

## Testing

- **Case-Insensitive Mapping Test:**  
  Added `test_process_genetic_info_case_insensitive_mapping` to ensure that gene symbol matching between the mapping file and allele info is case-insensitive, and that the original gene symbol case is preserved in the output.
