### PR TITLE
MG-264: Update R notebooks to ensure model values align across files

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
+++ b/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
@@ -1,0 +1,112 @@
+
+# Modify Disease Correlation source (MG-264)
+
+This notebook downloads the correlation data that was exported from the legacy explorer (syn65467849.1) and aligns the model_name values with our other data.
+
+
+## Library setup
+Install required packages:
+- synapser (also requires a Synapse account with an auth token)
+- tidyverse
+```{r}
+if (!require("synapser", quietly = TRUE)) {
+  install.packages("synapser", repos = c("http://ran.synapse.org",
+                                         "http://cran.fhcrc.org"))
+}
+
+if (!require("tidyverse", quietly = TRUE)) {
+  install.packages("tidyverse")
+}
+
+library(synapser)
+library(tidyverse)
+```
+
+## Utility functions & variables
+Run this to initialize shared variables and functions.
+```{r}
+# MODEL-AD 2.0 harmonized source file directory
+# ADP Backend > Files > 2.ConsortiumStudies > MODEL-AD Data Explorer > Model AD Explorer 2.0 Source Files
+synapse_folder <- 'syn51498054'
+
+# Vector to store all downloaded synIds for Synapse provenance (populated via download_file function)
+data_sources <- character()
+
+# Download a file from Synapse by synId and read it into a dataframe
+download_file <- function(synId, df_name, type) {
+
+  synLogin()
+
+  # Capture all downloaded synIds for provenance
+  data_sources <<- c(data_sources, synId)
+
+  input_dir <- file.path("./", "input")
+  id_parts <- strsplit(synId, '.', fixed = TRUE)
+  id_value <- id_parts[[1]][1]
+  version_value <- id_parts[[1]][2]
+
+  if (is.na(version_value)) {
+    version_value <- NULL
+  }
+
+  cat(paste0("Downloading ", synId, "..."))
+
+
+  file <- synGet(id_value, version = version_value, downloadLocation = input_dir, ifcollision='overwrite.local')
+  path <- file$path
+
+  cat("\nDownload on:  ", date())
+  cat("\n", synId, "\n- Modified on ", file$properties$modifiedOn, "\n- Version ", file$properties$versionNumber)
+  cat("\npath: ", file$path, "\n")
+
+  if (type == 'f') {
+    data <- read_feather(path)
+  } else {
+    if (type == 'json') { data <- fromJSON(path) }
+    if (type == 'csv' || type == 'table') { data <- read.csv(path) }
+    if (type == 'tsv') { data <- read.csv(path, sep = "\t") }
+    if (type == 'rda') { data <- load(path)}
+    if (type == 'rds') {data <- readRDS(path)}
+    df_name <- as.data.frame(data)
+  }
+}
+```
+
+
+## Download data file from Synapse
+Note that each file's synId and version is added to the data_sources vector via the download_file function.
+The populated data_sources vector is used to populate Synapse provenance when the harmonized csv is uploaded.
+```{r}
+disease_correlation_source <- download_file('syn65467849.1', type = "csv")
+```
+
+
+## Update 5xFAD model_name to include center info
+
+```{r}
+disease_correlation_final <- copy(disease_correlation_source)
+disease_correlation_final$Mouse.Model[disease_correlation_final$Mouse.Model == '5xFAD'] <- '5xFAD (IU/Jax/Pitt)'
+```
+
+
+## Write csv file and upload to synapse
+```{r}
+# write csv file
+output_dir <- file.path("./", "output")
+if(!dir.exists(output_dir)){
+  dir.create(output_dir)
+}
+write.csv(disease_correlation_final, file.path(output_dir, "disease_correlation_results.csv"), row.names = FALSE)
+
+# upload to synapse
+syn_file <- File(file.path(output_dir, "disease_correlation_results.csv"),
+                 parent = synapse_folder)
+
+res <- synStore(syn_file, forceVersion = FALSE,
+                used = data_sources,
+                executed = "https://github.com/Sage-Bionetworks/agora-data-tools/blob/dev/data_analysis/model_ad/notebooks/MG-261_Modify_disease_correlation_source_file.rmd")
+
+print(paste0("ID: ", res$id, " v", res$versionNumber, ", Name: ", res$name))
+
+```
+

--- a/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
+++ b/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
@@ -82,6 +82,7 @@ disease_correlation_source <- download_file('syn65467849.1', type = "csv")
 
 
 ## Update 5xFAD model_name to include center info
+Since only IU/Jax/Pitt contributed disease_correlation data, we can assign all 5xFAD results to that center.
 
 ```{r}
 disease_correlation_final <- copy(disease_correlation_source)

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -225,14 +225,14 @@ threex_pathology <- threex_pathology_source %>%
         filter(
                 stain %in% stain_keeps
 
-                # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+          # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
         ) %>% pivot_longer(
         cols = c(objectDensity, averageObjectVolume, totalObjectVolume),
         names_to = "units",
         values_to = "measurement",
         values_transform = list(measurement = as.numeric)
 
-        # Convert units to display values
+  # Convert units to display values
 ) %>% mutate(
         units = case_match(
                 units,
@@ -241,7 +241,7 @@ threex_pathology <- threex_pathology_source %>%
                 'totalObjectVolume' ~ totalObjectVolume_display_name
         )
 
-        # Map 'stain' values to 'type' display names
+  # Map 'stain' values to 'type' display names
 ) %>% mutate(
         type = case_when(
                 stain == 'IBA1' ~ IBA1_display_name,
@@ -256,19 +256,19 @@ threex_pathology <- threex_pathology_source %>%
                 .default = 'UNMAPPED_DROPME'
         )
 
-        # drop rows for unused ThioS stain/unit combinations
+  # drop rows for unused ThioS stain/unit combinations
 ) %>% filter(
         type != 'UNMAPPED_DROPME'
 
-        # Drop rows with NA measurements
+  # Drop rows with NA measurements
 ) %>% filter(
         !is.na(measurement)
 
-        # Populate model column
+  # Populate model column
 ) %>% add_column(
         model = '3xTG-AD'
 
-        # Drop unwanted columns
+  # Drop unwanted columns
 ) %>% select(
         all_of(keeps_with_pool_join_field)
 )
@@ -293,16 +293,17 @@ fivex_gfap_s100b_pivot <- fivex_gfap_s100b %>%
                 values_to = "measurement",
                 values_transform = list(measurement = as.numeric)
 
-                # Rename columns for consistency
+          # Rename columns for consistency
         ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
-                     # Populate model column
+  # Populate model column
+  # Since only UCI contributes pathology/biomarker data, we can assign all 5xFAD results to that center.
 ) %>% add_column(
         model = '5xFAD (UCI)'
 
-        # Drop unused columns
+  # Drop unused columns
 ) %>% select(
         all_of(keeps_with_join_fields)
 )
@@ -316,16 +317,16 @@ fivex_lamp1_pivot <- fivex_lamp1 %>%
                 values_to = "measurement",
                 values_transform = list(measurement = as.numeric),
 
-                # Rename columns for consistency
+        # Rename columns for consistency
         ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
-                     # Populate model column
+  # Populate model column
 ) %>% add_column(
         model = '5xFAD (UCI)'
 
-        # Drop unused columns
+  # Drop unused columns
 ) %>% select(
         all_of(keeps_with_join_fields)
 )
@@ -339,16 +340,17 @@ fivex_iba1_thios_pivot <- fivex_iba1_thios %>%
                 values_to = "measurement",
                 values_transform = list(measurement = as.numeric),
 
-                # Rename columns for consistency
+          # Rename columns for consistency
         ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
-                     # Populate model column
+   # Populate model column
+   # Since only UCI contributes pathology/biomarker data, we can assign all 5xFAD results to that center.
 ) %>% add_column(
         model = '5xFAD (UCI)'
 
-        # Drop unused columns
+  # Drop unused columns
 ) %>% select(
         all_of(keeps_with_join_fields)
 )
@@ -368,7 +370,7 @@ fivex_pathology <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_ib
                 'mean.object.area..squm.' ~ meanObjectArea_display_name
         )
 
-        # Map stain values to type display names
+ # Map stain values to type display names
 ) %>% mutate(
         type = case_when(
                 type == 'Iba1' ~ IBA1_display_name,
@@ -383,15 +385,15 @@ fivex_pathology <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_ib
                 .default = 'UNMAPPED_DROPME'
         )
 
-        # drop rows for unused ThioS stain/unit combinations
+  # drop rows for unused ThioS stain/unit combinations
 ) %>% filter(
         type != 'UNMAPPED_DROPME'
 
-        # Drop rows with NA measurements
+  # Drop rows with NA measurements
 ) %>% filter(
         !is.na(measurement)
 
-        # Drop unwanted columns
+  # Drop unwanted columns
 ) %>% select(
         all_of(keeps_with_join_fields)
 )
@@ -416,7 +418,7 @@ nss_pathology <- nss_pathology_source %>%
         values_to = "measurement",
         values_transform = list(measurement = as.numeric)
 
-        # Convert units to display values
+  # Convert units to display values
 ) %>% mutate(
         units = case_match(
                 units,
@@ -425,7 +427,7 @@ nss_pathology <- nss_pathology_source %>%
                 'totalObjectVolume' ~ totalObjectVolume_display_name
         )
 
-        # Map 'stain' values to 'type' display names
+  # Map 'stain' values to 'type' display names
 ) %>% mutate(
         type = case_when(
                 stain == 'IBA1' & units == objectDensity_display_name ~ IBA1_display_name,
@@ -440,19 +442,19 @@ nss_pathology <- nss_pathology_source %>%
                 .default = 'UNMAPPED_DROPME'
         )
 
-        # drop rows for unused stain/unit combinations
+  # drop rows for unused stain/unit combinations
 ) %>% filter(
         type != 'UNMAPPED_DROPME'
 
-        # Drop rows with NA measurements
+  # Drop rows with NA measurements
 ) %>% filter(
         !is.na(measurement)
 
-        # Populate model column
+  # Populate model column
 ) %>% add_column(
         model = 'Trem2-R47H_NSS'
 
-        # Drop unwanted columns
+  # Drop unwanted columns
 ) %>% select(
         all_of(keeps_with_pool_join_field)
 )
@@ -476,7 +478,7 @@ abca7_pathology <- abca7_pathology_source %>%
         values_to = "measurement",
         values_transform = list(measurement = as.numeric)
 
-        # Convert units to display values
+  # Convert units to display values
 ) %>% mutate(
         units = case_match(
                 units,
@@ -485,7 +487,7 @@ abca7_pathology <- abca7_pathology_source %>%
                 'totalObjectVolume' ~ totalObjectVolume_display_name
         )
 
-        # Map 'stain' values to 'type' display names
+  # Map 'stain' values to 'type' display names
 ) %>% mutate(
         type = case_when(
                 stain == 'IBA1' & units == objectDensity_display_name ~ IBA1_display_name,
@@ -500,7 +502,7 @@ abca7_pathology <- abca7_pathology_source %>%
                 .default = 'UNMAPPED_DROPME'
         )
 
-        # drop rows for unused stain/unit combinations
+  # drop rows for unused stain/unit combinations
 ) %>% filter(
         type != 'UNMAPPED_DROPME'
 
@@ -714,7 +716,7 @@ pathology_final <- mutate(pathology_merged, genotype = case_when(
 
         TRUE ~ genotype))
 
-#Correct typos
+#Correct typos in source model and genotype values
 pathology_final$model <- gsub("3xTG-AD", "3xTg-AD", pathology_final$model)
 pathology_final$genotype <- gsub("3xTG-AD", "3xTg-AD", pathology_final$genotype)
 

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -715,7 +715,7 @@ pathology_final <- mutate(pathology_merged, genotype = case_when(
         TRUE ~ genotype))
 
 #Correct typos
-pathology_final$name <- gsub("3xTG-AD", "3xTg-AD", pathology_final$model)
+pathology_final$model <- gsub("3xTG-AD", "3xTg-AD", pathology_final$model)
 pathology_final$genotype <- gsub("3xTG-AD", "3xTg-AD", pathology_final$genotype)
 
 # print final data frame below

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -159,13 +159,13 @@ join_to_metadata <- function(individual_metadata, biospecimen_metadata, df) {
   merged_metadata <- merge(individual_metadata, biospecimen_metadata, by = 'individualID')
 
   # Figure out what columns to merge by
-  join_by <- if(all(c('specimenID', 'individualID') %in% colnames(df)) && 
+  join_by <- if(all(c('specimenID', 'individualID') %in% colnames(df)) &&
               all(c('specimenID', 'individualID') %in% colnames(merged_metadata))) {
     c('specimenID', 'individualID')
   } else {
     c('specimenID')
   }
-  
+
   # Prevent creating duplicate data rows for 'Pool-X' specimenIDs by matching only first metadata row
   df_out <- df %>% left_join(merged_metadata, by=join_by, multiple="first")
 
@@ -294,13 +294,13 @@ fivex_gfap_s100b_pivot <- fivex_gfap_s100b %>%
                 values_transform = list(measurement = as.numeric)
 
                 # Rename columns for consistency
-        ) %>% rename(c('type' = 'Stain',
+        ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
                      # Populate model column
 ) %>% add_column(
-        model = '5xFAD'
+        model = '5xFAD (UCI)'
 
         # Drop unused columns
 ) %>% select(
@@ -317,13 +317,13 @@ fivex_lamp1_pivot <- fivex_lamp1 %>%
                 values_transform = list(measurement = as.numeric),
 
                 # Rename columns for consistency
-        ) %>% rename(c('type' = 'Stain',
+        ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
                      # Populate model column
 ) %>% add_column(
-        model = '5xFAD'
+        model = '5xFAD (UCI)'
 
         # Drop unused columns
 ) %>% select(
@@ -340,13 +340,13 @@ fivex_iba1_thios_pivot <- fivex_iba1_thios %>%
                 values_transform = list(measurement = as.numeric),
 
                 # Rename columns for consistency
-        ) %>% rename(c('type' = 'Stain',
+        ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
                      # Populate model column
 ) %>% add_column(
-        model = '5xFAD'
+        model = '5xFAD (UCI)'
 
         # Drop unused columns
 ) %>% select(
@@ -687,7 +687,7 @@ pathology_merged <- bind_rows(
   nss_final %>% mutate(individualID = as.character(individualID)),
   abca7_final %>% mutate(individualID = as.character(individualID))
 ) %>%
-  rename(
+  dplyr::rename(
     specimen_id = specimenID,
     individual_id = individualID,
     age_death = ageDeath
@@ -715,7 +715,7 @@ pathology_final <- mutate(pathology_merged, genotype = case_when(
         TRUE ~ genotype))
 
 #Correct typos
-pathology_final$model <- gsub("3xTG-AD", "3xTg-AD", pathology_final$model)
+pathology_final$name <- gsub("3xTG-AD", "3xTg-AD", pathology_final$model)
 pathology_final$genotype <- gsub("3xTG-AD", "3xTg-AD", pathology_final$genotype)
 
 # print final data frame below

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -68,7 +68,7 @@ library(tidyverse)
 ## Utility functions & variables
 ```{r}
 # Harmonized column spec for intermediate per-model files
-keeps <- c('specimenID', 'individualID', 'model', 'type', 'measurement', 'units')
+intermediate_keeps <- c('specimenID', 'individualID', 'model', 'type', 'measurement', 'units')
 
 # Vector to store all downloaded synIds for Synapse provenance
 data_sources <- character()
@@ -202,7 +202,7 @@ threex_abs_pivot <- threex_abs_merged %>%
 threex_abs_pivot$type <- paste(threex_abs_pivot$fraction_type, threex_abs_pivot$abeta_type)
 
 # Drop unwanted columns and rows with no measurement value
-threex_abs_with_nas <- threex_abs_pivot[keeps]
+threex_abs_with_nas <- threex_abs_pivot[intermediate_keeps]
 threex_abs <- threex_abs_with_nas[!is.na(threex_abs_with_nas$measurement),]
 
 # No NfL measures for this model
@@ -219,7 +219,7 @@ fivex_abs_insol <- fivex_abs_insol_source %>% mutate(fraction_type = 'Insoluble'
 fivex_abs_merged <- bind_rows(fivex_abs_sol, fivex_abs_insol)
 
 # populate 'model' column
-fivex_abs_merged$model <- '5xFAD'
+fivex_abs_merged$model <- '5xFAD (UCI)'
 
 # Pivot Abeta columns; capture temp 'abeta_type' values and populate the target 'measurement' column
 fivex_abs_pivot <- fivex_abs_merged %>%
@@ -233,7 +233,7 @@ fivex_abs_pivot <- fivex_abs_merged %>%
 fivex_abs_pivot$type <- paste(fivex_abs_pivot$fraction_type, fivex_abs_pivot$abeta_type)
 
 # Drop unwanted columns and rows with no measurement value
-fivex_abs_with_nas <- fivex_abs_pivot[keeps]
+fivex_abs_with_nas <- fivex_abs_pivot[intermediate_keeps]
 fivex_abs <- fivex_abs_with_nas[!is.na(fivex_abs_with_nas$measurement),]
 
 # No NfL measures for this model
@@ -271,7 +271,7 @@ nss_abs_pivot <- nss_abs_merged %>%
 nss_abs_pivot$type <- paste(nss_abs_pivot$fraction_type, nss_abs_pivot$abeta_type)
 
 # Drop unwanted columns and rows with no measurement value
-nss_abs_with_nas <- nss_abs_pivot[keeps]
+nss_abs_with_nas <- nss_abs_pivot[intermediate_keeps]
 nss_abs <- nss_abs_with_nas[!is.na(nss_abs_with_nas$measurement),]
 
 # NfL measures
@@ -290,7 +290,7 @@ nss_nfl_pivot <- nss_nfl_merged %>%
         )
 
 # Drop unwanted columns and rows with no measurement value
-nss_nfl_with_nas <- nss_nfl_pivot[keeps]
+nss_nfl_with_nas <- nss_nfl_pivot[intermediate_keeps]
 nss_nfl <- nss_nfl_with_nas[!is.na(nss_nfl_with_nas$measurement),]
 
 # Merge Abetas and NfL
@@ -309,7 +309,7 @@ abca7_abs_insol_12mo <- abca7_abs_insol_12mo_source %>% mutate(fraction_type = '
 abca7_abs_merged <- bind_rows(abca7_abs_sol_4mo, abca7_abs_sol_12mo, abca7_abs_insol_4mo, abca7_abs_insol_12mo)
 
 # populate 'model' column
-abca7_abs_merged$model <- 'Abca7*v1599M'
+abca7_abs_merged$model <- 'Abca7*V1599M'
 
 # Pivot Abeta columns; capture temp 'abeta_type' values and populate the target 'measurement' column
 abca7_abs_pivot <- abca7_abs_merged %>%
@@ -323,7 +323,7 @@ abca7_abs_pivot <- abca7_abs_merged %>%
 abca7_abs_pivot$type <- paste(abca7_abs_pivot$fraction_type, abca7_abs_pivot$abeta_type)
 
 # Drop unwanted columns and rows with no measurement value
-abca7_abs_with_nas <- abca7_abs_pivot[keeps]
+abca7_abs_with_nas <- abca7_abs_pivot[intermediate_keeps]
 abca7_abs <- abca7_abs_with_nas[!is.na(abca7_abs_with_nas$measurement),]
 
 # NfL measures
@@ -331,7 +331,7 @@ abca7_abs <- abca7_abs_with_nas[!is.na(abca7_abs_with_nas$measurement),]
 abca7_nfl_merged <- bind_rows(abca7_nfl_cortex_source, abca7_nfl_plasma_source)
 
 # Populate 'model' column
-abca7_nfl_merged$model <- 'Abca7*v1599M'
+abca7_nfl_merged$model <- 'Abca7*V1599M'
 
 # Pivot nfl column and populate the target 'measurement' column
 abca7_nfl_pivot <- abca7_nfl_merged %>%
@@ -342,7 +342,7 @@ abca7_nfl_pivot <- abca7_nfl_merged %>%
         )
 
 # Drop unwanted columns and rows with no measurement value
-abca7_nfl_with_nas <- abca7_nfl_pivot[keeps]
+abca7_nfl_with_nas <- abca7_nfl_pivot[intermediate_keeps]
 abca7_nfl <- abca7_nfl_with_nas[!is.na(abca7_nfl_with_nas$measurement),]
 
 # Merge abs and nfl
@@ -408,15 +408,14 @@ stopifnot(nrow(abca7_nfl) + nrow(abca7_abs) == nrow(abca7_biomarkers))
 stopifnot(nrow(abca7_biomarkers) == nrow(abca7_final))
 ```
 
-## Merge files
+## Merge files and make final adjustments to colnames and values
 ```{r}
 biomarkers_merged <- bind_rows(
   threex_final %>% mutate(individualID = as.character(individualID)),
   fivex_final %>% mutate(individualID = as.character(individualID)),
   nss_final %>% mutate(individualID = as.character(individualID)),
   abca7_final %>% mutate(individualID = as.character(individualID))
-) %>%
-  rename(
+) %>% dplyr::rename(
     individual_id = individualID,
     specimen_id = specimenID,
     age_death = ageDeath
@@ -437,11 +436,11 @@ biomarkers_final <- mutate(biomarkers_merged,
 
                                    # NSS genotypes
                                    genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
-                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "5xFADTrem2-R47H_NSS",
+                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "5xFAD Trem2-R47H_NSS",
 
                                    # Abca7 genotypes
                                    genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
-                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "5xFADAbca7*V1599M",
+                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "5xFAD Abca7*V1599M",
 
                                    TRUE ~ genotype))
 

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -219,6 +219,7 @@ fivex_abs_insol <- fivex_abs_insol_source %>% mutate(fraction_type = 'Insoluble'
 fivex_abs_merged <- bind_rows(fivex_abs_sol, fivex_abs_insol)
 
 # populate 'model' column
+# Since only UCI contributes pathology/biomarker data, we can assign all 5xFAD results to that center.
 fivex_abs_merged$model <- '5xFAD (UCI)'
 
 # Pivot Abeta columns; capture temp 'abeta_type' values and populate the target 'measurement' column

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -436,11 +436,11 @@ biomarkers_final <- mutate(biomarkers_merged,
 
                                    # NSS genotypes
                                    genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
-                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "5xFAD Trem2-R47H_NSS",
+                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "5xFADTrem2-R47H_NSS",
 
                                    # Abca7 genotypes
                                    genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
-                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "5xFAD Abca7*V1599M",
+                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "5xFADAbca7*V1599M",
 
                                    TRUE ~ genotype))
 

--- a/src/agoradatatools/great_expectations/gx/expectations/biomarkers.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/biomarkers.json
@@ -68,9 +68,9 @@
         "column": "model",
         "value_set": [
           "3xTg-AD",
-          "5xFAD",
+          "5xFAD (UCI)",
           "Trem2-R47H_NSS",
-          "Abca7*v1599M"
+          "Abca7*V1599M"
         ]
       },
       "meta": {}

--- a/src/agoradatatools/great_expectations/gx/expectations/pathology.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/pathology.json
@@ -68,7 +68,7 @@
         "column": "model",
         "value_set": [
           "3xTg-AD",
-          "5xFAD",
+          "5xFAD (UCI)",
           "Trem2-R47H_NSS",
           "Abca7*V1599M"
         ]


### PR DESCRIPTION
These updates ensure that joins on our `model` display values work as intended:
1. Fix case mismatches & adjust GX expectations
2. Disambiguate the two 5xFAD models

This PR addresses these issues in the `disease_correlation`, `pathology` and `biomarker` source data. The required changes to other source files (`model_info`, `model_allele_info`, `model_results_info`) were made manually.

Note that these new/modified notebooks have already been executed and updated source files are already in synapse.