### PR TITLE
[DPE-1400] Fix: update python requirement in the setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     pyarrow~=14.0.1
     typer~=0.7.0
     great-expectations==0.18.1
-python_requires = >=3.8, <3.12
+python_requires = >=3.10, <3.12
 include_package_data = True
 zip_safe = False
 [options.packages.find]


### PR DESCRIPTION
## Problem 
A user was using Python 3.9 when running `adt modelad_test_config.yaml`: 
```
pathology:
 unsupported operand type(s) for |: 'types.GenericAlias' and 'type'
Traceback (most recent call last):
  File "/workspaces/agora-data-tools/src/agoradatatools/process.py", line 327, in process_all_files
    dataset_report = process_dataset(
  File "/workspaces/agora-data-tools/src/agoradatatools/logs.py", line 46, in wrapped
    elapsed_time_formatted, result = time_function(func, *args, **kwargs)
  File "/workspaces/agora-data-tools/src/agoradatatools/logs.py", line 15, in time_function
    result = func(*args, **kwargs)
  File "/workspaces/agora-data-tools/src/agoradatatools/process.py", line 199, in process_dataset
    gx_runner = GreatExpectationsRunner(
  File "/workspaces/agora-data-tools/src/agoradatatools/gx.py", line 75, in __init__
    from expectations.expect_column_nested_field_values_to_be_mostly_not_null import (
  File "/workspaces/agora-data-tools/src/agoradatatools/great_expectations/gx/plugins/expectations/expect_column_nested_field_values_to_be_mostly_not_null.py", line 163, in <module>
    class ExpectColumnNestedObjectNotNull(ColumnAggregateExpectation):
  File "/workspaces/agora-data-tools/src/agoradatatools/great_expectations/gx/plugins/expectations/expect_column_nested_field_values_to_be_mostly_not_null.py", line 321, in ExpectColumnNestedObjectNotNull
    ) -> dict[str, dict[str, float] | bool]:
TypeError: unsupported operand type(s) for |: 'types.GenericAlias' and 'type'
```

## Solution
Remove supporting Python 3.9 and below in the setup.cfg