### PR TITLE
MG-322/MG-268: Update Pathology notebook

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -270,17 +270,13 @@ https://docs.google.com/spreadsheets/d/1B3ZMReC7nR2CGgpFNJuxJTj__lF2h6dt/edit?gi
 threex_pathology <- threex_pathology_source %>%
 
         # Filter out rows with unused 'Stain' values
-        filter(stain %in% stain_keeps)
+        filter(stain %in% stain_keeps
 
-threex_pathology
+        # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+        ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "3xTg-AD", keeps_with_pool_join_field
 
-# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-threex_pathology <- transform_results(threex_pathology, c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "3xTg-AD", keeps_with_pool_join_field)
-threex_pathology
-
-# Drop rows with NA measurements
-threex_pathology <-  filter(threex_pathology, !is.na(measurement))
-threex_pathology
+        # Drop rows with NA measurements
+        ) %>% filter(!is.na(measurement))
 ```
 
 
@@ -288,14 +284,14 @@ threex_pathology
 ### 5xFAD
 fivex_source_keeps <- c("IndividualID", "SpecimenID", "Stain")
 
-# 5xFAD colnames aren't consistent with other source data
+# 5xFAD colnames aren't consistent with other models
 fivex_rename_cols <- function (results) {
   results %>% dplyr::rename(c('stain' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID'))
 }
 
-# Filter source files to select desired rows by 'Stain' value, drop unneeded columns
+# Filter each source file to select desired rows by 'Stain' value, drop unneeded columns, and rename the remaining columns
 fivex_gfap_s100b <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain %in% c('GFAP', 'S100B'),] %>%
   select(c(fivex_source_keeps, "X.objects..sqmm"))  %>%
   fivex_rename_cols()
@@ -313,12 +309,12 @@ fivex_thios <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'ThioS',
   mutate(X.objects..sqmm = ifelse(X.objects..sqmm == "N/A", 0, X.objects..sqmm)) %>%
   fivex_rename_cols()
 
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
 model = "5xFAD (UCI)"
 fivex_gfap_s100b_pivot <- transform_results(fivex_gfap_s100b, c('X.objects..sqmm'), model, keeps_with_join_fields)
 fivex_lamp1_pivot <- transform_results(fivex_lamp1, c('Area..'), model, keeps_with_join_fields)
 fivex_iba1_pivot <- transform_results(fivex_iba1, c('X.objects..sqmm'), model, keeps_with_join_fields)
 fivex_thios_pivot <- transform_results(fivex_thios, c('X.objects..sqmm', 'mean.object.area..squm.'), model, keeps_with_join_fields)
-
 
 # Merge all results into a single data frame
 fivex_pathology <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_iba1_pivot, fivex_thios_pivot
@@ -331,8 +327,6 @@ fivex_pathology <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_ib
     ) %>% mutate(
             measurement = ifelse(is.na(measurement), 0, measurement)
 )
-
-fivex_pathology
 ```
 
 ### Trem2-R47H_NSS
@@ -340,17 +334,13 @@ fivex_pathology
 nss_pathology <- nss_pathology_source %>%
 
         # Filter out rows with unused 'Stain' values
-        filter(stain %in% stain_keeps)
+        filter(stain %in% stain_keeps
 
-nss_pathology
+        # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+        ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "Trem2-R47H_NSS", keeps_with_pool_join_field
 
-# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-nss_pathology <- transform_results(nss_pathology, c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "Trem2-R47H_NSS", keeps_with_pool_join_field)
-nss_pathology
-
-# Drop rows with NA measurements
-nss_pathology <-  filter(nss_pathology, !is.na(measurement))
-nss_pathology
+        # Drop rows with NA measurements
+        ) %>% filter(!is.na(measurement))
 ```
 
 ### Abca7*V1599M
@@ -358,21 +348,16 @@ nss_pathology
 abca7_pathology <- abca7_pathology_source %>%
 
         # Filter out rows with unused 'Stain' values
-        filter(stain %in% stain_keeps)
+        filter(stain %in% stain_keeps
 
-abca7_pathology
+        # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+        ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "Abca7*V1599M", keeps_with_pool_join_field
 
-# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-abca7_pathology <- transform_results(abca7_pathology, c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "Abca7*V1599M", keeps_with_pool_join_field)
-abca7_pathology
+        # Drop rows with NA measurements
+        ) %>% filter(!is.na(measurement)
 
-# Drop rows with NA measurements
-abca7_pathology <-  filter(abca7_pathology, !is.na(measurement))
-
-# Drop LAMP1 rows with measurements other than total object volume (cubic mm)
-abca7_pathology <-  filter(abca7_pathology, !(type == LAMP1_display_name & (units == objectDensity_display_name | units == averageObjectVolume_display_name)))
-
-abca7_pathology
+        # Drop LAMP1 rows with measurements other than total object volume (cubic mm)
+        ) %>% filter(!(type == LAMP1_display_name & (units == objectDensity_display_name | units == averageObjectVolume_display_name)))
 ```
 
 ## Sanity check generated files

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -1,4 +1,3 @@
-
 # Create Pathology source file (MG-40)
 
 This notebook generates a single harmonized source file (syn61357279) containing the results data and display values required to surface Pathology evidence in the Model-AD Explorer.
@@ -19,6 +18,7 @@ To incorporate each new model into this notebook:
 
 2. 'Generate model-specific intermediate files' section
 - Add a code block that generates an intermediate results file for the new model
+- You may need to modify the transform_results function to include new unit and type display value mappings
 
 3. 'Sanity check nrow in generated files' section
 - Add validation for the new model's intermediate file
@@ -28,7 +28,7 @@ To incorporate each new model into this notebook:
 
 5. 'Merge files, write csv file, and upload to synapse' section
 - Add the new model's intermediate file to the bind_rows call on the first line
-- Add genotype-genotype display name mappings for the new model
+- Add genotype display name mappings for the new model
 
 
 ADDING NEW MEASURES
@@ -74,18 +74,16 @@ library(tidyverse)
 ## Utility functions & variables
 Run this to initialize shared variables and functions.
 ```{r}
-# MODEL-AD 2.0 harmonized source file directory
-# ADP Backend > Files > 2.ConsortiumStudies > MODEL-AD Data Explorer > Model AD Explorer 2.0 Source Files
-synapse_folder <- 'syn51498054'
-
 # Measures (stain values) that we want to include
 stain_keeps <- c("GFAP", "S100B", "LAMP1", "IBA1", "ThioS", "HT7", "AT8")
 
-# Harmonized column specs for intermediate per-model files
-keeps_with_pool_join_field <- c('specimenID', 'model', 'type', 'measurement', 'units') # 3xTG-AD, NSS
-keeps_with_join_fields <- c('individualID', 'specimenID', 'model', 'type', 'measurement', 'units') # 5xFAD
+# column specs for intermediate per-model files
+# For result files without individualID column: 3xTG-AD, NSS, Abca7
+keeps_with_pool_join_field <- c('specimenID', 'model', 'type', 'measurement', 'units')
+# For result files with individualID column: 5xFAD
+keeps_with_join_fields <- c('individualID', 'specimenID', 'model', 'type', 'measurement', 'units')
 
-# Harmonized column spec for final output file
+# column spec for final harmonized output file
 keeps <- c('individualID', 'specimenID', 'model', 'type', 'measurement', 'units', 'ageDeath', 'tissue', 'sex', 'genotype')
 
 # Pathology display names
@@ -98,20 +96,20 @@ HT7_display_name <- 'Tau (HT7)'
 ThioS_density_display_name <- 'Plaque Density (Thio-S)'
 ThioS_size_display_name <- 'Plaque Size (Thio-S)'
 
-
 # Pathology display units
 objectDensity_display_name <- '# objects / square mm'
 averageObjectVolume_display_name <- 'mean object volume (cubic mm)'
 totalObjectVolume_display_name <- 'total object volume (cubic mm)'
 meanObjectArea_display_name <- 'mean object area (square mm)'
-areaPercent_display_name <- '%'
-
+areaPercent_display_name <- 'area %'
 
 # Vector to store all downloaded synIds for Synapse provenance (populated via download_file function)
 data_sources <- character()
 
 # Download a file from Synapse by synId and read it into a dataframe
-download_file <- function(synId, df_name, type) {
+# - synId: synapse ID of the file to download
+# - df_name: the name to use for the resulting dataframe
+download_file <- function(synId, df_name) {
 
   synLogin()
 
@@ -129,7 +127,6 @@ download_file <- function(synId, df_name, type) {
 
   cat(paste0("Downloading ", synId, "..."))
 
-
   file <- synGet(id_value, version = version_value, downloadLocation = input_dir, ifcollision='overwrite.local')
   path <- file$path
 
@@ -137,19 +134,70 @@ download_file <- function(synId, df_name, type) {
   cat("\n", synId, "\n- Modified on ", file$properties$modifiedOn, "\n- Version ", file$properties$versionNumber)
   cat("\npath: ", file$path, "\n")
 
-  if (type == 'f') {
-    data <- read_feather(path)
-  } else {
-    if (type == 'json') { data <- fromJSON(path) }
-    if (type == 'csv' || type == 'table') { data <- read.csv(path) }
-    if (type == 'tsv') { data <- read.csv(path, sep = "\t") }
-    if (type == 'rda') { data <- load(path)}
-    if (type == 'rds') {data <- readRDS(path)}
-    df_name <- as.data.frame(data)
-  }
+  data <- read.csv(path)
+  df_name <- as.data.frame(data)
 }
 
+
+# Transforms source data into the desired format, converts type and unit values to standardized display labels,
+# and drops unneeded columns
+#  - results: A dataframe containing result rows
+#  - measurement_columns: A vector containing the colname(s) of the results column(s) that contain the targeted measure(s)
+#  - model_name: the model display name; canonical display names are defined in model_info.csv [syn61378590]
+#  - fields_to_keep: the appropriate 'column specs for intermediate per-model files' from above
+transform_results <- function(results, measurement_columns, model_name, fields_to_keep) {
+  results %>% pivot_longer(
+                cols = measurement_columns,
+                names_to = "units",
+                values_to = "measurement",
+                values_transform = list(measurement = as.numeric)
+
+        # Populate model column
+        ) %>% add_column(
+                model = model_name
+
+        # Convert various unit colnames to consistent unit display values
+        ) %>% mutate(
+
+                units = case_match(
+                        units,
+                        c('objectDensity', 'X.objects..sqmm') ~ objectDensity_display_name,
+                        c('mean.object.area..sqmm.', 'mean.object.area..squm.') ~ meanObjectArea_display_name,
+                        'averageObjectVolume' ~ averageObjectVolume_display_name,
+                        'totalObjectVolume' ~ totalObjectVolume_display_name,
+                        'Area..' ~ areaPercent_display_name
+                )
+
+        # Convert stain values to type display names; tolower() to avoids case mismatches due to variation across source files
+        ) %>% mutate(
+                type = case_when(
+                        tolower(stain) == 'iba1' & units == objectDensity_display_name ~ IBA1_display_name,
+                        tolower(stain) == 'gfap'  & units == objectDensity_display_name ~  GFAP_display_name,
+                        tolower(stain) == 's100b' & units == objectDensity_display_name ~ S100B_display_name,
+                        tolower(stain) == 'lamp1' ~ LAMP1_display_name,
+                        tolower(stain) == 'at8' ~ AT8_display_name,
+                        tolower(stain) == 'ht7' ~ HT7_display_name,
+                        tolower(stain) == 'thios' & units == meanObjectArea_display_name ~ ThioS_size_display_name, # 5xFAD
+                        tolower(stain) == 'thios' & units == averageObjectVolume_display_name ~ ThioS_size_display_name, # 3xTg-AD
+                        tolower(stain) == 'thios' & units == objectDensity_display_name ~ ThioS_density_display_name,
+                        .default = 'UNMAPPED_DROPME'
+                )
+
+        # drop any unmapped rows
+        ) %>% filter(
+                type != 'UNMAPPED_DROPME'
+
+        # Drop unused columns
+        ) %>% select(
+                all_of(fields_to_keep)
+        )
+}
+
+
 # Join a data file to a pair of metadata files to get required age, sex, ageDeath, and genotype values
+# - individual_metadata: A dataframe containing individual-level metadata
+# - biospecimen_metadata: A dataframe containing specimen metadata
+# - df: A dataframe containing result rows
 join_to_metadata <- function(individual_metadata, biospecimen_metadata, df) {
 
   individual_metadata <- subset(individual_metadata, select=c(individualID, sex, ageDeath, genotype))
@@ -183,33 +231,33 @@ The populated data_sources vector is used to populate Synapse provenance when th
 ```{r}
 # 3xTG-AD
 # metadata
-threex_biospecimen <- download_file('syn23532198.3', type = "csv")
-threex_individual <- download_file('syn23532199.4', type = "csv")
+threex_biospecimen <- download_file('syn23532198.3')
+threex_individual <- download_file('syn23532199.4')
 # data
-threex_pathology_source <- download_file('syn26601504.1', type = "csv")
+threex_pathology_source <- download_file('syn26601504.1')
 
 # 5xFAD
 # metadata
-fivex_biospecimen <- download_file('syn18876530.10', type = "csv")
-fivex_individual <- download_file('syn18880070.14', type = "csv")
+fivex_biospecimen <- download_file('syn18876530.10')
+fivex_individual <- download_file('syn18880070.14')
 # data
-fivex_gfap_s100b_source <- download_file('syn22049816.3', type = "csv")
-fivex_lamp1_source <- download_file('syn22049817.2', type = "csv")
-fivex_iba1_thios_source <- download_file('syn22049825.4', type = "csv")
+fivex_gfap_s100b_source <- download_file('syn22049816.3')
+fivex_lamp1_source <- download_file('syn22049817.2')
+fivex_iba1_thios_source <- download_file('syn22049825.4')
 
 #NSS
 # metadata
-nss_biospecimen <- download_file('syn29568452.3', type = "csv")
-nss_individual <- download_file('syn27147690.3', type = "csv")
+nss_biospecimen <- download_file('syn29568452.3')
+nss_individual <- download_file('syn27147690.3')
 # data
-nss_pathology_source <- download_file('syn42131930.1', type = "csv")
+nss_pathology_source <- download_file('syn42131930.1')
 
 #Abca7
 # metadata
-abca7_biospecimen <- download_file('syn30859390.2', type = "csv")
-abca7_individual <- download_file('syn30859394.2', type = "csv")
+abca7_biospecimen <- download_file('syn30859390.2')
+abca7_individual <- download_file('syn30859394.2')
 # data
-abca7_pathology_source <- download_file('syn53127289.1', type = "csv")
+abca7_pathology_source <- download_file('syn53127289.1')
 ```
 
 
@@ -222,247 +270,87 @@ https://docs.google.com/spreadsheets/d/1B3ZMReC7nR2CGgpFNJuxJTj__lF2h6dt/edit?gi
 threex_pathology <- threex_pathology_source %>%
 
         # Filter out rows with unused 'Stain' values
-        filter(
-                stain %in% stain_keeps
+        filter(stain %in% stain_keeps)
 
-                # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-        ) %>% pivot_longer(
-        cols = c(objectDensity, averageObjectVolume, totalObjectVolume),
-        names_to = "units",
-        values_to = "measurement",
-        values_transform = list(measurement = as.numeric)
+threex_pathology
 
-        # Convert units to display values
-        ) %>% mutate(
-                units = case_match(
-                        units,
-                        'objectDensity' ~ objectDensity_display_name,
-                        'averageObjectVolume' ~ averageObjectVolume_display_name,
-                        'totalObjectVolume' ~ totalObjectVolume_display_name
-                )
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+threex_pathology <- transform_results(threex_pathology, c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "3xTg-AD", keeps_with_pool_join_field)
+threex_pathology
 
-        # Map 'stain' values to 'type' display names
-        ) %>% mutate(
-                type = case_when(
-                        stain == 'IBA1' ~ IBA1_display_name,
-                        stain == 'GFAP' ~ GFAP_display_name,
-                        stain == 'S100B' ~ S100B_display_name,
-                        stain == 'LAMP1' ~ LAMP1_display_name,
-                        stain == 'AT8' ~ AT8_display_name,
-                        stain == 'HT7' ~ HT7_display_name,
-                        stain == 'ThioS' & units == averageObjectVolume_display_name ~ ThioS_size_display_name,
-                        stain == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
-                        # Drops ThioS totalObjectVolume measurements
-                        .default = 'UNMAPPED_DROPME'
-                )
-
-        # drop rows for unused ThioS stain/unit combinations
-        ) %>% filter(
-                type != 'UNMAPPED_DROPME'
-
-        # Drop rows with NA measurements
-        ) %>% filter(
-                !is.na(measurement)
-
-        # Populate model column
-        ) %>% add_column(
-                model = '3xTG-AD'
-
-        # Drop unwanted columns
-        ) %>% select(
-                all_of(keeps_with_pool_join_field)
-        )
-
+# Drop rows with NA measurements
+threex_pathology <-  filter(threex_pathology, !is.na(measurement))
 threex_pathology
 ```
 
 
-
-### 5xFAD
 ```{r}
-# Filter each source to remove unused rows by 'Stain' value & drop unused columns
+### 5xFAD
+fivex_source_keeps <- c("IndividualID", "SpecimenID", "Stain")
+
+# 5xFAD colnames aren't consistent with other source data
+fivex_rename_cols <- function (results) {
+  results %>% dplyr::rename(c('stain' = 'Stain',
+                       'individualID' = 'IndividualID',
+                       'specimenID' = 'SpecimenID'))
+}
+
+# Filter source files to select desired rows by 'Stain' value, drop unneeded columns
 fivex_gfap_s100b <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain %in% c('GFAP', 'S100B'),] %>%
-  select(c("IndividualID", "SpecimenID", "Stain", "X.objects..sqmm"))
+  select(c(fivex_source_keeps, "X.objects..sqmm"))  %>%
+  fivex_rename_cols()
 
 fivex_lamp1 <- fivex_lamp1_source[fivex_lamp1_source$Stain == 'LAMP1',] %>%
-  select(c("IndividualID", "SpecimenID", "Stain", "Area.."))
+  select(c(fivex_source_keeps, "Area..")) %>%
+  fivex_rename_cols()
 
-fivex_iba1_thios <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain %in% c('Iba1', 'ThioS'),] %>%
-  select(c("IndividualID", "SpecimenID", "Stain", "X.objects..sqmm", "mean.object.area..squm."))
+fivex_iba1 <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'Iba1',] %>%
+  select(c(fivex_source_keeps, "X.objects..sqmm")) %>%
+  fivex_rename_cols()
 
-# Pivot targeted measurement column(s); capture colname as 'unit' and value as numeric 'measurement'
-# GFAP/S100B source file
-fivex_gfap_s100b_pivot <- fivex_gfap_s100b %>%
-        pivot_longer(
-                cols = c('X.objects..sqmm'),
-                names_to = "units",
-                values_to = "measurement",
-                values_transform = list(measurement = as.numeric)
+fivex_thios <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'ThioS',] %>%
+  select(c(fivex_source_keeps, "X.objects..sqmm", "mean.object.area..squm.")) %>%
+  mutate(X.objects..sqmm = ifelse(X.objects..sqmm == "N/A", 0, X.objects..sqmm)) %>%
+  fivex_rename_cols()
 
-        # Rename columns for consistency
-        ) %>% dplyr::rename(c('type' = 'Stain',
-                       'individualID' = 'IndividualID',
-                       'specimenID' = 'SpecimenID')
-
-        # Populate model column; only UCI contributes pathology/biomarker data
-        ) %>% add_column(
-                model = '5xFAD (UCI)'
-
-        # Drop unused columns
-        ) %>% select(
-                all_of(keeps_with_join_fields)
-        )
-
-
-# LAMP1 source file
-fivex_lamp1_pivot <- fivex_lamp1 %>%
-        pivot_longer(
-                cols = c('Area..'),
-                names_to = "units",
-                values_to = "measurement",
-                values_transform = list(measurement = as.numeric),
-
-        # Rename columns for consistency
-        ) %>% dplyr::rename(c('type' = 'Stain',
-                       'individualID' = 'IndividualID',
-                       'specimenID' = 'SpecimenID')
-
-        # Populate model column; only UCI contributes pathology/biomarker data
-        ) %>% add_column(
-                model = '5xFAD (UCI)'
-
-        # Drop unused columns
-        ) %>% select(
-                all_of(keeps_with_join_fields)
-        )
-
-
-# IBA1/ThioS source file
-fivex_iba1_thios_pivot <- fivex_iba1_thios %>%
-        pivot_longer(
-                cols = c('X.objects..sqmm', 'mean.object.area..squm.'),
-                names_to = "units",
-                values_to = "measurement",
-                values_transform = list(measurement = as.numeric),
-
-        # Rename columns for consistency
-        ) %>% dplyr::rename(c('type' = 'Stain',
-                       'individualID' = 'IndividualID',
-                       'specimenID' = 'SpecimenID')
-
-        # Populate model column; only UCI contributes pathology/biomarker data
-        ) %>% add_column(
-                model = '5xFAD (UCI)'
-
-        # Drop unused columns
-        ) %>% select(
-                all_of(keeps_with_join_fields)
-        )
+model = "5xFAD (UCI)"
+fivex_gfap_s100b_pivot <- transform_results(fivex_gfap_s100b, c('X.objects..sqmm'), model, keeps_with_join_fields)
+fivex_lamp1_pivot <- transform_results(fivex_lamp1, c('Area..'), model, keeps_with_join_fields)
+fivex_iba1_pivot <- transform_results(fivex_iba1, c('X.objects..sqmm'), model, keeps_with_join_fields)
+fivex_thios_pivot <- transform_results(fivex_thios, c('X.objects..sqmm', 'mean.object.area..squm.'), model, keeps_with_join_fields)
 
 
 # Merge all results into a single data frame
-fivex_pathology <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_iba1_thios_pivot
+fivex_pathology <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_iba1_pivot, fivex_thios_pivot
 
-        # Convert units to display values
-        ) %>% mutate(
-                units = case_match(
-                        units,
-                        'X.objects..sqmm' ~ objectDensity_display_name,
-                        'mean.object.area..sqmm.' ~ meanObjectArea_display_name,
-                        'mean.object.area..squm.' ~ meanObjectArea_display_name,
-                        'Area..' ~ areaPercent_display_name,
-                )
+    # MG-12: drop rows with "N/A" specimenIDs
+    ) %>% filter(
+          specimenID != "N/A"
 
-        # Map stain values to type display names
-        ) %>% mutate(
-                type = case_when(
-                        type == 'Iba1' & units == meanObjectArea_display_name ~ IBA1_display_name,
-                        type == 'GFAP'  ~ GFAP_display_name,
-                        type == 'S100B' ~ S100B_display_name,
-                        type == 'LAMP1' ~ LAMP1_display_name,
-                        type == 'AT8' ~ AT8_display_name,
-                        type == 'HT7' ~ HT7_display_name,
-                        type == 'ThioS' & units == meanObjectArea_display_name ~ ThioS_size_display_name,
-                        type == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
-                        # Drops ThioS totalObjectVolume measurements
-                        .default = 'UNMAPPED_DROPME'
-                )
-
-        # drop rows for unused ThioS stain/unit combinations
-        ) %>% filter(
-                type != 'UNMAPPED_DROPME'
-
-        # Drop rows with NA measurements
-        ) %>% filter(
-                !is.na(measurement)
-
-        # Drop unwanted columns
-        ) %>% select(
-                all_of(keeps_with_join_fields)
+    # MG-268: Replace N/A measurement values with 0s
+    ) %>% mutate(
+            measurement = ifelse(is.na(measurement), 0, measurement)
 )
 
 fivex_pathology
 ```
-
 
 ### Trem2-R47H_NSS
 ```{r}
 nss_pathology <- nss_pathology_source %>%
 
         # Filter out rows with unused 'Stain' values
-        filter(
-                stain %in% stain_keeps
-
-        # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-        ) %>% pivot_longer(
-            cols = c(objectDensity, averageObjectVolume, totalObjectVolume),
-            names_to = "units",
-            values_to = "measurement",
-            values_transform = list(measurement = as.numeric)
-
-        # Convert units to display values
-        ) %>% mutate(
-            units = case_match(
-                    units,
-                    'objectDensity' ~ objectDensity_display_name,
-                    'averageObjectVolume' ~ averageObjectVolume_display_name,
-                    'totalObjectVolume' ~ totalObjectVolume_display_name
-            )
-
-        # Map 'stain' values to 'type' display names
-        ) %>% mutate(
-            type = case_when(
-                    stain == 'IBA1' & units == objectDensity_display_name ~ IBA1_display_name,
-                    stain == 'GFAP' & units == objectDensity_display_name ~ GFAP_display_name,
-                    stain == 'S100B' & units == objectDensity_display_name ~ S100B_display_name,
-                    stain == 'LAMP1' ~ LAMP1_display_name,
-                    stain == 'AT8' ~ AT8_display_name,
-                    stain == 'HT7' ~ HT7_display_name,
-                    stain == 'ThioS' & units == averageObjectVolume_display_name ~ ThioS_size_display_name,
-                    stain == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
-                    # Set default value for rows with unused measurements
-                    .default = 'UNMAPPED_DROPME'
-            )
-
-        # drop rows for unused stain/unit combinations
-        ) %>% filter(
-                type != 'UNMAPPED_DROPME'
-
-        # Drop rows with NA measurements
-         ) %>% filter(
-                !is.na(measurement)
-
-        # Populate model column
-        ) %>% add_column(
-                model = 'Trem2-R47H_NSS'
-
-        # Drop unwanted columns
-        ) %>% select(
-                all_of(keeps_with_pool_join_field)
-        )
+        filter(stain %in% stain_keeps)
 
 nss_pathology
 
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+nss_pathology <- transform_results(nss_pathology, c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "Trem2-R47H_NSS", keeps_with_pool_join_field)
+nss_pathology
+
+# Drop rows with NA measurements
+nss_pathology <-  filter(nss_pathology, !is.na(measurement))
+nss_pathology
 ```
 
 ### Abca7*V1599M
@@ -470,197 +358,162 @@ nss_pathology
 abca7_pathology <- abca7_pathology_source %>%
 
         # Filter out rows with unused 'Stain' values
-        filter(
-                stain %in% stain_keeps
-
-        # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-        ) %>% pivot_longer(
-            cols = c(objectDensity, averageObjectVolume, totalObjectVolume),
-            names_to = "units",
-            values_to = "measurement",
-            values_transform = list(measurement = as.numeric)
-
-        # Convert units to display values
-        ) %>% mutate(
-            units = case_match(
-                    units,
-                    'objectDensity' ~ objectDensity_display_name,
-                    'averageObjectVolume' ~ averageObjectVolume_display_name,
-                    'totalObjectVolume' ~ totalObjectVolume_display_name
-            )
-
-        # Map 'stain' values to 'type' display names
-        ) %>% mutate(
-                type = case_when(
-                        stain == 'IBA1' & units == objectDensity_display_name ~ IBA1_display_name,
-                        stain == 'GFAP' & units == objectDensity_display_name ~ GFAP_display_name,
-                        stain == 'S100B' & units == objectDensity_display_name ~ S100B_display_name,
-                        stain == 'LAMP1' & units == totalObjectVolume_display_name ~ LAMP1_display_name,
-                        stain == 'AT8' ~ AT8_display_name,
-                        stain == 'HT7' ~ HT7_display_name,
-                        stain == 'ThioS' & units == averageObjectVolume_display_name ~ ThioS_size_display_name,
-                        stain == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
-                        # Set default value for rows with unused measurements
-                        .default = 'UNMAPPED_DROPME'
-                )
-
-        # drop rows for unused stain/unit combinations
-        ) %>% filter(
-                type != 'UNMAPPED_DROPME'
-
-        # Drop rows with NA measurements
-        ) %>% filter(
-                !is.na(measurement)
-
-        # Populate model column
-        ) %>% add_column(
-                model = 'Abca7*V1599M'
-
-        # Drop unwanted columns
-        ) %>% select(
-                all_of(keeps_with_pool_join_field)
-        )
+        filter(stain %in% stain_keeps)
 
 abca7_pathology
 
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+abca7_pathology <- transform_results(abca7_pathology, c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "Abca7*V1599M", keeps_with_pool_join_field)
+abca7_pathology
+
+# Drop rows with NA measurements
+abca7_pathology <-  filter(abca7_pathology, !is.na(measurement))
+
+# Drop LAMP1 rows with measurements other than total object volume (cubic mm)
+abca7_pathology <-  filter(abca7_pathology, !(type == LAMP1_display_name & (units == objectDensity_display_name | units == averageObjectVolume_display_name)))
+
+abca7_pathology
 ```
 
+## Sanity check generated files
+Checks that ensure that the processed data includes the expected number of results per model, per result type:
+1. Source data vs processed data: nrow(filtered_source_data) == nrow(processed_data)
+2. Source data vs expected rows: nrow(nrow(processed_data)) == nrow(legacy_explorer_data)
 
-## Sanity check nrow in generated files
+Expected rows:
+* Values were determined by downloading data from the legacy explorer's Pathlogy interface, where available
+* Exported legacy data files are in syn68930581
+
 ```{r}
+# *******
 # 3xTG-AD
-# IBA1 Correct for "N/A" values in targeted source column: objectDensity
+# *******
+# IBA1
 threex_iba1 <- threex_pathology_source[threex_pathology_source$stain == 'IBA1',]
-threex_iba1_nas <- sum(is.na(threex_iba1$objectDensity))
-stopifnot(nrow(threex_pathology[threex_pathology$type == IBA1_display_name,]) == nrow(threex_iba1) - threex_iba1_nas)
+stopifnot(nrow(threex_pathology[threex_pathology$type == IBA1_display_name,]) == nrow(threex_iba1))
+stopifnot(nrow(threex_iba1) == 144) # IBA1 :  3xTg-AD + B6129  ==  144
 
-# GFAP Correct for "N/A" values in targeted source column: objectDensity
+# GFAP
 threex_gfap <- threex_pathology_source[threex_pathology_source$stain == 'GFAP',]
-threex_gfap_nas <- sum(is.na(threex_gfap$objectDensity))
-stopifnot(nrow(threex_pathology[threex_pathology$type == GFAP_display_name,]) == nrow(threex_gfap) - threex_gfap_nas)
+stopifnot(nrow(threex_pathology[threex_pathology$type == GFAP_display_name,]) == nrow(threex_gfap))
+stopifnot(nrow(threex_gfap) == 144) #  GFAP :  3xTg-AD + B6129  ==  144
 
-# S100B Correct for "N/A" values in targeted source column: objectDensity
+# S100B
 threex_s100b <- threex_pathology_source[threex_pathology_source$stain == 'S100B',]
-threex_s100b_nas <- sum(is.na(threex_s100b$objectDensity))
-stopifnot(nrow(threex_pathology[threex_pathology$type == S100B_display_name,]) == nrow(threex_s100b) - threex_s100b_nas)
+stopifnot(nrow(threex_pathology[threex_pathology$type == S100B_display_name,]) == nrow(threex_s100b))
+stopifnot(nrow(threex_s100b) == 144) #  S100B :  3xTg-AD + B6129  ==  144
 
-# LAMP1 Correct for "N/A" values in targeted source column: totalObjectVolume
+# LAMP1
 threex_lamp1 <- threex_pathology_source[threex_pathology_source$stain == 'LAMP1',]
-threex_lamp1_nas <- sum(is.na(threex_lamp1$totalObjectVolume))
-stopifnot(nrow(threex_pathology[threex_pathology$type == LAMP1_display_name,]) == nrow(threex_lamp1) - threex_lamp1_nas)
+stopifnot(nrow(threex_pathology[threex_pathology$type == LAMP1_display_name,]) == nrow(threex_lamp1))
+stopifnot(nrow(threex_lamp1) == 142) # LAMP1 :  3xTg-AD + B6129  ==  142
 
-# AT8 Correct for "N/A" values in targeted source column: totalObjectVolume
+# AT8
 threex_at8 <- threex_pathology_source[threex_pathology_source$stain == 'AT8',]
-threex_at8_nas <- sum(is.na(threex_at8$totalObjectVolume))
-stopifnot(nrow(threex_pathology[threex_pathology$type == AT8_display_name,]) == nrow(threex_at8) - threex_at8_nas)
+stopifnot(nrow(threex_pathology[threex_pathology$type == AT8_display_name,]) == nrow(threex_at8))
+stopifnot(nrow(threex_at8) == 72) # AT8 :  3xTg-AD + B6129  ==  72
 
-# HT7 Correct for "N/A" values in targeted source column: totalObjectVolume
+# HT7
 threex_ht7 <- threex_pathology_source[threex_pathology_source$stain == 'HT7',]
-threex_ht7_nas <- sum(is.na(threex_at8$totalObjectVolume))
-stopifnot(nrow(threex_pathology[threex_pathology$type == HT7_display_name,]) == nrow(threex_ht7) -threex_ht7_nas)
+stopifnot(nrow(threex_pathology[threex_pathology$type == HT7_display_name,]) == nrow(threex_ht7))
+stopifnot(nrow(threex_ht7) == 72) # HT7 :  3xTg-AD + B6129  ==  72
 
-# ThioS size Correct for "N/A" values in targeted source column: averageObjectVolume
+# ThioS size & density
 threex_thioss <- threex_pathology_source[threex_pathology_source$stain == 'ThioS',]
-threex_thioss_nas <- sum(is.na(threex_thioss$averageObjectVolume))
-stopifnot(nrow(threex_pathology[threex_pathology$type == ThioS_size_display_name,]) == nrow(threex_thioss) - threex_thioss_nas)
+stopifnot(nrow(threex_pathology[threex_pathology$type == ThioS_size_display_name,]) == nrow(threex_thioss))
+stopifnot(nrow(threex_pathology[threex_pathology$type == ThioS_density_display_name,]) == nrow(threex_thioss))
+stopifnot(nrow(threex_thioss) == 144) #  ThioS size :  3xTg-AD + B6129  ==  144
 
-# Thios density Correct for "N/A" values in targeted source column: objectDensity
-threex_thiosd <- threex_pathology_source[threex_pathology_source$stain == 'ThioS',]
-threex_thiosd_nas <- sum(is.na(threex_thiosd$objectDensity))
-stopifnot(nrow(threex_pathology[threex_pathology$type == ThioS_density_display_name,]) == nrow(threex_thiosd) - threex_thiosd_nas)
-
-
+# *****
 # 5xFAD
-# Iba1 Correct for "N/A" values in targeted source columns: 'X.objects..sqmm', 'mean.object.area..squm.'
+# *****
+# IBA1
 fivex_ibas <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'Iba1',]
-fivex_iba_nas <- sum(fivex_ibas$X.objects..sqmm == "N/A")
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == IBA1_display_name,]) == nrow(fivex_ibas) - fivex_iba_nas)
+stopifnot(nrow(fivex_pathology[fivex_pathology$type == IBA1_display_name,]) == nrow(fivex_ibas))
+stopifnot(nrow(fivex_ibas) == 280) # IBA1 :  5xFAD + C57BL/6J ==  280 rows expected
 
-# GFAP Correct for "N/A" values in targeted source columns: 'X.objects..sqmm', 'mean.object.area..sqmm.'
+# GFAP
 fivex_gfap <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain == 'GFAP',]
-fivex_gfap_nas <- sum(fivex_gfap$X.objects..sqmm == "N/A")
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == GFAP_display_name,]) == nrow(fivex_gfap) - fivex_gfap_nas)
+stopifnot(nrow(fivex_pathology[fivex_pathology$type == GFAP_display_name,]) == nrow(fivex_gfap))
+stopifnot(nrow(fivex_gfap) == 215) # GFAP :  5xFAD + C57BL/6J  ==  215 rows expected
 
-# S100B Correct for "N/A" values in targeted source column: 'X.objects..sqmm'
+# S100B
 fivex_s100bs <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain == 'S100B',]
-fivex_s100b_nas <- sum(fivex_s100bs$X.objects..sqmm == "N/A")
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == S100B_display_name,]) == nrow(fivex_s100bs) - fivex_s100b_nas)
+stopifnot(nrow(fivex_pathology[fivex_pathology$type == S100B_display_name,]) == nrow(fivex_s100bs))
+stopifnot(nrow(fivex_s100bs) == 215) #  S100B :  5xFAD + C57BL/6J  ==  215  rows expected
 
-# LAMP1 Correct for "N/A" values in targeted source column: 'Area..'
-fivex_lamp1s <- fivex_lamp1_source[fivex_lamp1_source$Stain == 'LAMP1',]
-fivex_lamp1_nas <- sum(fivex_lamp1s$Area.. == "N/A")
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == LAMP1_display_name,]) == nrow(fivex_lamp1s) - fivex_lamp1_nas)
+# LAMP1
+fivex_lamp1 <- fivex_lamp1_source[fivex_lamp1_source$Stain == 'LAMP1',]
+stopifnot(nrow(fivex_pathology[fivex_pathology$type == LAMP1_display_name,]) == nrow(fivex_lamp1))
+stopifnot(nrow(fivex_lamp1) == 264) # LAMP1 :  5xFAD + C57BL/6J  ==  264  rows expected
 
-# ThioS size Correct for N/A values in targeted source column: 'mean.object.area..squm.'
-fivex_thios <- fivex_lamp1_source[fivex_lamp1_source$Stain == 'ThioS',]
-fivex_thios_size_nas <- !is.na(fivex_thios$mean.object.area..squm)
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == ThioS_size_display_name,]) == nrow(fivex_thios) - fivex_thios_size_nas)
+# ThioS size & density
+fivex_thios <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'ThioS',]
+fivex_thios <-  filter(fivex_thios, SpecimenID != 'N/A') # Remove rows with specimenID == "N/A"
+stopifnot(nrow(fivex_pathology[fivex_pathology$type == ThioS_size_display_name,]) == nrow(fivex_thios))
+stopifnot(nrow(fivex_pathology[fivex_pathology$type == ThioS_density_display_name,]) == nrow(fivex_thios))
+stopifnot(nrow(fivex_thios) == 278) #  ThioS (size == density):  5xFAD + C57BL/6J  ==  278 rows expected
 
-# ThioS density Correct for N/A values in targeted source column: 'X.objects..sqmm'
-thios_density_nas <-is.na(fivex_thios$X.objects..sqmm)
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == ThioS_density_display_name,]) == nrow(fivex_thios) - thios_density_nas)
-
-
+# **************
 # Trem2-R47H_NSS
-# IBA1 Correct for "N/A" values in targeted source column: objectDensity
+# **************
+# IBA1
 nss_iba1 <- nss_pathology_source[nss_pathology_source$stain == 'IBA1',]
-nss_iba1_nas <- sum(is.na(nss_iba1$objectDensity))
-stopifnot(nrow(nss_pathology[nss_pathology$type == IBA1_display_name,]) == nrow(nss_iba1) - nss_iba1_nas)
+stopifnot(nrow(nss_pathology[nss_pathology$type == IBA1_display_name,]) == nrow(nss_iba1))
+# results not in legacy explorer
 
-# GFAP Correct for "N/A" values in targeted source column: objectDensity
+# GFAP
 nss_gfap <- nss_pathology_source[nss_pathology_source$stain == 'GFAP',]
-nss_gfap_nas <- sum(is.na(nss_gfap$objectDensity))
-stopifnot(nrow(nss_pathology[nss_pathology$type == GFAP_display_name,]) == nrow(nss_gfap) - nss_gfap_nas)
+stopifnot(nrow(nss_pathology[nss_pathology$type == GFAP_display_name,]) == nrow(nss_gfap))
+# results not in legacy explorer
 
-# S100B Correct for "N/A" values in targeted source column: objectDensity
+# S100B
 nss_s100b <- nss_pathology_source[nss_pathology_source$stain == 'S100B',]
-nss_s100b_nas <- sum(is.na(nss_s100b$objectDensity))
-stopifnot(nrow(nss_pathology[nss_pathology$type == S100B_display_name,]) == nrow(nss_s100b) - nss_s100b_nas)
+stopifnot(nrow(nss_pathology[nss_pathology$type == S100B_display_name,]) == nrow(nss_s100b))
+# results not in legacy explorer
 
-# LAMP1 Correct for "N/A" values in targeted source column: totalObjectVolume
+# LAMP1
 nss_lamp1 <- nss_pathology_source[nss_pathology_source$stain == 'LAMP1',]
-nss_lamp1_nas <- sum(is.na(nss_lamp1$totalObjectVolume))
-stopifnot(nrow(nss_pathology[nss_pathology$type == LAMP1_display_name,]) == nrow(nss_lamp1) - nss_lamp1_nas)
+stopifnot(nrow(nss_pathology[nss_pathology$type == LAMP1_display_name,]) == nrow(nss_lamp1))
+# results not in legacy explorer
 
-# ThioS size Correct for "N/A" values in targeted source column: averageObjectVolume
+# ThioS size & density
 nss_thios <- nss_pathology_source[nss_pathology_source$stain == 'ThioS',]
-nss_thioss_nas <- sum(is.na(nss_thios$averageObjectVolume))
-stopifnot(nrow(nss_pathology[nss_pathology$type == ThioS_size_display_name,]) == nrow(nss_thios) - nss_thioss_nas)
+nss_thioss <-  filter(nss_thios, !is.na(nss_thios$averageObjectVolume)) # Remove source rows with NA measurements
+nss_thiosd <-  filter(nss_thios, !is.na(nss_thios$objectDensity)) # Remove sourcerows with NA measurements
+stopifnot(nrow(nss_pathology[nss_pathology$type == ThioS_size_display_name,]) == nrow(nss_thioss))
+stopifnot(nrow(nss_pathology[nss_pathology$type == ThioS_density_display_name,]) == nrow(nss_thiosd))
+# results not in legacy explorer
 
-# Thios density Correct for "N/A" values in targeted source column: objectDensity
-nss_thiosd_nas <- sum(is.na(nss_thios$objectDensity))
-stopifnot(nrow(nss_pathology[nss_pathology$type == ThioS_density_display_name,]) == nrow(nss_thios) - nss_thiosd_nas)
-
-
+# ************
 # Abca7*V1599M
-# IBA1 Correct for "N/A" values in targeted source column: objectDensity
+# ************
+# IBA1
 abca7_iba1 <- abca7_pathology_source[abca7_pathology_source$stain == 'IBA1',]
-abca7_iba1_nas <- sum(abca7_iba1$objectDensity == "N/A")
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == IBA1_display_name,]) == nrow(abca7_iba1) - abca7_iba1_nas)
+stopifnot(nrow(abca7_pathology[abca7_pathology$type == IBA1_display_name,]) == nrow(abca7_iba1))
+# results not in legacy explorer
 
-# GFAP Correct for "N/A" values in targeted source column: objectDensity
+# GFAP
 abca7_gfap <- abca7_pathology_source[abca7_pathology_source$stain == 'GFAP',]
-abca7_gfap_nas <- sum(abca7_gfap$objectDensity == "N/A")
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == GFAP_display_name,]) == nrow(abca7_gfap) - abca7_gfap_nas)
+abca7_gfap <-  filter(abca7_gfap, abca7_gfap$objectDensity != 'N/A') # Remove source rows with 'N/A' measurements
+stopifnot(nrow(abca7_pathology[abca7_pathology$type == GFAP_display_name,]) == nrow(abca7_gfap))
+# results not in legacy explorer
 
-# S100B Correct for "N/A" values in targeted source column: objectDensity
+# S100B
 abca7_s100b <- abca7_pathology_source[abca7_pathology_source$stain == 'S100B',]
-abca7_s100b_nas <- sum(abca7_s100b$objectDensity == "N/A")
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == S100B_display_name,]) == nrow(abca7_s100b) - abca7_s100b_nas)
+stopifnot(nrow(abca7_pathology[abca7_pathology$type == S100B_display_name,]) == nrow(abca7_s100b))
+# results not in legacy explorer
 
-# LAMP1 Correct for "N/A" values in targeted source column: totalObjectVolume
+# LAMP1
 abca7_lamp1 <- abca7_pathology_source[abca7_pathology_source$stain == 'LAMP1',]
-abca7_lamp1_nas <- sum(is.na(abca7_lamp1$totalObjectVolume))
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == LAMP1_display_name,]) == nrow(abca7_lamp1) - abca7_lamp1_nas)
+stopifnot(nrow(abca7_pathology[abca7_pathology$type == LAMP1_display_name,]) == nrow(abca7_lamp1))
+# results not in legacy explorer
 
-# ThioS size Correct for "N/A" values in targeted source column: averageObjectVolume
+# ThioS size & density
 abca7_thios <- abca7_pathology_source[abca7_pathology_source$stain == 'ThioS',]
-abca7_thioss_nas <- sum(abca7_thios$averageObjectVolume == "N/A")
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == ThioS_size_display_name,]) == nrow(abca7_thios) - abca7_thioss_nas)
-
-# Thios density Correct for "N/A" values in targeted source column: objectDensity
-abca7_thiosd_nas <- sum(abca7_thios$objectDensity == "N/A")
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == ThioS_density_display_name,]) == nrow(abca7_thios) - abca7_thiosd_nas)
+stopifnot(nrow(abca7_pathology[abca7_pathology$type == ThioS_size_display_name,]) == nrow(abca7_thios))
+stopifnot(nrow(abca7_pathology[abca7_pathology$type == ThioS_density_display_name,]) == nrow(abca7_thios))
+# results not in legacy explorer
 ```
 
 
@@ -729,6 +582,10 @@ pathology_final
 
 ## Write csv file and upload to synapse
 ```{r}
+# MODEL-AD 2.0 harmonized source file directory
+# ADP Backend > Files > 2.ConsortiumStudies > MODEL-AD Data Explorer > Model AD Explorer 2.0 Source Files
+synapse_folder <- 'syn51498054'
+
 # write csv file
 output_dir <- file.path("./", "output")
 if(!dir.exists(output_dir)){

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -225,88 +225,93 @@ threex_pathology <- threex_pathology_source %>%
         filter(
                 stain %in% stain_keeps
 
-          # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+                # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
         ) %>% pivot_longer(
         cols = c(objectDensity, averageObjectVolume, totalObjectVolume),
         names_to = "units",
         values_to = "measurement",
         values_transform = list(measurement = as.numeric)
 
-  # Convert units to display values
-) %>% mutate(
-        units = case_match(
-                units,
-                'objectDensity' ~ objectDensity_display_name,
-                'averageObjectVolume' ~ averageObjectVolume_display_name,
-                'totalObjectVolume' ~ totalObjectVolume_display_name
+        # Convert units to display values
+        ) %>% mutate(
+                units = case_match(
+                        units,
+                        'objectDensity' ~ objectDensity_display_name,
+                        'averageObjectVolume' ~ averageObjectVolume_display_name,
+                        'totalObjectVolume' ~ totalObjectVolume_display_name
+                )
+
+        # Map 'stain' values to 'type' display names
+        ) %>% mutate(
+                type = case_when(
+                        stain == 'IBA1' ~ IBA1_display_name,
+                        stain == 'GFAP' ~ GFAP_display_name,
+                        stain == 'S100B' ~ S100B_display_name,
+                        stain == 'LAMP1' ~ LAMP1_display_name,
+                        stain == 'AT8' ~ AT8_display_name,
+                        stain == 'HT7' ~ HT7_display_name,
+                        stain == 'ThioS' & units == averageObjectVolume_display_name ~ ThioS_size_display_name,
+                        stain == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
+                        # Drops ThioS totalObjectVolume measurements
+                        .default = 'UNMAPPED_DROPME'
+                )
+
+        # drop rows for unused ThioS stain/unit combinations
+        ) %>% filter(
+                type != 'UNMAPPED_DROPME'
+
+        # Drop rows with NA measurements
+        ) %>% filter(
+                !is.na(measurement)
+
+        # Populate model column
+        ) %>% add_column(
+                model = '3xTG-AD'
+
+        # Drop unwanted columns
+        ) %>% select(
+                all_of(keeps_with_pool_join_field)
         )
-
-  # Map 'stain' values to 'type' display names
-) %>% mutate(
-        type = case_when(
-                stain == 'IBA1' ~ IBA1_display_name,
-                stain == 'GFAP' ~ GFAP_display_name,
-                stain == 'S100B' ~ S100B_display_name,
-                stain == 'LAMP1' ~ LAMP1_display_name,
-                stain == 'AT8' ~ AT8_display_name,
-                stain == 'HT7' ~ HT7_display_name,
-                stain == 'ThioS' & units == averageObjectVolume_display_name ~ ThioS_size_display_name,
-                stain == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
-                # Drops ThioS totalObjectVolume measurements
-                .default = 'UNMAPPED_DROPME'
-        )
-
-  # drop rows for unused ThioS stain/unit combinations
-) %>% filter(
-        type != 'UNMAPPED_DROPME'
-
-  # Drop rows with NA measurements
-) %>% filter(
-        !is.na(measurement)
-
-  # Populate model column
-) %>% add_column(
-        model = '3xTG-AD'
-
-  # Drop unwanted columns
-) %>% select(
-        all_of(keeps_with_pool_join_field)
-)
 
 threex_pathology
 ```
 
 
+
 ### 5xFAD
 ```{r}
-# Filter each source to remove unused rows by 'Stain' value
-fivex_gfap_s100b <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain %in% c('GFAP', 'S100B'),]
-fivex_lamp1 <- fivex_lamp1_source[fivex_lamp1_source$Stain == 'LAMP1',]
-fivex_iba1_thios <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain %in% c('Iba1', 'ThioS'),]
+# Filter each source to remove unused rows by 'Stain' value & drop unused columns
+fivex_gfap_s100b <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain %in% c('GFAP', 'S100B'),] %>%
+  select(c("IndividualID", "SpecimenID", "Stain", "X.objects..sqmm"))
 
-# Pivot targeted measurement columns; capture colname as 'unit' and value as numeric 'measurement'
+fivex_lamp1 <- fivex_lamp1_source[fivex_lamp1_source$Stain == 'LAMP1',] %>%
+  select(c("IndividualID", "SpecimenID", "Stain", "Area.."))
+
+fivex_iba1_thios <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain %in% c('Iba1', 'ThioS'),] %>%
+  select(c("IndividualID", "SpecimenID", "Stain", "X.objects..sqmm", "mean.object.area..squm."))
+
+# Pivot targeted measurement column(s); capture colname as 'unit' and value as numeric 'measurement'
 # GFAP/S100B source file
 fivex_gfap_s100b_pivot <- fivex_gfap_s100b %>%
         pivot_longer(
-                cols = c('X.objects..sqmm', 'mean.object.area..sqmm.'),
+                cols = c('X.objects..sqmm'),
                 names_to = "units",
                 values_to = "measurement",
                 values_transform = list(measurement = as.numeric)
 
-          # Rename columns for consistency
+        # Rename columns for consistency
         ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
-  # Populate model column
-  # Since only UCI contributes pathology/biomarker data, we can assign all 5xFAD results to that center.
-) %>% add_column(
-        model = '5xFAD (UCI)'
+        # Populate model column; only UCI contributes pathology/biomarker data
+        ) %>% add_column(
+                model = '5xFAD (UCI)'
 
-  # Drop unused columns
-) %>% select(
-        all_of(keeps_with_join_fields)
-)
+        # Drop unused columns
+        ) %>% select(
+                all_of(keeps_with_join_fields)
+        )
 
 
 # LAMP1 source file
@@ -322,14 +327,14 @@ fivex_lamp1_pivot <- fivex_lamp1 %>%
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
-  # Populate model column
-) %>% add_column(
-        model = '5xFAD (UCI)'
+        # Populate model column; only UCI contributes pathology/biomarker data
+        ) %>% add_column(
+                model = '5xFAD (UCI)'
 
-  # Drop unused columns
-) %>% select(
-        all_of(keeps_with_join_fields)
-)
+        # Drop unused columns
+        ) %>% select(
+                all_of(keeps_with_join_fields)
+        )
 
 
 # IBA1/ThioS source file
@@ -340,67 +345,64 @@ fivex_iba1_thios_pivot <- fivex_iba1_thios %>%
                 values_to = "measurement",
                 values_transform = list(measurement = as.numeric),
 
-          # Rename columns for consistency
+        # Rename columns for consistency
         ) %>% dplyr::rename(c('type' = 'Stain',
                        'individualID' = 'IndividualID',
                        'specimenID' = 'SpecimenID')
 
-   # Populate model column
-   # Since only UCI contributes pathology/biomarker data, we can assign all 5xFAD results to that center.
-) %>% add_column(
-        model = '5xFAD (UCI)'
+        # Populate model column; only UCI contributes pathology/biomarker data
+        ) %>% add_column(
+                model = '5xFAD (UCI)'
 
-  # Drop unused columns
-) %>% select(
-        all_of(keeps_with_join_fields)
-)
+        # Drop unused columns
+        ) %>% select(
+                all_of(keeps_with_join_fields)
+        )
 
 
-# Merge the three sources into a single data frame
+# Merge all results into a single data frame
 fivex_pathology <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_iba1_thios_pivot
 
-                             # Convert units to display values
-) %>% mutate(
-        units = case_match(
-                units,
-                'X.objects..sqmm' ~ objectDensity_display_name,
-                'mean.object.area..sqmm.' ~ meanObjectArea_display_name,
-                'Area..' ~ areaPercent_display_name,
-                'X.objects..sqmm' ~ objectDensity_display_name,
-                'mean.object.area..squm.' ~ meanObjectArea_display_name
-        )
+        # Convert units to display values
+        ) %>% mutate(
+                units = case_match(
+                        units,
+                        'X.objects..sqmm' ~ objectDensity_display_name,
+                        'mean.object.area..sqmm.' ~ meanObjectArea_display_name,
+                        'mean.object.area..squm.' ~ meanObjectArea_display_name,
+                        'Area..' ~ areaPercent_display_name,
+                )
 
- # Map stain values to type display names
-) %>% mutate(
-        type = case_when(
-                type == 'Iba1' ~ IBA1_display_name,
-                type == 'GFAP' ~ GFAP_display_name,
-                type == 'S100B' ~ S100B_display_name,
-                type == 'LAMP1' ~ LAMP1_display_name,
-                type == 'AT8' ~ AT8_display_name,
-                type == 'HT7' ~ HT7_display_name,
-                type == 'ThioS' & units == meanObjectArea_display_name ~ ThioS_size_display_name,
-                type == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
-                # Drops ThioS totalObjectVolume measurements
-                .default = 'UNMAPPED_DROPME'
-        )
+        # Map stain values to type display names
+        ) %>% mutate(
+                type = case_when(
+                        type == 'Iba1' & units == meanObjectArea_display_name ~ IBA1_display_name,
+                        type == 'GFAP'  ~ GFAP_display_name,
+                        type == 'S100B' ~ S100B_display_name,
+                        type == 'LAMP1' ~ LAMP1_display_name,
+                        type == 'AT8' ~ AT8_display_name,
+                        type == 'HT7' ~ HT7_display_name,
+                        type == 'ThioS' & units == meanObjectArea_display_name ~ ThioS_size_display_name,
+                        type == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
+                        # Drops ThioS totalObjectVolume measurements
+                        .default = 'UNMAPPED_DROPME'
+                )
 
-  # drop rows for unused ThioS stain/unit combinations
-) %>% filter(
-        type != 'UNMAPPED_DROPME'
+        # drop rows for unused ThioS stain/unit combinations
+        ) %>% filter(
+                type != 'UNMAPPED_DROPME'
 
-  # Drop rows with NA measurements
-) %>% filter(
-        !is.na(measurement)
+        # Drop rows with NA measurements
+        ) %>% filter(
+                !is.na(measurement)
 
-  # Drop unwanted columns
-) %>% select(
-        all_of(keeps_with_join_fields)
+        # Drop unwanted columns
+        ) %>% select(
+                all_of(keeps_with_join_fields)
 )
 
 fivex_pathology
 ```
-
 
 
 ### Trem2-R47H_NSS
@@ -411,53 +413,53 @@ nss_pathology <- nss_pathology_source %>%
         filter(
                 stain %in% stain_keeps
 
-                # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+        # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
         ) %>% pivot_longer(
-        cols = c(objectDensity, averageObjectVolume, totalObjectVolume),
-        names_to = "units",
-        values_to = "measurement",
-        values_transform = list(measurement = as.numeric)
+            cols = c(objectDensity, averageObjectVolume, totalObjectVolume),
+            names_to = "units",
+            values_to = "measurement",
+            values_transform = list(measurement = as.numeric)
 
-  # Convert units to display values
-) %>% mutate(
-        units = case_match(
-                units,
-                'objectDensity' ~ objectDensity_display_name,
-                'averageObjectVolume' ~ averageObjectVolume_display_name,
-                'totalObjectVolume' ~ totalObjectVolume_display_name
+        # Convert units to display values
+        ) %>% mutate(
+            units = case_match(
+                    units,
+                    'objectDensity' ~ objectDensity_display_name,
+                    'averageObjectVolume' ~ averageObjectVolume_display_name,
+                    'totalObjectVolume' ~ totalObjectVolume_display_name
+            )
+
+        # Map 'stain' values to 'type' display names
+        ) %>% mutate(
+            type = case_when(
+                    stain == 'IBA1' & units == objectDensity_display_name ~ IBA1_display_name,
+                    stain == 'GFAP' & units == objectDensity_display_name ~ GFAP_display_name,
+                    stain == 'S100B' & units == objectDensity_display_name ~ S100B_display_name,
+                    stain == 'LAMP1' ~ LAMP1_display_name,
+                    stain == 'AT8' ~ AT8_display_name,
+                    stain == 'HT7' ~ HT7_display_name,
+                    stain == 'ThioS' & units == averageObjectVolume_display_name ~ ThioS_size_display_name,
+                    stain == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
+                    # Set default value for rows with unused measurements
+                    .default = 'UNMAPPED_DROPME'
+            )
+
+        # drop rows for unused stain/unit combinations
+        ) %>% filter(
+                type != 'UNMAPPED_DROPME'
+
+        # Drop rows with NA measurements
+         ) %>% filter(
+                !is.na(measurement)
+
+        # Populate model column
+        ) %>% add_column(
+                model = 'Trem2-R47H_NSS'
+
+        # Drop unwanted columns
+        ) %>% select(
+                all_of(keeps_with_pool_join_field)
         )
-
-  # Map 'stain' values to 'type' display names
-) %>% mutate(
-        type = case_when(
-                stain == 'IBA1' & units == objectDensity_display_name ~ IBA1_display_name,
-                stain == 'GFAP' & units == objectDensity_display_name ~ GFAP_display_name,
-                stain == 'S100B' & units == objectDensity_display_name ~ S100B_display_name,
-                stain == 'LAMP1' ~ LAMP1_display_name,
-                stain == 'AT8' ~ AT8_display_name,
-                stain == 'HT7' ~ HT7_display_name,
-                stain == 'ThioS' & units == averageObjectVolume_display_name ~ ThioS_size_display_name,
-                stain == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
-                # Set default value for rows with unused measurements
-                .default = 'UNMAPPED_DROPME'
-        )
-
-  # drop rows for unused stain/unit combinations
-) %>% filter(
-        type != 'UNMAPPED_DROPME'
-
-  # Drop rows with NA measurements
-) %>% filter(
-        !is.na(measurement)
-
-  # Populate model column
-) %>% add_column(
-        model = 'Trem2-R47H_NSS'
-
-  # Drop unwanted columns
-) %>% select(
-        all_of(keeps_with_pool_join_field)
-)
 
 nss_pathology
 
@@ -471,53 +473,53 @@ abca7_pathology <- abca7_pathology_source %>%
         filter(
                 stain %in% stain_keeps
 
-                # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+        # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
         ) %>% pivot_longer(
-        cols = c(objectDensity, averageObjectVolume, totalObjectVolume),
-        names_to = "units",
-        values_to = "measurement",
-        values_transform = list(measurement = as.numeric)
+            cols = c(objectDensity, averageObjectVolume, totalObjectVolume),
+            names_to = "units",
+            values_to = "measurement",
+            values_transform = list(measurement = as.numeric)
 
-  # Convert units to display values
-) %>% mutate(
-        units = case_match(
-                units,
-                'objectDensity' ~ objectDensity_display_name,
-                'averageObjectVolume' ~ averageObjectVolume_display_name,
-                'totalObjectVolume' ~ totalObjectVolume_display_name
-        )
+        # Convert units to display values
+        ) %>% mutate(
+            units = case_match(
+                    units,
+                    'objectDensity' ~ objectDensity_display_name,
+                    'averageObjectVolume' ~ averageObjectVolume_display_name,
+                    'totalObjectVolume' ~ totalObjectVolume_display_name
+            )
 
-  # Map 'stain' values to 'type' display names
-) %>% mutate(
-        type = case_when(
-                stain == 'IBA1' & units == objectDensity_display_name ~ IBA1_display_name,
-                stain == 'GFAP' & units == objectDensity_display_name ~ GFAP_display_name,
-                stain == 'S100B' & units == objectDensity_display_name ~ S100B_display_name,
-                stain == 'LAMP1' & units == totalObjectVolume_display_name ~ LAMP1_display_name,
-                stain == 'AT8' ~ AT8_display_name,
-                stain == 'HT7' ~ HT7_display_name,
-                stain == 'ThioS' & units == averageObjectVolume_display_name ~ ThioS_size_display_name,
-                stain == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
-                # Set default value for rows with unused measurements
-                .default = 'UNMAPPED_DROPME'
-        )
+        # Map 'stain' values to 'type' display names
+        ) %>% mutate(
+                type = case_when(
+                        stain == 'IBA1' & units == objectDensity_display_name ~ IBA1_display_name,
+                        stain == 'GFAP' & units == objectDensity_display_name ~ GFAP_display_name,
+                        stain == 'S100B' & units == objectDensity_display_name ~ S100B_display_name,
+                        stain == 'LAMP1' & units == totalObjectVolume_display_name ~ LAMP1_display_name,
+                        stain == 'AT8' ~ AT8_display_name,
+                        stain == 'HT7' ~ HT7_display_name,
+                        stain == 'ThioS' & units == averageObjectVolume_display_name ~ ThioS_size_display_name,
+                        stain == 'ThioS' & units == objectDensity_display_name ~ ThioS_density_display_name,
+                        # Set default value for rows with unused measurements
+                        .default = 'UNMAPPED_DROPME'
+                )
 
-  # drop rows for unused stain/unit combinations
-) %>% filter(
-        type != 'UNMAPPED_DROPME'
+        # drop rows for unused stain/unit combinations
+        ) %>% filter(
+                type != 'UNMAPPED_DROPME'
 
         # Drop rows with NA measurements
-) %>% filter(
-        !is.na(measurement)
+        ) %>% filter(
+                !is.na(measurement)
 
         # Populate model column
-) %>% add_column(
-        model = 'Abca7*V1599M'
+        ) %>% add_column(
+                model = 'Abca7*V1599M'
 
         # Drop unwanted columns
-) %>% select(
-        all_of(keeps_with_pool_join_field)
-)
+        ) %>% select(
+                all_of(keeps_with_pool_join_field)
+        )
 
 abca7_pathology
 
@@ -571,13 +573,13 @@ stopifnot(nrow(threex_pathology[threex_pathology$type == ThioS_density_display_n
 # 5xFAD
 # Iba1 Correct for "N/A" values in targeted source columns: 'X.objects..sqmm', 'mean.object.area..squm.'
 fivex_ibas <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'Iba1',]
-fivex_iba_nas <- sum(fivex_ibas$X.objects..sqmm == "N/A") + sum(fivex_ibas$mean.object.area..squm. == "N/A")
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == IBA1_display_name,]) == nrow(fivex_ibas) * 2 - fivex_iba_nas)
+fivex_iba_nas <- sum(fivex_ibas$X.objects..sqmm == "N/A")
+stopifnot(nrow(fivex_pathology[fivex_pathology$type == IBA1_display_name,]) == nrow(fivex_ibas) - fivex_iba_nas)
 
 # GFAP Correct for "N/A" values in targeted source columns: 'X.objects..sqmm', 'mean.object.area..sqmm.'
 fivex_gfap <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain == 'GFAP',]
-fivex_gfap_nas <- sum(fivex_gfap$X.objects..sqmm == "N/A") + sum(fivex_gfap$mean.object.area..sqmm. == "N/A")
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == GFAP_display_name,]) == nrow(fivex_gfap) * 2 - fivex_gfap_nas)
+fivex_gfap_nas <- sum(fivex_gfap$X.objects..sqmm == "N/A")
+stopifnot(nrow(fivex_pathology[fivex_pathology$type == GFAP_display_name,]) == nrow(fivex_gfap) - fivex_gfap_nas)
 
 # S100B Correct for "N/A" values in targeted source column: 'X.objects..sqmm'
 fivex_s100bs <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain == 'S100B',]


### PR DESCRIPTION
# Problem
The R notebook that generates the harmonized pathology source file was a quick and dirty implementation to unblock development. As we approach MVP, we need to ensure that the generated source data includes all, and only, the data that we actually want to release.

# Solution
1. Refactor the notebook to extract common functionality into a shared `transform_results` function
2. Introduce model-specific handling as required to address edge cases: missing metadata values, duplicate measurements, "N/A" strings, etc.
3. Improve data validation 

## MG-322
### Problem
The data contains unexpected result types for IBA1 and GFAP. This data causes the application to plot duplicate results per age, as shown in for IBA at 12 months here:

<img width="1173" height="475" alt="Screenshot 2025-08-20 at 9 41 34 AM" src="https://github.com/user-attachments/assets/fa6477a1-c76f-4994-8b2d-5756c522f2e2" />

### Solution
Filter out GFAP and IBA1 rows for the unwanted measurements (units == "mean object area (sqmm)") to prevent them from surfacing in the application, while keeping the measurements with the unit type we do want  (units == '# objects / sqmm').

## MG-268
### Problem
The data was missing a subset of the expected results for 5xFAD, specifically the 0 measurements. These results are miscoded as NA values in the source file.

### Solution
Transform the NA measurements to 0s for 5xFAD results only.