### PR TITLE
MG-314: Update model_overview.link_name to link_text to match ui_config

### DIFF
--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -147,7 +147,7 @@ def transform_model_overview(
             else None
         )
         row["center"] = (
-            {"link_name": row["contributing_group"]}
+            {"link_text": row["contributing_group"]}
             if row["contributing_group"]
             else None
         )

--- a/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
@@ -20,7 +20,7 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": [
       "App",
@@ -49,7 +49,7 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": []
   },
@@ -72,7 +72,7 @@
       "link_url": "https://jax.org/strain/27894"
     },
     "center": {
-      "link_name": "IU/JAX/PITT"
+      "link_text": "IU/JAX/PITT"
     },
     "modified_genes": []
   }

--- a/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
@@ -18,7 +18,7 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": [
       "App",
@@ -45,7 +45,7 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": []
   },
@@ -68,7 +68,7 @@
       "link_url": "https://jax.org/strain/27894"
     },
     "center": {
-      "link_name": "IU/JAX/PITT"
+      "link_text": "IU/JAX/PITT"
     },
     "modified_genes": []
   }

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
@@ -18,7 +18,7 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": [
       "Psen1"
@@ -43,7 +43,7 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": []
   },
@@ -66,7 +66,7 @@
       "link_url": "https://jax.org/strain/27894"
     },
     "center": {
-      "link_name": "IU/JAX/PITT"
+      "link_text": "IU/JAX/PITT"
     },
     "modified_genes": []
   }

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
@@ -18,7 +18,7 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": [
       "APP",
@@ -41,7 +41,7 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": []
   }

--- a/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
@@ -18,7 +18,7 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": [
       "App",
@@ -45,7 +45,7 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_name": "UCI"
+      "link_text": "UCI"
     },
     "modified_genes": []
   },
@@ -68,7 +68,7 @@
       "link_url": "https://jax.org/strain/27894"
     },
     "center": {
-      "link_name": "IU/JAX/PITT"
+      "link_text": "IU/JAX/PITT"
     },
     "modified_genes": []
   }

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -289,7 +289,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
-                "center": {"link_name": "Test Center"},
+                "center": {"link_text": "Test Center"},
                 "modified_genes": ["TestGene"],
             }
         ]
@@ -365,7 +365,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
-                "center": {"link_name": "Test Center"},
+                "center": {"link_text": "Test Center"},
                 "modified_genes": [],
             }
         ]
@@ -449,7 +449,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn111"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/111"},
-                "center": {"link_name": "Center1"},
+                "center": {"link_text": "Center1"},
                 "modified_genes": ["Gene1", "Gene2"],
             },
             {
@@ -466,7 +466,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn222"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/222"},
-                "center": {"link_name": "Center2"},
+                "center": {"link_text": "Center2"},
                 "modified_genes": ["Gene3"],
             },
         ]


### PR DESCRIPTION
This PR fixes an inconsistency with field naming between `model_overview` and `ui_config` by:

* Updating `link_name` -> `link_text` in `model_overview` to align with the field name in `ui_config`
* Updating all test cases to expect the new field name