### PR TITLE
[dpe-1384] transform data to dataframe after apply_custom_transformations function

### DIFF
--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -19,9 +19,13 @@ def _login_to_synapse(token: str = None) -> synapseclient.Synapse:
     """
     syn = synapseclient.Synapse()
     if token is None:
-        syn.login()
+        syn.login(
+            authToken="eyJ0eXAiOiJKV1QiLCJraWQiOiJXN05OOldMSlQ6SjVSSzpMN1RMOlQ3TDc6M1ZYNjpKRU9VOjY0NFI6VTNJWDo1S1oyOjdaQ0s6RlBUSCIsImFsZyI6IlJTMjU2In0.eyJhY2Nlc3MiOnsic2NvcGUiOlsidmlldyIsImRvd25sb2FkIiwibW9kaWZ5Il0sIm9pZGNfY2xhaW1zIjp7fX0sInRva2VuX3R5cGUiOiJQRVJTT05BTF9BQ0NFU1NfVE9LRU4iLCJpc3MiOiJodHRwczovL3JlcG8tcHJvZC5wcm9kLnNhZ2ViYXNlLm9yZy9hdXRoL3YxIiwiYXVkIjoiMCIsIm5iZiI6MTc0MjA5NDUyNCwiaWF0IjoxNzQyMDk0NTI0LCJqdGkiOiIxNzYzNSIsInN1YiI6IjM0NDM3MDcifQ.oFloVSbUvRQEiqQWGqhoLi8xpmiMxCyNPCTylytfjab19yfDVjMRjpbkDNcr884cPt5JIwJRUoCmYwJ0hXgff3RPenVwqgZaOpiRgM8MjTL7FMIYg4-jxAnTZiJYdpA9AXCephfLau98SOy12SFt7CCSMXRV05IDtYgeVy1zV4nbFBD8MB3vSwlJonkytQ1-9CX0kv7EgFqfJcHhbxHTP1JkLa49-JJvEVYl9_I-RQy2sByGYBXLXUfioBtmnIF0lm91v75Zl3KuOkQLrC-qPuFUxa4sxFa2WzqotbDZtvVrnffKS7RZ0LS_wDt6mD29muQNzCJQyZ8MIU-HsB-9Fw"
+        )
     else:
-        syn.login(authToken=token)
+        syn.login(
+            authToken="eyJ0eXAiOiJKV1QiLCJraWQiOiJXN05OOldMSlQ6SjVSSzpMN1RMOlQ3TDc6M1ZYNjpKRU9VOjY0NFI6VTNJWDo1S1oyOjdaQ0s6RlBUSCIsImFsZyI6IlJTMjU2In0.eyJhY2Nlc3MiOnsic2NvcGUiOlsidmlldyIsImRvd25sb2FkIiwibW9kaWZ5Il0sIm9pZGNfY2xhaW1zIjp7fX0sInRva2VuX3R5cGUiOiJQRVJTT05BTF9BQ0NFU1NfVE9LRU4iLCJpc3MiOiJodHRwczovL3JlcG8tcHJvZC5wcm9kLnNhZ2ViYXNlLm9yZy9hdXRoL3YxIiwiYXVkIjoiMCIsIm5iZiI6MTc0MjA5NDUyNCwiaWF0IjoxNzQyMDk0NTI0LCJqdGkiOiIxNzYzNSIsInN1YiI6IjM0NDM3MDcifQ.oFloVSbUvRQEiqQWGqhoLi8xpmiMxCyNPCTylytfjab19yfDVjMRjpbkDNcr884cPt5JIwJRUoCmYwJ0hXgff3RPenVwqgZaOpiRgM8MjTL7FMIYg4-jxAnTZiJYdpA9AXCephfLau98SOy12SFt7CCSMXRV05IDtYgeVy1zV4nbFBD8MB3vSwlJonkytQ1-9CX0kv7EgFqfJcHhbxHTP1JkLa49-JJvEVYl9_I-RQy2sByGYBXLXUfioBtmnIF0lm91v75Zl3KuOkQLrC-qPuFUxa4sxFa2WzqotbDZtvVrnffKS7RZ0LS_wDt6mD29muQNzCJQyZ8MIU-HsB-9Fw"
+        )
     return syn
 
 
@@ -307,7 +311,7 @@ def convert_transformation_result_to_dataframe(
     dataset_name: str,
 ) -> Union[DataFrame, Dict[str, Any]]:
     """
-    Convert the result of a custom transformation to a pandas DataFrame or keep the dictionary as is.
+    Convert the result of a custom transformation to a pandas DataFrame or keep the original dictionary to ensure backward compatibility.
 
     Args:
         result: The result from a custom transformation function
@@ -322,7 +326,7 @@ def convert_transformation_result_to_dataframe(
 
     if isinstance(result, DataFrame) or isinstance(result, dict):
         return result
-    elif isinstance(result, list):
+    elif isinstance(result, list) or isinstance(result, dict):
         return pd.DataFrame(result)
     else:
         raise TypeError(

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -326,7 +326,7 @@ def convert_transformation_result_to_dataframe(
 
     if isinstance(result, DataFrame) or isinstance(result, dict):
         return result
-    elif isinstance(result, list) or isinstance(result, dict):
+    elif isinstance(result, list):
         return pd.DataFrame(result)
     else:
         raise TypeError(

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -305,7 +305,7 @@ def remove_duplicates_keep_order(lst: List[Any]) -> List[Any]:
 def convert_transformation_result_to_dataframe(
     result: Union[DataFrame, Dict[str, Any], List[Dict[str, Any]], Any],
     dataset_name: str,
-) -> DataFrame:
+) -> Union[DataFrame, Dict[str, Any]]:
     """Convert the result of a custom transformation to a pandas DataFrame.
 
     Args:
@@ -313,15 +313,14 @@ def convert_transformation_result_to_dataframe(
         dataset_name (str): Name of the dataset for error reporting
 
     Returns:
-        DataFrame: The converted result as a pandas DataFrame
+        DataFrame: The converted result as a pandas DataFrame or a dictionary
 
     Raises:
         TypeError: If the result type is not supported for conversion
     """
-    if isinstance(result, DataFrame):
+
+    if isinstance(result, DataFrame) or isinstance(result, dict):
         return result
-    elif isinstance(result, dict):
-        return DataFrame.from_dict(result)
     elif isinstance(result, list):
         return pd.DataFrame(result)
     else:

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -314,7 +314,7 @@ def convert_transformation_result_to_dataframe(
         dataset_name (str): Name of the dataset for error reporting
 
     Returns:
-        DataFrame: The converted result as a pandas DataFrame or a dictionary
+        pd.DataFrame or dict: The converted result as a pandas DataFrame or a dictionary
 
     Raises:
         TypeError: If the result type is not supported for conversion

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -19,13 +19,9 @@ def _login_to_synapse(token: str = None) -> synapseclient.Synapse:
     """
     syn = synapseclient.Synapse()
     if token is None:
-        syn.login(
-            authToken="eyJ0eXAiOiJKV1QiLCJraWQiOiJXN05OOldMSlQ6SjVSSzpMN1RMOlQ3TDc6M1ZYNjpKRU9VOjY0NFI6VTNJWDo1S1oyOjdaQ0s6RlBUSCIsImFsZyI6IlJTMjU2In0.eyJhY2Nlc3MiOnsic2NvcGUiOlsidmlldyIsImRvd25sb2FkIiwibW9kaWZ5Il0sIm9pZGNfY2xhaW1zIjp7fX0sInRva2VuX3R5cGUiOiJQRVJTT05BTF9BQ0NFU1NfVE9LRU4iLCJpc3MiOiJodHRwczovL3JlcG8tcHJvZC5wcm9kLnNhZ2ViYXNlLm9yZy9hdXRoL3YxIiwiYXVkIjoiMCIsIm5iZiI6MTc0MjA5NDUyNCwiaWF0IjoxNzQyMDk0NTI0LCJqdGkiOiIxNzYzNSIsInN1YiI6IjM0NDM3MDcifQ.oFloVSbUvRQEiqQWGqhoLi8xpmiMxCyNPCTylytfjab19yfDVjMRjpbkDNcr884cPt5JIwJRUoCmYwJ0hXgff3RPenVwqgZaOpiRgM8MjTL7FMIYg4-jxAnTZiJYdpA9AXCephfLau98SOy12SFt7CCSMXRV05IDtYgeVy1zV4nbFBD8MB3vSwlJonkytQ1-9CX0kv7EgFqfJcHhbxHTP1JkLa49-JJvEVYl9_I-RQy2sByGYBXLXUfioBtmnIF0lm91v75Zl3KuOkQLrC-qPuFUxa4sxFa2WzqotbDZtvVrnffKS7RZ0LS_wDt6mD29muQNzCJQyZ8MIU-HsB-9Fw"
-        )
+        syn.login()
     else:
-        syn.login(
-            authToken="eyJ0eXAiOiJKV1QiLCJraWQiOiJXN05OOldMSlQ6SjVSSzpMN1RMOlQ3TDc6M1ZYNjpKRU9VOjY0NFI6VTNJWDo1S1oyOjdaQ0s6RlBUSCIsImFsZyI6IlJTMjU2In0.eyJhY2Nlc3MiOnsic2NvcGUiOlsidmlldyIsImRvd25sb2FkIiwibW9kaWZ5Il0sIm9pZGNfY2xhaW1zIjp7fX0sInRva2VuX3R5cGUiOiJQRVJTT05BTF9BQ0NFU1NfVE9LRU4iLCJpc3MiOiJodHRwczovL3JlcG8tcHJvZC5wcm9kLnNhZ2ViYXNlLm9yZy9hdXRoL3YxIiwiYXVkIjoiMCIsIm5iZiI6MTc0MjA5NDUyNCwiaWF0IjoxNzQyMDk0NTI0LCJqdGkiOiIxNzYzNSIsInN1YiI6IjM0NDM3MDcifQ.oFloVSbUvRQEiqQWGqhoLi8xpmiMxCyNPCTylytfjab19yfDVjMRjpbkDNcr884cPt5JIwJRUoCmYwJ0hXgff3RPenVwqgZaOpiRgM8MjTL7FMIYg4-jxAnTZiJYdpA9AXCephfLau98SOy12SFt7CCSMXRV05IDtYgeVy1zV4nbFBD8MB3vSwlJonkytQ1-9CX0kv7EgFqfJcHhbxHTP1JkLa49-JJvEVYl9_I-RQy2sByGYBXLXUfioBtmnIF0lm91v75Zl3KuOkQLrC-qPuFUxa4sxFa2WzqotbDZtvVrnffKS7RZ0LS_wDt6mD29muQNzCJQyZ8MIU-HsB-9Fw"
-        )
+        syn.login(authToken=token)
     return syn
 
 

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import synapseclient
 import yaml
+from pandas import DataFrame
 
 
 # TODO remove "_" - these utils functions are not only used internally
@@ -299,3 +300,31 @@ def remove_duplicates_keep_order(lst: List[Any]) -> List[Any]:
         if item not in result:
             result.append(item)
     return result
+
+
+def convert_transformation_result_to_dataframe(
+    result: Union[DataFrame, Dict[str, Any], List[Dict[str, Any]], Any],
+    dataset_name: str,
+) -> DataFrame:
+    """Convert the result of a custom transformation to a pandas DataFrame.
+
+    Args:
+        result: The result from a custom transformation function
+        dataset_name (str): Name of the dataset for error reporting
+
+    Returns:
+        DataFrame: The converted result as a pandas DataFrame
+
+    Raises:
+        TypeError: If the result type is not supported for conversion
+    """
+    if isinstance(result, DataFrame):
+        return result
+    elif isinstance(result, dict):
+        return DataFrame.from_dict(result)
+    elif isinstance(result, list):
+        return pd.DataFrame(result)
+    else:
+        raise TypeError(
+            f"Custom transformation for dataset {dataset_name} returned an unsupported type: {type(result)}."
+        )

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -306,7 +306,8 @@ def convert_transformation_result_to_dataframe(
     result: Union[DataFrame, Dict[str, Any], List[Dict[str, Any]], Any],
     dataset_name: str,
 ) -> Union[DataFrame, Dict[str, Any]]:
-    """Convert the result of a custom transformation to a pandas DataFrame.
+    """
+    Convert the result of a custom transformation to a pandas DataFrame or keep the dictionary as is.
 
     Args:
         result: The result from a custom transformation function

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -4,6 +4,7 @@ from typing import Optional, Union, Dict, Any
 import inspect
 import synapseclient
 from pandas import DataFrame
+import pandas as pd
 from typer import Argument, Option, Typer
 
 from agoradatatools.errors import ADTDataProcessingError, ADTDataValidationError
@@ -159,11 +160,13 @@ def process_dataset(
         entities_as_df[entity_name] = df
 
     if "custom_transformations" in dataset_obj[dataset_name].keys():
-        df = apply_custom_transformations(
+        result = apply_custom_transformations(
             datasets=entities_as_df,
             dataset_name=dataset_name,
             dataset_obj=dataset_obj[dataset_name],
         )
+        df = convert_transformation_result_to_dataframe(result, dataset_name)
+        
     else:
         df = entities_as_df[list(entities_as_df)[0]]
 
@@ -378,6 +381,33 @@ def process_all_files(
         )
 
     reporter.update_table()
+
+
+def convert_transformation_result_to_dataframe(
+    result: Union[DataFrame, dict, list, Any], dataset_name: str
+) -> DataFrame:
+    """Convert the result of a custom transformation to a pandas DataFrame.
+
+    Args:
+        result: The result from a custom transformation function
+        dataset_name (str): Name of the dataset for error reporting
+
+    Returns:
+        DataFrame: The converted result as a pandas DataFrame
+
+    Raises:
+        TypeError: If the result type is not supported for conversion
+    """
+    if isinstance(result, DataFrame):
+        return result
+    elif isinstance(result, dict):
+        return DataFrame.from_dict(result)
+    elif isinstance(result, list):
+        return pd.DataFrame(result)
+    else:
+        raise TypeError(
+            f"Custom transformation for dataset {dataset_name} returned an unsupported type: {type(result)}."
+        )
 
 
 app = Typer()

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -166,7 +166,7 @@ def process_dataset(
             dataset_obj=dataset_obj[dataset_name],
         )
         df = convert_transformation_result_to_dataframe(result, dataset_name)
-        
+
     else:
         df = entities_as_df[list(entities_as_df)[0]]
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -1,6 +1,6 @@
 import logging
 import warnings
-from typing import Optional, Union, Dict, Any
+from typing import Optional, Union, Dict, Any, List
 import inspect
 import synapseclient
 from pandas import DataFrame
@@ -22,7 +22,7 @@ def apply_custom_transformations(
     datasets: Dict[str, Any],
     dataset_name: str,
     dataset_obj: Dict[str, Any],
-) -> Union[DataFrame, dict, None]:
+) -> Union[DataFrame, Dict[str, Any], List[Dict[str, Any]], None]:
     """Apply custom transformations to the dataset based on the provided function names and parameters.
 
     Args:

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -4,7 +4,6 @@ from typing import Optional, Union, Dict, Any, List
 import inspect
 import synapseclient
 from pandas import DataFrame
-import pandas as pd
 from typer import Argument, Option, Typer
 
 from agoradatatools.errors import ADTDataProcessingError, ADTDataValidationError
@@ -165,7 +164,7 @@ def process_dataset(
             dataset_name=dataset_name,
             dataset_obj=dataset_obj[dataset_name],
         )
-        df = convert_transformation_result_to_dataframe(result, dataset_name)
+        df = utils.convert_transformation_result_to_dataframe(result, dataset_name)
 
     else:
         df = entities_as_df[list(entities_as_df)[0]]
@@ -381,33 +380,6 @@ def process_all_files(
         )
 
     reporter.update_table()
-
-
-def convert_transformation_result_to_dataframe(
-    result: Union[DataFrame, dict, list, Any], dataset_name: str
-) -> DataFrame:
-    """Convert the result of a custom transformation to a pandas DataFrame.
-
-    Args:
-        result: The result from a custom transformation function
-        dataset_name (str): Name of the dataset for error reporting
-
-    Returns:
-        DataFrame: The converted result as a pandas DataFrame
-
-    Raises:
-        TypeError: If the result type is not supported for conversion
-    """
-    if isinstance(result, DataFrame):
-        return result
-    elif isinstance(result, dict):
-        return DataFrame.from_dict(result)
-    elif isinstance(result, list):
-        return pd.DataFrame(result)
-    else:
-        raise TypeError(
-            f"Custom transformation for dataset {dataset_name} returned an unsupported type: {type(result)}."
-        )
 
 
 app = Typer()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -553,7 +553,7 @@ class TestProcessDataset:
             },
         )
         self.patch_df_to_json.assert_called_once()
-        args, kwargs = self.patch_df_to_json.call_args
+        _, kwargs = self.patch_df_to_json.call_args
 
         assert kwargs["staging_path"] == STAGING_PATH
         assert kwargs["filename"] == "neuropath_corr.json"

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -417,12 +417,12 @@ class TestProcessDataset:
         ).start()
         self.patch_load = patch.object(load, "load", return_value=("syn123", 1)).start()
         self.patch_custom_transform = patch.object(
-            process, "apply_custom_transformations", return_value=pd.DataFrame
+            process, "apply_custom_transformations", return_value=pd.DataFrame()
         ).start()
         self.patch_convert_transformation_result_to_dataframe = patch.object(
             utils,
             "convert_transformation_result_to_dataframe",
-            return_value=pd.DataFrame,
+            return_value=pd.DataFrame(),
         ).start()
         self.patch_dict_to_json = patch.object(
             load, "dict_to_json", return_value="path/to/json"

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -551,7 +551,7 @@ class TestProcessDataset:
             },
         )
         self.patch_df_to_json.assert_called_once_with(
-            df=pd.DataFrame, staging_path=STAGING_PATH, filename="neuropath_corr.json"
+            df=pd.DataFrame(), staging_path=STAGING_PATH, filename="neuropath_corr.json"
         )
         self.patch_dict_to_json.assert_not_called()
         self.patch_list_to_json.assert_not_called()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -508,9 +508,11 @@ class TestProcessDataset:
             df=pd.DataFrame, column_map={"col_1": "new_col_1", "col_2": "new_col_2"}
         )
         self.patch_custom_transform.assert_not_called()
+
         self.patch_df_to_json.assert_called_once_with(
-            df=pd.DataFrame, staging_path=STAGING_PATH, filename="neuropath_corr.json"
+            df=pd.DataFrame(), staging_path=STAGING_PATH, filename="neuropath_corr.json"
         )
+
         self.patch_dict_to_json.assert_not_called()
         self.patch_list_to_json.assert_not_called()
         self.patch_gx_runner_run.assert_not_called()
@@ -550,9 +552,12 @@ class TestProcessDataset:
                 "custom_transformations": "test_transformation",
             },
         )
-        self.patch_df_to_json.assert_called_once_with(
-            df=pd.DataFrame(), staging_path=STAGING_PATH, filename="neuropath_corr.json"
-        )
+        self.patch_df_to_json.assert_called_once()
+        args, kwargs = self.patch_df_to_json.call_args
+
+        assert kwargs["staging_path"] == STAGING_PATH
+        assert kwargs["filename"] == "neuropath_corr.json"
+        pd.testing.assert_frame_equal(kwargs["df"], pd.DataFrame())
         self.patch_dict_to_json.assert_not_called()
         self.patch_list_to_json.assert_not_called()
         self.patch_gx_runner_run.assert_not_called()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -419,6 +419,11 @@ class TestProcessDataset:
         self.patch_custom_transform = patch.object(
             process, "apply_custom_transformations", return_value=pd.DataFrame
         ).start()
+        self.patch_convert_transformation_result_to_dataframe = patch.object(
+            utils,
+            "convert_transformation_result_to_dataframe",
+            return_value=pd.DataFrame,
+        ).start()
         self.patch_dict_to_json = patch.object(
             load, "dict_to_json", return_value="path/to/json"
         ).start()
@@ -533,6 +538,7 @@ class TestProcessDataset:
             df=self.patch_standardize_column_names.return_value
         )
         self.patch_rename_columns.assert_not_called()
+
         self.patch_custom_transform.assert_called_once_with(
             datasets={"test_file_1": pd.DataFrame},
             dataset_name="neuropath_corr",

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -508,10 +508,13 @@ class TestProcessDataset:
             df=pd.DataFrame, column_map={"col_1": "new_col_1", "col_2": "new_col_2"}
         )
         self.patch_custom_transform.assert_not_called()
+        
+        self.patch_df_to_json.assert_called_once()
+        _, kwargs = self.patch_df_to_json.call_args
 
-        self.patch_df_to_json.assert_called_once_with(
-            df=pd.DataFrame(), staging_path=STAGING_PATH, filename="neuropath_corr.json"
-        )
+        assert kwargs["staging_path"] == STAGING_PATH
+        assert kwargs["filename"] == "neuropath_corr.json"
+        pd.testing.assert_frame_equal(kwargs["df"], pd.DataFrame())
 
         self.patch_dict_to_json.assert_not_called()
         self.patch_list_to_json.assert_not_called()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -514,7 +514,8 @@ class TestProcessDataset:
 
         assert kwargs["staging_path"] == STAGING_PATH
         assert kwargs["filename"] == "neuropath_corr.json"
-        pd.testing.assert_frame_equal(kwargs["df"], pd.DataFrame())
+        df = kwargs["df"]
+        pd.testing.assert_frame_equal(df(), pd.DataFrame())
 
         self.patch_dict_to_json.assert_not_called()
         self.patch_list_to_json.assert_not_called()
@@ -593,9 +594,15 @@ class TestProcessDataset:
             df=pd.DataFrame, column_map={"col_1": "new_col_1", "col_2": "new_col_2"}
         )
         self.patch_custom_transform.assert_not_called()
-        self.patch_df_to_json.assert_called_once_with(
-            df=pd.DataFrame, staging_path=STAGING_PATH, filename="neuropath_corr.json"
-        )
+
+        self.patch_df_to_json.assert_called_once()
+        _, kwargs = self.patch_df_to_json.call_args
+
+        assert kwargs["staging_path"] == STAGING_PATH
+        assert kwargs["filename"] == "neuropath_corr.json"
+        df = kwargs["df"]
+        pd.testing.assert_frame_equal(df(), pd.DataFrame())
+
         self.patch_dict_to_json.assert_not_called()
         self.patch_list_to_json.assert_not_called()
         self.patch_gx_runner_run.assert_not_called()

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -508,7 +508,7 @@ class TestProcessDataset:
             df=pd.DataFrame, column_map={"col_1": "new_col_1", "col_2": "new_col_2"}
         )
         self.patch_custom_transform.assert_not_called()
-        
+
         self.patch_df_to_json.assert_called_once()
         _, kwargs = self.patch_df_to_json.call_args
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -467,13 +467,18 @@ class TestRemoveDuplicatesKeepOrder:
 
 
 class TestConvertTransformationResultToDataFrame:
+    """Tests the convert_transformation_result_to_dataframe function
+    with various input types to ensure it correctly converts"""
+
     def test_convert_transformation_result_to_dataframe_with_df(self):
+        """Test with a pandas DataFrame input"""
         result = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
         df = utils.convert_transformation_result_to_dataframe(result, "test_dataset")
         assert isinstance(df, pd.DataFrame)
         assert df.equals(result)
 
     def test_convert_transformation_result_to_dataframe_with_dict(self):
+        "Test with a dictionary input"
         result = {"a": [1, 2], "b": [3, 4]}
         df = utils.convert_transformation_result_to_dataframe(result, "test_dataset")
         assert isinstance(df, pd.DataFrame)
@@ -481,6 +486,7 @@ class TestConvertTransformationResultToDataFrame:
         assert df.equals(expected_df)
 
     def test_convert_transformation_result_to_dataframe_with_list_of_dicts(self):
+        """Test with a list of dictionaries input"""
         result = [{"a": 1, "b": 3}, {"a": 2, "b": 4}]
         df = utils.convert_transformation_result_to_dataframe(result, "test_dataset")
         assert isinstance(df, pd.DataFrame)
@@ -488,6 +494,7 @@ class TestConvertTransformationResultToDataFrame:
         assert df.equals(expected_df)
 
     def test_convert_transformation_result_to_dataframe_with_wrong_type(self):
+        """Test with an unsupported type input"""
         result = True
         with pytest.raises(
             TypeError,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -473,17 +473,20 @@ class TestConvertTransformationResultToDataFrame:
     def test_convert_transformation_result_to_dataframe_with_df(self):
         """Test with a pandas DataFrame input"""
         result = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
-        df = utils.convert_transformation_result_to_dataframe(result, "test_dataset")
-        assert isinstance(df, pd.DataFrame)
-        assert df.equals(result)
+        output = utils.convert_transformation_result_to_dataframe(
+            result, "test_dataset"
+        )
+        assert isinstance(output, pd.DataFrame)
+        assert output.equals(result)
 
     def test_convert_transformation_result_to_dataframe_with_dict(self):
         "Test with a dictionary input"
         result = {"a": [1, 2], "b": [3, 4]}
-        df = utils.convert_transformation_result_to_dataframe(result, "test_dataset")
-        assert isinstance(df, pd.DataFrame)
-        expected_df = pd.DataFrame(result)
-        assert df.equals(expected_df)
+        output = utils.convert_transformation_result_to_dataframe(
+            result, "test_dataset"
+        )
+        assert isinstance(output, dict)
+        assert output == result
 
     def test_convert_transformation_result_to_dataframe_with_list_of_dicts(self):
         """Test with a list of dictionaries input"""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -464,3 +464,33 @@ class TestRemoveDuplicatesKeepOrder:
     def test_remove_duplicates_preserves_order(self):
         input_list = ["a", "b", "a", "c", "b", "d"]
         assert utils.remove_duplicates_keep_order(input_list) == ["a", "b", "c", "d"]
+
+
+class TestConvertTransformationResultToDataFrame:
+    def test_convert_transformation_result_to_dataframe_with_df(self):
+        result = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+        df = utils.convert_transformation_result_to_dataframe(result, "test_dataset")
+        assert isinstance(df, pd.DataFrame)
+        assert df.equals(result)
+
+    def test_convert_transformation_result_to_dataframe_with_dict(self):
+        result = {"a": [1, 2], "b": [3, 4]}
+        df = utils.convert_transformation_result_to_dataframe(result, "test_dataset")
+        assert isinstance(df, pd.DataFrame)
+        expected_df = pd.DataFrame(result)
+        assert df.equals(expected_df)
+
+    def test_convert_transformation_result_to_dataframe_with_list_of_dicts(self):
+        result = [{"a": 1, "b": 3}, {"a": 2, "b": 4}]
+        df = utils.convert_transformation_result_to_dataframe(result, "test_dataset")
+        assert isinstance(df, pd.DataFrame)
+        expected_df = pd.DataFrame(result)
+        assert df.equals(expected_df)
+
+    def test_convert_transformation_result_to_dataframe_with_wrong_type(self):
+        result = True
+        with pytest.raises(
+            TypeError,
+            match="Custom transformation for dataset test_dataset returned an unsupported type",
+        ):
+            utils.convert_transformation_result_to_dataframe(result, "test_dataset")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -488,9 +488,24 @@ class TestConvertTransformationResultToDataFrame:
         assert isinstance(output, dict)
         assert output == result
 
-    def test_convert_transformation_result_to_dataframe_with_list_of_dicts(self):
+    @pytest.mark.parametrize(
+        "result",
+        [
+            [
+                {"model": "LOAD1", "matched_controls": "value", "model_type": "LOAD"},
+                {
+                    "model": "5XFAD",
+                    "matched_controls": ["value1", "value2"],
+                    "model_type": "familial",
+                },
+            ],
+            [{"a": 1, "b": 3}, {"a": 2, "b": 4}],
+        ],
+    )
+    def test_convert_transformation_result_to_dataframe_with_list_of_dicts(
+        self, result
+    ):
         """Test with a list of dictionaries input"""
-        result = [{"a": 1, "b": 3}, {"a": 2, "b": 4}]
         df = utils.convert_transformation_result_to_dataframe(result, "test_dataset")
         assert isinstance(df, pd.DataFrame)
         expected_df = pd.DataFrame(result)


### PR DESCRIPTION
## Problem: 
Two custom transformation functions listed in `local_config.yaml`: `transform_model_details` and `transform_disease_correlation` transform the data as a list of dictionaries instead of pandas dataframes. That caused the pipeline to fail when renaming the columns in a later step. 

## Solution:
I was initially considering two approaches:
1. Modify transform_model_details and transform_disease_correlation directly so that they return a pandas DataFrame, consistent with our other transformation functions.
2. Handle the DataFrame transformation in a separate step after applying custom transformation functions, which would also ensure that operations like renaming columns proceed smoothly.

I think the second approach is more general and robust. It allows custom transform functions to remain flexible, without being constrained to always produce a specific output type. This separation of concerns also makes it easier to debug later. 

## Test
1. Obtain local_config.yaml from https://sagebionetworks.jira.com/browse/DPE-1384
2. Run `adt local_config.yaml`
a. disease_correlation.json with the model key
b. disease_correlation_with_agora_rename.json with the name key
c. model_details.json with the study_synid key
d. model_details.json_with_agora_rename with the something_else key
c. network.json with multiple aliased keys 
d. neuropath_corr.json with multiple aliased keys