### PR TITLE
Updated github actions to include modelad test config

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -66,6 +66,7 @@ jobs:
       - run: pip install -U setuptools
       - run: pip install .
       - run: adt test_config.yaml --upload --platform GITHUB --run_id ${{ github.run_id }} --token ${{secrets.SYNAPSE_PAT}}
+      - run: adt modelad_test_config.yaml --platform GITHUB --run_id ${{ github.run_id }} --token ${{secrets.SYNAPSE_PAT}}
 
   ghcr-publish:
     needs: [build, test]


### PR DESCRIPTION
## Problem

The CI does not currently test any of the Model AD transforms. We have already had issues where the developer (me) forgets to test the entire ADT pipeline before merging a PR, which has resulted in annoying Nextflow failures. To avoid this, we would like CI to run `adt modelad_test_config.yaml` without the `--upload` flag (we don't need to test that specific part of the pipeline twice).

The existing testing suite cannot catch config related issues, such as incorrect use of the `column_rename` parameter.

## Solution

Add a new CI job that runs the Model AD transforms without uploading to Synapse. This will ensure that all Model AD transformations are tested as part of the CI pipeline, catching any issues before they reach production.

This will provide confidence that Model AD transforms are working correctly before any code is merged to the dev branch.