### PR TITLE
Rename model to name, update name values for cross-file consistency

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -82,11 +82,11 @@ synapse_folder <- 'syn51498054'
 stain_keeps <- c("GFAP", "S100B", "LAMP1", "IBA1", "ThioS", "HT7", "AT8")
 
 # Harmonized column specs for intermediate per-model files
-keeps_with_pool_join_field <- c('specimenID', 'model', 'type', 'measurement', 'units') # 3xTG-AD, NSS
-keeps_with_join_fields <- c('individualID', 'specimenID', 'model', 'type', 'measurement', 'units') # 5xFAD
+keeps_with_pool_join_field <- c('specimenID', 'model_name', 'type', 'measurement', 'units') # 3xTG-AD, NSS
+keeps_with_join_fields <- c('individualID', 'specimenID', 'model_name', 'type', 'measurement', 'units') # 5xFAD
 
 # Harmonized column spec for final output file
-keeps <- c('individualID', 'specimenID', 'model', 'type', 'measurement', 'units', 'ageDeath', 'tissue', 'sex', 'genotype')
+keeps <- c('individualID', 'specimenID', 'model_name', 'type', 'measurement', 'units', 'ageDeath', 'tissue', 'sex', 'genotype')
 
 # Pathology display names
 IBA1_display_name <- 'Microglia Cell Density (IBA1)'
@@ -159,13 +159,13 @@ join_to_metadata <- function(individual_metadata, biospecimen_metadata, df) {
   merged_metadata <- merge(individual_metadata, biospecimen_metadata, by = 'individualID')
 
   # Figure out what columns to merge by
-  join_by <- if(all(c('specimenID', 'individualID') %in% colnames(df)) && 
+  join_by <- if(all(c('specimenID', 'individualID') %in% colnames(df)) &&
               all(c('specimenID', 'individualID') %in% colnames(merged_metadata))) {
     c('specimenID', 'individualID')
   } else {
     c('specimenID')
   }
-  
+
   # Prevent creating duplicate data rows for 'Pool-X' specimenIDs by matching only first metadata row
   df_out <- df %>% left_join(merged_metadata, by=join_by, multiple="first")
 
@@ -266,7 +266,7 @@ threex_pathology <- threex_pathology_source %>%
 
         # Populate model column
 ) %>% add_column(
-        model = '3xTG-AD'
+        model_name = '3xTG-AD'
 
         # Drop unwanted columns
 ) %>% select(
@@ -294,13 +294,13 @@ fivex_gfap_s100b_pivot <- fivex_gfap_s100b %>%
                 values_transform = list(measurement = as.numeric)
 
                 # Rename columns for consistency
-        ) %>% rename(c('type' = 'Stain',
+        ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
-                     # Populate model column
+                     # Populate model_name column
 ) %>% add_column(
-        model = '5xFAD'
+        model_name = '5xFAD (UCI)'
 
         # Drop unused columns
 ) %>% select(
@@ -317,13 +317,13 @@ fivex_lamp1_pivot <- fivex_lamp1 %>%
                 values_transform = list(measurement = as.numeric),
 
                 # Rename columns for consistency
-        ) %>% rename(c('type' = 'Stain',
+        ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
                      # Populate model column
 ) %>% add_column(
-        model = '5xFAD'
+        model_name = '5xFAD (UCI)'
 
         # Drop unused columns
 ) %>% select(
@@ -340,13 +340,13 @@ fivex_iba1_thios_pivot <- fivex_iba1_thios %>%
                 values_transform = list(measurement = as.numeric),
 
                 # Rename columns for consistency
-        ) %>% rename(c('type' = 'Stain',
+        ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
                      # Populate model column
 ) %>% add_column(
-        model = '5xFAD'
+        model_name = '5xFAD (UCI)'
 
         # Drop unused columns
 ) %>% select(
@@ -450,7 +450,7 @@ nss_pathology <- nss_pathology_source %>%
 
         # Populate model column
 ) %>% add_column(
-        model = 'Trem2-R47H_NSS'
+        model_name = 'Trem2-R47H_NSS'
 
         # Drop unwanted columns
 ) %>% select(
@@ -510,7 +510,7 @@ abca7_pathology <- abca7_pathology_source %>%
 
         # Populate model column
 ) %>% add_column(
-        model = 'Abca7*V1599M'
+        model_name = 'Abca7*V1599M'
 
         # Drop unwanted columns
 ) %>% select(
@@ -687,7 +687,7 @@ pathology_merged <- bind_rows(
   nss_final %>% mutate(individualID = as.character(individualID)),
   abca7_final %>% mutate(individualID = as.character(individualID))
 ) %>%
-  rename(
+  dplyr::rename(
     specimen_id = specimenID,
     individual_id = individualID,
     age_death = ageDeath
@@ -715,7 +715,7 @@ pathology_final <- mutate(pathology_merged, genotype = case_when(
         TRUE ~ genotype))
 
 #Correct typos
-pathology_final$model <- gsub("3xTG-AD", "3xTg-AD", pathology_final$model)
+pathology_final$model_name <- gsub("3xTG-AD", "3xTg-AD", pathology_final$model_name)
 pathology_final$genotype <- gsub("3xTG-AD", "3xTg-AD", pathology_final$genotype)
 
 # print final data frame below

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -68,7 +68,7 @@ library(tidyverse)
 ## Utility functions & variables
 ```{r}
 # Harmonized column spec for intermediate per-model files
-keeps <- c('specimenID', 'individualID', 'model', 'type', 'measurement', 'units')
+intermediate_keeps <- c('specimenID', 'individualID', 'model', 'type', 'measurement', 'units')
 
 # Vector to store all downloaded synIds for Synapse provenance
 data_sources <- character()
@@ -202,7 +202,7 @@ threex_abs_pivot <- threex_abs_merged %>%
 threex_abs_pivot$type <- paste(threex_abs_pivot$fraction_type, threex_abs_pivot$abeta_type)
 
 # Drop unwanted columns and rows with no measurement value
-threex_abs_with_nas <- threex_abs_pivot[keeps]
+threex_abs_with_nas <- threex_abs_pivot[intermediate_keeps]
 threex_abs <- threex_abs_with_nas[!is.na(threex_abs_with_nas$measurement),]
 
 # No NfL measures for this model
@@ -219,7 +219,7 @@ fivex_abs_insol <- fivex_abs_insol_source %>% mutate(fraction_type = 'Insoluble'
 fivex_abs_merged <- bind_rows(fivex_abs_sol, fivex_abs_insol)
 
 # populate 'model' column
-fivex_abs_merged$model <- '5xFAD'
+fivex_abs_merged$model <- '5xFAD (UCI)'
 
 # Pivot Abeta columns; capture temp 'abeta_type' values and populate the target 'measurement' column
 fivex_abs_pivot <- fivex_abs_merged %>%
@@ -233,7 +233,7 @@ fivex_abs_pivot <- fivex_abs_merged %>%
 fivex_abs_pivot$type <- paste(fivex_abs_pivot$fraction_type, fivex_abs_pivot$abeta_type)
 
 # Drop unwanted columns and rows with no measurement value
-fivex_abs_with_nas <- fivex_abs_pivot[keeps]
+fivex_abs_with_nas <- fivex_abs_pivot[intermediate_keeps]
 fivex_abs <- fivex_abs_with_nas[!is.na(fivex_abs_with_nas$measurement),]
 
 # No NfL measures for this model
@@ -271,7 +271,7 @@ nss_abs_pivot <- nss_abs_merged %>%
 nss_abs_pivot$type <- paste(nss_abs_pivot$fraction_type, nss_abs_pivot$abeta_type)
 
 # Drop unwanted columns and rows with no measurement value
-nss_abs_with_nas <- nss_abs_pivot[keeps]
+nss_abs_with_nas <- nss_abs_pivot[intermediate_keeps]
 nss_abs <- nss_abs_with_nas[!is.na(nss_abs_with_nas$measurement),]
 
 # NfL measures
@@ -290,7 +290,7 @@ nss_nfl_pivot <- nss_nfl_merged %>%
         )
 
 # Drop unwanted columns and rows with no measurement value
-nss_nfl_with_nas <- nss_nfl_pivot[keeps]
+nss_nfl_with_nas <- nss_nfl_pivot[intermediate_keeps]
 nss_nfl <- nss_nfl_with_nas[!is.na(nss_nfl_with_nas$measurement),]
 
 # Merge Abetas and NfL
@@ -309,7 +309,7 @@ abca7_abs_insol_12mo <- abca7_abs_insol_12mo_source %>% mutate(fraction_type = '
 abca7_abs_merged <- bind_rows(abca7_abs_sol_4mo, abca7_abs_sol_12mo, abca7_abs_insol_4mo, abca7_abs_insol_12mo)
 
 # populate 'model' column
-abca7_abs_merged$model <- 'Abca7*v1599M'
+abca7_abs_merged$model <- 'Abca7*V1599M'
 
 # Pivot Abeta columns; capture temp 'abeta_type' values and populate the target 'measurement' column
 abca7_abs_pivot <- abca7_abs_merged %>%
@@ -323,7 +323,7 @@ abca7_abs_pivot <- abca7_abs_merged %>%
 abca7_abs_pivot$type <- paste(abca7_abs_pivot$fraction_type, abca7_abs_pivot$abeta_type)
 
 # Drop unwanted columns and rows with no measurement value
-abca7_abs_with_nas <- abca7_abs_pivot[keeps]
+abca7_abs_with_nas <- abca7_abs_pivot[intermediate_keeps]
 abca7_abs <- abca7_abs_with_nas[!is.na(abca7_abs_with_nas$measurement),]
 
 # NfL measures
@@ -331,7 +331,7 @@ abca7_abs <- abca7_abs_with_nas[!is.na(abca7_abs_with_nas$measurement),]
 abca7_nfl_merged <- bind_rows(abca7_nfl_cortex_source, abca7_nfl_plasma_source)
 
 # Populate 'model' column
-abca7_nfl_merged$model <- 'Abca7*v1599M'
+abca7_nfl_merged$model <- 'Abca7*V1599M'
 
 # Pivot nfl column and populate the target 'measurement' column
 abca7_nfl_pivot <- abca7_nfl_merged %>%
@@ -342,7 +342,7 @@ abca7_nfl_pivot <- abca7_nfl_merged %>%
         )
 
 # Drop unwanted columns and rows with no measurement value
-abca7_nfl_with_nas <- abca7_nfl_pivot[keeps]
+abca7_nfl_with_nas <- abca7_nfl_pivot[intermediate_keeps]
 abca7_nfl <- abca7_nfl_with_nas[!is.na(abca7_nfl_with_nas$measurement),]
 
 # Merge abs and nfl
@@ -408,18 +408,18 @@ stopifnot(nrow(abca7_nfl) + nrow(abca7_abs) == nrow(abca7_biomarkers))
 stopifnot(nrow(abca7_biomarkers) == nrow(abca7_final))
 ```
 
-## Merge files
+## Merge files and make final adjustments to colnames and values
 ```{r}
 biomarkers_merged <- bind_rows(
   threex_final %>% mutate(individualID = as.character(individualID)),
   fivex_final %>% mutate(individualID = as.character(individualID)),
   nss_final %>% mutate(individualID = as.character(individualID)),
   abca7_final %>% mutate(individualID = as.character(individualID))
-) %>%
-  rename(
+) %>% dplyr::rename(
     individual_id = individualID,
     specimen_id = specimenID,
-    age_death = ageDeath
+    age_death = ageDeath,
+    model_name = model
   )
 
 
@@ -437,17 +437,17 @@ biomarkers_final <- mutate(biomarkers_merged,
 
                                    # NSS genotypes
                                    genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
-                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "5xFADTrem2-R47H_NSS",
+                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "5xFAD Trem2-R47H_NSS",
 
                                    # Abca7 genotypes
                                    genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
-                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "5xFADAbca7*V1599M",
+                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "5xFAD Abca7*V1599M",
 
                                    TRUE ~ genotype))
 
 
 #Correct typos
-biomarkers_final$model <- gsub("3xTG-AD", "3xTg-AD", biomarkers_final$model)
+biomarkers_final$model_name <- gsub("3xTG-AD", "3xTg-AD", biomarkers_final$model_name)
 biomarkers_final$genotype <- gsub("3xTG-AD", "3xTg-AD", biomarkers_final$genotype)
 
 # print final data frame below


### PR DESCRIPTION
This PR updates the existing biomarkers and pathology R notebooks, and creates a new one for disease_correlation. These updates modify the corresponding source files to ensure that we can successfully join across data files using model display name values.

The new/updated notebooks ensure that:
1. Model display name values use consistent casing across source files
2. Adds center-specific qualifiers to the two 5xFAD models
3. Renames the `model` column to `name` [biomarkers and pathology only]