### PR TITLE
AG-1827: Update source file version for tep_adi_info to pick up new TEP targets

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -165,7 +165,7 @@ datasets:
           format: csv
         - <<: *genes_biodomains_files
         - name: tep_adi_info
-          id: syn51942280.4
+          id: syn51942280.6
           format: csv
         - name: ensg_to_uniprot_mapping
           id: syn54113663.5
@@ -204,7 +204,7 @@ datasets:
         - syn12540368.54
         - syn27211878.2
         - *genes_biodomains_provenance
-        - syn51942280.4
+        - syn51942280.6
         - syn54113663.5
         - syn64123611.2
       agora_rename:

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -165,7 +165,7 @@ datasets:
           format: csv
         - <<: *genes_biodomains_files
         - name: tep_adi_info
-          id: syn51942280.4
+          id: syn51942280.6
           format: csv
         - name: ensg_to_uniprot_mapping
           id: syn54113663.5
@@ -204,7 +204,7 @@ datasets:
         - syn12540368.54
         - syn27211878.2
         - *genes_biodomains_provenance
-        - syn51942280.4
+        - syn51942280.6
         - syn54113663.5
         - syn64123611.2
       agora_rename:


### PR DESCRIPTION
TEPs for seven additional targets are being developed by TREAT-AD, and we want to surface them in Agora.

A new version of the `tep_adi_info` source file that includes those new targets was created and uploaded to Synapse. This PR updates Agora's ADT configuration files to consume that new version of the source file.
