### PR TITLE
MG-229: Update ui_config notebook with link column adjustments

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-190_Create_ui_info_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-190_Create_ui_info_source_file.rmd
@@ -156,13 +156,30 @@ mo_static_definitions <- data.frame(
 build_mo_object <- function() {
   columns <- apply(mo_static_definitions, 1, function(row) {
     name <- row["name"]
-    metadata <- c(row["type"], row["column_type"], "", paste("Sort by", name, "value"))
-    make_column(name, metadata)
+    type <- row["type"]
+    column_type <- row["column_type"]
+
+    metadata <- c(type, column_type, "", paste("Sort by", name, "value"))
+    column <- make_column(name, metadata)
+
+    if (column$column_type %in% c("link_internal", "link_external")) {
+      if (name %in% c("Gene Expression", "Disease Correlation", "Pathology", "Biomarkers")) {
+        column$link_text <- "Results"
+      } else if (name == "Study Data") {
+        column$link_text <- "View Data"
+      } else if (name == "JAX Strain") {
+        column$link_text <- "View Strain"
+      } else if (name == "Center") {
+        # Explicitly omit link_text by not setting it
+      }
+    }
+
+    column
   })
 
   list(
     page = "Model Overview",
-    dropdowns = list(),  # no dropdowns
+    dropdowns = list(),
     columns = columns
   )
 }


### PR DESCRIPTION
### Problem
A few inconsistencies were identified in the first version of the ui_config dataset.

### Solution
This PR updates the R notebook that generates the ui_config source file to address these inconsistencies.

1. We are now using consistent naming patterns across our ui and data defintion files
- `column_type` enum members now start with the base column type, e.g. `link_external` instead of `external_link`
- link-specific fields now start with the base column type they are specific to, e.g. `link_text` and `link_url`

2. Values that apply across all rows of data are now defined in ui_config