### PR TITLE
[DPE-1411] Fix: correct off-by-one version reference in data_manifest.csv

### DIFF
--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -272,7 +272,8 @@ def create_data_manifest(
             "id": file["id"],
             "version": (
                 file["versionNumber"] + 1
-                if file["name"] == "data_manifest.csv" or file["name"] == "dataversion.json"
+                if file["name"] == "data_manifest.csv"
+                or file["name"] == "dataversion.json"
                 else file["versionNumber"]
             ),
         }

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -272,7 +272,7 @@ def create_data_manifest(
             "id": file["id"],
             "version": (
                 file["versionNumber"] + 1
-                if file["name"] == "data_manifest.csv"
+                if file["name"] == "data_manifest.csv" or file["name"] == "dataversion.json"
                 else file["versionNumber"]
             ),
         }


### PR DESCRIPTION
# Problem: 
`data_manifest.csv` references the wrong version of dataversion.json (off by one). See screenshot: 

<img width="700" height="500" alt="Screenshot 2025-07-29 at 3 21 29 PM" src="https://github.com/user-attachments/assets/ffe6ecd9-d051-4d51-b1fd-6c10b93bcb06" />

This error occurred because the dataframe of the manifest was created before `dataversion.json` was updated. 

# Solution 
Incremented `dataversion.json` version by 1 when creating the manifest. 

# Test
Tested with my test project and folders to ensure that dataversion.json and data_manifest.csv reference each other correctly.

✅ As shown in the screenshot, the `data_manifest.csv` references version 3 of dataversion.json which is correct
<img width="700" height="500" alt="Screenshot 2025-07-29 at 4 22 36 PM" src="https://github.com/user-attachments/assets/5c4718b1-43d6-4647-b917-42e07cf2f092" />
✅ `data_manifest.csv` references itself correctly 
✅ `dataversion.json` references `data_manifest.csv` correctly

<img width="700" height="500" alt="Screenshot 2025-07-29 at 4 25 37 PM" src="https://github.com/user-attachments/assets/5d5c6de3-c28d-4c98-8001-11ca5bb613e1" />
