### PR TITLE
MG-257: model_details.jax_id should preserve leading 0s

### DIFF
--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -213,6 +213,12 @@ def transform_model_details(
     model_info_df = datasets["model_info"].fillna("")
     human_transgene_allele_map_df = datasets["human_transgene_allele_map"].fillna("")
 
+    # Ensure jax_id preserves leading zeros by converting to string with proper formatting
+    if "jax_id" in model_info_df.columns:
+        model_info_df["jax_id"] = model_info_df["jax_id"].apply(
+            lambda x: str(x).zfill(6) if pd.notna(x) and str(x).strip() != "" else x
+        )
+
     # Prepare biomarker and pathology dataframes
     biomarkers_df = prepare_biomarker_pathology(datasets["biomarkers"])
     pathology_df = prepare_biomarker_pathology(datasets["pathology"])

--- a/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
@@ -8,7 +8,7 @@
     "contributing_group": "UCI",
     "study_synid": "syn22964685",
     "rrid": "MMRRC_034830-JAX",
-    "jax_id": 4807,
+    "jax_id": "004807",
     "alzforum_id": "3xtg",
     "genotype": "B6;129-Tg(APPSwe,tauP301L)1Lfa <i>Psen1<sup>tm1Mpm</sup></i>/Mmjax",
     "aliases": [
@@ -63,7 +63,7 @@
     "contributing_group": "Mayo",
     "study_synid": "syn25539881",
     "rrid": "IMSR_JAX:005491",
-    "jax_id": 5491,
+    "jax_id": "005491",
     "alzforum_id": "htau",
     "genotype": "B6.Cg-Mapttm1(EGFP)Klt Tg(MAPT)8cPdav/J",
     "aliases": [

--- a/tests/test_assets/model_details/output/model_details_transform_extra_column_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_extra_column_output.json
@@ -8,7 +8,7 @@
     "contributing_group": "UCI",
     "study_synid": "syn22964685",
     "rrid": "MMRRC_034830-JAX",
-    "jax_id": 4807,
+    "jax_id": "004807",
     "alzforum_id": "3xtg",
     "genotype": "B6;129-Tg(APPSwe,tauP301L)1Lfa <i>Psen1<sup>tm1Mpm</sup></i>/Mmjax",
     "aliases": [
@@ -197,7 +197,7 @@
     "contributing_group": "Mayo",
     "study_synid": "syn25539881",
     "rrid": "IMSR_JAX:005491",
-    "jax_id": 5491,
+    "jax_id": "005491",
     "alzforum_id": "htau",
     "genotype": "B6.Cg-Mapttm1(EGFP)Klt Tg(MAPT)8cPdav/J",
     "aliases": [

--- a/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
@@ -8,7 +8,7 @@
     "contributing_group": "UCI",
     "study_synid": "syn22964685",
     "rrid": "MMRRC_034830-JAX",
-    "jax_id": 4807,
+    "jax_id": "004807",
     "alzforum_id": "3xtg",
     "genotype": "B6;129-Tg(APPSwe,tauP301L)1Lfa <i>Psen1<sup>tm1Mpm</sup></i>/Mmjax",
     "aliases": [
@@ -197,7 +197,7 @@
     "contributing_group": "Mayo",
     "study_synid": "syn25539881",
     "rrid": "IMSR_JAX:005491",
-    "jax_id": 5491,
+    "jax_id": "005491",
     "alzforum_id": "htau",
     "genotype": "B6.Cg-Mapttm1(EGFP)Klt Tg(MAPT)8cPdav/J",
     "aliases": [

--- a/tests/test_assets/model_details/output/model_details_transform_missing_allele_info_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_allele_info_output.json
@@ -8,7 +8,7 @@
     "contributing_group": "UCI",
     "study_synid": "syn22964685",
     "rrid": "MMRRC_034830-JAX",
-    "jax_id": 4807,
+    "jax_id": "004807",
     "alzforum_id": "3xtg",
     "genotype": "B6;129-Tg(APPSwe,tauP301L)1Lfa <i>Psen1<sup>tm1Mpm</sup></i>/Mmjax",
     "aliases": [
@@ -176,7 +176,7 @@
     "contributing_group": "Mayo",
     "study_synid": "syn25539881",
     "rrid": "IMSR_JAX:005491",
-    "jax_id": 5491,
+    "jax_id": "005491",
     "alzforum_id": "htau",
     "genotype": "B6.Cg-Mapttm1(EGFP)Klt Tg(MAPT)8cPdav/J",
     "aliases": [

--- a/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
@@ -8,7 +8,7 @@
     "contributing_group": "UCI",
     "study_synid": "syn22964685",
     "rrid": "MMRRC_034830-JAX",
-    "jax_id": 4807,
+    "jax_id": "004807",
     "alzforum_id": "3xtg",
     "genotype": "B6;129-Tg(APPSwe,tauP301L)1Lfa <i>Psen1<sup>tm1Mpm</sup></i>/Mmjax",
     "aliases": [
@@ -183,7 +183,7 @@
     "contributing_group": "Mayo",
     "study_synid": "syn25539881",
     "rrid": "IMSR_JAX:005491",
-    "jax_id": 5491,
+    "jax_id": "005491",
     "alzforum_id": "htau",
     "genotype": "B6.Cg-Mapttm1(EGFP)Klt Tg(MAPT)8cPdav/J",
     "aliases": [
@@ -292,7 +292,7 @@
     "contributing_group": "UCI",
     "study_synid": "syn22964685",
     "rrid": "MMRRC_034830-JAX",
-    "jax_id": 4808,
+    "jax_id": "004808",
     "alzforum_id": "new1",
     "genotype": "B6;129-Tg(APPSwe)1Lfa",
     "aliases": [
@@ -335,7 +335,7 @@
     "contributing_group": "Mayo",
     "study_synid": "syn25539881",
     "rrid": "IMSR_JAX:005492",
-    "jax_id": 5492,
+    "jax_id": "005492",
     "alzforum_id": "new2",
     "genotype": "B6.Cg-Mapttm1(EGFP)Klt",
     "aliases": [

--- a/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
@@ -8,7 +8,7 @@
     "contributing_group": "UCI",
     "study_synid": "syn22964685",
     "rrid": "MMRRC_034830-JAX",
-    "jax_id": 4807,
+    "jax_id": "004807",
     "alzforum_id": "3xtg",
     "genotype": "B6;129-Tg(APPSwe,tauP301L)1Lfa <i>Psen1<sup>tm1Mpm</sup></i>/Mmjax",
     "aliases": [
@@ -197,7 +197,7 @@
     "contributing_group": "Mayo",
     "study_synid": "syn25539881",
     "rrid": "IMSR_JAX:005491",
-    "jax_id": 5491,
+    "jax_id": "005491",
     "alzforum_id": "htau",
     "genotype": "B6.Cg-Mapttm1(EGFP)Klt Tg(MAPT)8cPdav/J",
     "aliases": [

--- a/tests/transform/test_model_details.py
+++ b/tests/transform/test_model_details.py
@@ -592,3 +592,125 @@ class TestTransformModelDetails:
 
         # Compare output with expected
         assert output == expected_output
+
+    def test_jax_id_leading_zeros_preservation(self):
+        """
+        Test that jax_id values are properly formatted with leading zeros to ensure 6-digit format.
+        This tests the specific functionality in transform_model_details that handles jax_id formatting.
+        """
+        # Create test datasets with various jax_id formats
+        model_info_df = pd.DataFrame(
+            {
+                "model": ["model1", "model2", "model3", "model4", "model5", "model6"],
+                "matched_controls": [
+                    "control1",
+                    "control2",
+                    "control3",
+                    "control4",
+                    "control5",
+                    "control6",
+                ],
+                "model_type": ["type1", "type2", "type3", "type4", "type5", "type6"],
+                "contributing_group": [
+                    "group1",
+                    "group2",
+                    "group3",
+                    "group4",
+                    "group5",
+                    "group6",
+                ],
+                "study_synid": ["syn1", "syn2", "syn3", "syn4", "syn5", "syn6"],
+                "rrid": ["rrid1", "rrid2", "rrid3", "rrid4", "rrid5", "rrid6"],
+                "jax_id": [
+                    123,
+                    "456",
+                    7890,
+                    "123456",
+                    "",
+                    None,
+                ],  # Various formats to test
+                "alzforum_id": ["alz1", "alz2", "alz3", "alz4", "alz5", "alz6"],
+                "genotype": ["geno1", "geno2", "geno3", "geno4", "geno5", "geno6"],
+                "aliases": ["alias1", "alias2", "alias3", "alias4", "alias5", "alias6"],
+            }
+        )
+
+        # Create minimal required datasets for the transform function
+        allele_info_df = pd.DataFrame(
+            {
+                "model": ["model1", "model2", "model3", "model4", "model5", "model6"],
+                "modified_gene": ["gene1", "gene2", "gene3", "gene4", "gene5", "gene6"],
+                "gene_ensembl_id": ["ens1", "ens2", "ens3", "ens4", "ens5", "ens6"],
+                "allele": [
+                    "allele1",
+                    "allele2",
+                    "allele3",
+                    "allele4",
+                    "allele5",
+                    "allele6",
+                ],
+                "allele_type": ["type1", "type2", "type3", "type4", "type5", "type6"],
+                "mgi_allele_id": [1, 2, 3, 4, 5, 6],
+            }
+        )
+
+        human_transgene_allele_map_df = pd.DataFrame(
+            {
+                "mgi_allele_id": pd.Series(dtype="object"),
+                "gene_symbol": pd.Series(dtype="object"),
+                "human_ensembl_id": pd.Series(dtype="object"),
+            }
+        )
+
+        biomarkers_df = pd.DataFrame(
+            {
+                "model": pd.Series(dtype="object"),
+                "type": pd.Series(dtype="object"),
+                "measurement": pd.Series(dtype="object"),
+                "units": pd.Series(dtype="object"),
+                "age_death": pd.Series(dtype="object"),
+                "tissue": pd.Series(dtype="object"),
+                "sex": pd.Series(dtype="object"),
+                "genotype": pd.Series(dtype="object"),
+                "individual_id": pd.Series(dtype="object"),
+            }
+        )
+
+        pathology_df = pd.DataFrame(
+            {
+                "model": pd.Series(dtype="object"),
+                "type": pd.Series(dtype="object"),
+                "measurement": pd.Series(dtype="object"),
+                "units": pd.Series(dtype="object"),
+                "age_death": pd.Series(dtype="object"),
+                "tissue": pd.Series(dtype="object"),
+                "sex": pd.Series(dtype="object"),
+                "genotype": pd.Series(dtype="object"),
+                "individual_id": pd.Series(dtype="object"),
+            }
+        )
+
+        datasets = {
+            "model_info": model_info_df,
+            "allele_info": allele_info_df,
+            "human_transgene_allele_map": human_transgene_allele_map_df,
+            "biomarkers": biomarkers_df,
+            "pathology": pathology_df,
+        }
+
+        # Transform data
+        output = transform_model_details(datasets=datasets)
+
+        # Check that jax_id values are properly formatted
+        expected_jax_ids = ["000123", "000456", "007890", "123456", "", ""]
+
+        for i, model_entry in enumerate(output):
+            assert (
+                model_entry["jax_id"] == expected_jax_ids[i]
+            ), f"Expected jax_id '{expected_jax_ids[i]}' for model{i+1}, but got '{model_entry['jax_id']}'"
+
+        # Additional test: verify that the original DataFrame was not modified
+        # (the function should work on a copy)
+        assert (
+            model_info_df["jax_id"].iloc[0] == 123
+        ), "Original DataFrame should not be modified"


### PR DESCRIPTION
## Problem

JAX IDs in the model_details transformation were being stored as integers, which caused leading zeros to be lost. For example, JAX ID `4807` should be displayed as `004807` to maintain the proper 6-digit format that JAX uses for their mouse strain identifiers.

## Solution

Added logic in the `transform_model_details` function to preserve leading zeros in JAX IDs by converting them to strings with proper 6-digit zero-padding. The solution:

1. **Added JAX ID formatting logic** in `src/agoradatatools/etl/transform/model_details.py` (lines 216-220):
   ```python
   # Ensure jax_id preserves leading zeros by converting to string with proper formatting
   if "jax_id" in model_info_df.columns:
       model_info_df["jax_id"] = model_info_df["jax_id"].apply(
           lambda x: str(x).zfill(6) if pd.notna(x) and str(x).strip() != "" else x
       )
   ```

2. **Updated test assets** to reflect the new string format with leading zeros:
   - Input files continue to use integer format (e.g., `4807`, `5491`)
   - Output files now show properly formatted strings (e.g., `"004807"`, `"005491"`)

The implementation handles edge cases by:
- Only applying formatting when the `jax_id` column exists
- Preserving null/empty values without modification
- Using `zfill(6)` to ensure consistent 6-digit formatting

## Testing

The changes are verified through the existing test suite:

- **Input test files** contain JAX IDs as integers (e.g., `4807`, `5491`, `4808`, `5492`)
- **Output test files** now contain properly formatted strings with leading zeros (e.g., `"004807"`, `"005491"`, `"004808"`, `"005492"`)
- **All existing tests pass** with the updated expected outputs
- **Edge case handling** is tested through existing test scenarios that include missing data and empty values

The transformation maintains backward compatibility while ensuring JAX IDs are displayed in the correct format for downstream applications and user interfaces.