### PR TITLE
MG-345: Corrected model_overview.study_data.link_url to include synapse

### DIFF
--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -162,7 +162,7 @@ def transform_model_overview(
         )
         row["study_data"] = (
             {
-                "link_url": f"https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study={row['study_synid']}"
+                "link_url": f"https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study={row['study_synid']}"
             }
             if row["study_synid"]
             else None

--- a/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
@@ -14,7 +14,7 @@
       "link_url": "models/3xTg-AD/biomarkers"
     },
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
@@ -48,7 +48,7 @@
       "link_url": "models/5xFAD (UCI)/biomarkers"
     },
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"
@@ -76,7 +76,7 @@
     "pathology": null,
     "biomarkers": null,
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn17095980"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn17095980"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/27894"

--- a/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
@@ -14,7 +14,7 @@
       "link_url": "models/3xTg-AD/biomarkers"
     },
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
@@ -48,7 +48,7 @@
       "link_url": "models/5xFAD (UCI)/biomarkers"
     },
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"
@@ -76,7 +76,7 @@
     "pathology": null,
     "biomarkers": null,
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn17095980"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn17095980"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/27894"

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
@@ -14,7 +14,7 @@
       "link_url": "models/3xTg-AD/biomarkers"
     },
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
@@ -44,7 +44,7 @@
     },
     "biomarkers": null,
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"
@@ -71,7 +71,7 @@
     "pathology": null,
     "biomarkers": null,
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn17095980"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn17095980"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/27894"

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
@@ -14,7 +14,7 @@
       "link_url": "models/3xTg-AD/biomarkers"
     },
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
@@ -42,7 +42,7 @@
     "pathology": null,
     "biomarkers": null,
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"

--- a/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
@@ -14,7 +14,7 @@
       "link_url": "models/3xTg-AD/biomarkers"
     },
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn22964685"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
@@ -48,7 +48,7 @@
       "link_url": "models/5xFAD (UCI)/biomarkers"
     },
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn16798076"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"
@@ -76,7 +76,7 @@
     "pathology": null,
     "biomarkers": null,
     "study_data": {
-      "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn17095980"
+      "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn17095980"
     },
     "jax_strain": {
       "link_url": "https://jax.org/strain/27894"

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -286,7 +286,7 @@ class TestTransformModelOverview:
                 "pathology": {"link_url": "models/test_model/pathology"},
                 "biomarkers": None,
                 "study_data": {
-                    "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
+                    "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
                 "center": {"link_text": "Test Center"},
@@ -363,7 +363,7 @@ class TestTransformModelOverview:
                 "pathology": None,
                 "biomarkers": None,
                 "study_data": {
-                    "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
+                    "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
                 "center": {"link_text": "Test Center"},
@@ -448,7 +448,7 @@ class TestTransformModelOverview:
                 "pathology": {"link_url": "models/model1/pathology"},
                 "biomarkers": None,
                 "study_data": {
-                    "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn111"
+                    "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn111"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/111"},
                 "center": {"link_text": "Center1"},
@@ -466,7 +466,7 @@ class TestTransformModelOverview:
                 "pathology": {"link_url": "models/model2/pathology"},
                 "biomarkers": {"link_url": "models/model2/biomarkers"},
                 "study_data": {
-                    "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn222"
+                    "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn222"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/222"},
                 "center": {"link_text": "Center2"},


### PR DESCRIPTION
## Problem
The model_overview.study_data.link_url values look like this:
`https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=<study>`
But they need to include **synapse** in the path:
`https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=<study>`

## Solution
Updated link from `adknowledgeportal.org` to `adknowledgeportal.synapse.org`. Updated all of the tests to include the corrected link.