### PR TITLE
MG-235: Override gene_symbol when human_ensembl_id is available

### DIFF
--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -165,6 +165,14 @@ def process_genetic_info(
         axis=1,
     )
 
+    # Only override gene_symbol if we have a valid human_ensembl_id
+    merged_df["modified_gene"] = merged_df.apply(
+        lambda row: row["gene_symbol"]
+        if pd.notna(row["human_ensembl_id"])
+        else row["modified_gene"],
+        axis=1,
+    )
+
     # Drop duplicates to ensure we don't have exact duplicates of the same allele
     merged_df = merged_df.drop_duplicates(
         subset=["modified_gene", "allele", "mgi_allele_id"]

--- a/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
@@ -16,7 +16,7 @@
     ],
     "genetic_info": [
       {
-        "modified_gene": "App",
+        "modified_gene": "APP",
         "ensembl_gene_id": "ENSG00000142192",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
@@ -192,7 +192,7 @@
     ],
     "genetic_info": [
       {
-        "modified_gene": "Mapt",
+        "modified_gene": "MAPT",
         "ensembl_gene_id": "ENSG00000186868",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",
@@ -300,7 +300,7 @@
     ],
     "genetic_info": [
       {
-        "modified_gene": "App",
+        "modified_gene": "APP",
         "ensembl_gene_id": "ENSG00000142192",
         "allele": "APP K670_M671delinsNL (Swedish)",
         "allele_type": "Transgenic",
@@ -343,7 +343,7 @@
     ],
     "genetic_info": [
       {
-        "modified_gene": "Mapt",
+        "modified_gene": "MAPT",
         "ensembl_gene_id": "ENSG00000186868",
         "allele": "Mapttm1(EGFP)Klt",
         "allele_type": "Targeted",

--- a/tests/transform/test_model_details.py
+++ b/tests/transform/test_model_details.py
@@ -572,14 +572,14 @@ class TestTransformModelDetails:
         # Expected output: ENSG IDs should be mapped, gene names should keep original case
         expected_output = [
             {
-                "modified_gene": "App",
+                "modified_gene": "APP",
                 "ensembl_gene_id": "ENSG00000123456",
                 "allele": "APP Example Allele",
                 "allele_type": "Transgenic",
                 "mgi_allele_id": 1234567,
             },
             {
-                "modified_gene": "Mapt",
+                "modified_gene": "mapt",
                 "ensembl_gene_id": "ENSG00000987654",
                 "allele": "MAPT Example Allele",
                 "allele_type": "Transgenic",


### PR DESCRIPTION
# Override gene_symbol when human_ensembl_id is available

## Problem
When processing genetic information for human transgenes, the code was only overriding the `ensembl_gene_id` with the human version when a valid `human_ensembl_id` was found. However, the `gene_symbol` (stored as `modified_gene` in the output) was not being updated to use the human gene symbol from the `human_transgene_allele_map` dataset.

## Solution
Modified the `process_genetic_info` function in `src/agoradatatools/etl/transform/model_details.py` to:

1. **Override `modified_gene` with human gene symbol**: When a valid `human_ensembl_id` is found, the `modified_gene` field is now updated to use the `gene_symbol` from the `human_transgene_allele_map` dataset instead of keeping the original gene name.

2. **Maintain consistency**: Both the `ensembl_gene_id` and `modified_gene` are now overridden together when human transgene data is available, ensuring the genetic information is consistent.

The logic follows the same pattern as the existing `ensembl_gene_id` override:
```python
merged_df["modified_gene"] = merged_df.apply(
    lambda row: row["gene_symbol"]
    if pd.notna(row["human_ensembl_id"])
    else row["modified_gene"],
    axis=1,
)
```

## Testing
- **Unit tests**: Updated unit test assets to reflect this change.
