### PR TITLE
AG-1825: Bumped version of gene_info to v15 for Ensembl release 114

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -145,7 +145,7 @@ datasets:
   - gene_info:
       files:
         - name: gene_metadata
-          id: syn25953363.14
+          id: syn25953363.15
           format: feather
         - name: igap
           id: syn12514826.5
@@ -194,7 +194,7 @@ datasets:
         uniprotkb_accession: uniprotkb_accessions
         resource_identifier: ensembl_gene_id
       provenance:
-        - syn25953363.14
+        - syn25953363.15
         - syn12514826.5
         - syn12514912.3
         - *agora_proteomics_provenance

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -145,7 +145,7 @@ datasets:
   - gene_info:
       files:
         - name: gene_metadata
-          id: syn25953363.14
+          id: syn25953363.15
           format: feather
         - name: igap
           id: syn12514826.5
@@ -194,7 +194,7 @@ datasets:
         uniprotkb_accession: uniprotkb_accessions
         resource_identifier: ensembl_gene_id
       provenance:
-        - syn25953363.14
+        - syn25953363.15
         - syn12514826.5
         - syn12514912.3
         - *agora_proteomics_provenance


### PR DESCRIPTION
[JIRA ticket](https://sagebionetworks.jira.com/browse/AG-1825)

I ran Agora's Preprocess_Gene_Annotations notebook to update all gene annotations to Ensembl release 114, and bumped the version of the file in the configs to pull in the new version.