### PR TITLE
MG-356 - Added link_url to center field in model_overview

### DIFF
--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -73,6 +73,18 @@ def get_list_of_available_data(row: Dict[str, Any]) -> List[str]:
     return available_data
 
 
+def get_center_link_url(contributing_group: str) -> str:
+    """
+    Get the link URL for the center.
+    """
+    if contributing_group == "UCI":
+        return "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+    elif contributing_group == "IU/Jax/Pitt":
+        return "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
+    else:
+        raise ValueError(f"Invalid contributing group: {contributing_group}")
+
+
 def transform_model_overview(
     datasets: Dict[str, pd.DataFrame],
     required_input: Dict[str, List[str]] = REQUIRED_INPUT,
@@ -173,7 +185,10 @@ def transform_model_overview(
             else None
         )
         row["center"] = (
-            {"link_text": row["contributing_group"]}
+            {
+                "link_text": row["contributing_group"],
+                "link_url": get_center_link_url(row["contributing_group"]),
+            }
             if row["contributing_group"]
             else None
         )

--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -77,12 +77,12 @@ def get_center_link_url(contributing_group: str) -> str:
     """
     Get the link URL for the center.
     """
-    if contributing_group == "UCI":
-        return "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    elif contributing_group == "IU/Jax/Pitt" or contributing_group == "IU/JAX/PITT":
-        return "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
-    else:
-        raise ValueError(f"Invalid contributing group: {contributing_group}")
+    if isinstance(contributing_group, str):
+        if contributing_group.upper() == "UCI":
+            return "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+        elif contributing_group.upper() == "IU/JAX/PITT":
+            return "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
+    raise ValueError(f"Invalid contributing group: {contributing_group}")
 
 
 def transform_model_overview(

--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -79,7 +79,7 @@ def get_center_link_url(contributing_group: str) -> str:
     """
     if contributing_group == "UCI":
         return "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    elif contributing_group == "IU/Jax/Pitt":
+    elif contributing_group == "IU/Jax/Pitt" or contributing_group == "IU/JAX/PITT":
         return "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
     else:
         raise ValueError(f"Invalid contributing group: {contributing_group}")

--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -79,7 +79,9 @@ def get_center_link_url(contributing_group: str) -> str:
     """
     if isinstance(contributing_group, str):
         if contributing_group.upper() == "UCI":
-            return "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+            return (
+                "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+            )
         elif contributing_group.upper() == "IU/JAX/PITT":
             return "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
     raise ValueError(f"Invalid contributing group: {contributing_group}")

--- a/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
@@ -20,7 +20,8 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [
       "App",
@@ -54,7 +55,8 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [],
     "available_data": [

--- a/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
@@ -84,7 +84,8 @@
       "link_url": "https://jax.org/strain/27894"
     },
     "center": {
-      "link_text": "IU/JAX/PITT"
+      "link_text": "IU/JAX/PITT",
+      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
     },
     "modified_genes": [],
     "available_data": [

--- a/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
@@ -20,7 +20,8 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [
       "App",
@@ -54,7 +55,8 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [],
     "available_data": [

--- a/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
@@ -84,7 +84,8 @@
       "link_url": "https://jax.org/strain/27894"
     },
     "center": {
-      "link_text": "IU/JAX/PITT"
+      "link_text": "IU/JAX/PITT",
+      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
     },
     "modified_genes": [],
     "available_data": [

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
@@ -20,7 +20,8 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [
       "Psen1"
@@ -50,7 +51,8 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [],
     "available_data": [

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
@@ -79,7 +79,8 @@
       "link_url": "https://jax.org/strain/27894"
     },
     "center": {
-      "link_text": "IU/JAX/PITT"
+      "link_text": "IU/JAX/PITT",
+      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
     },
     "modified_genes": [],
     "available_data": [

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
@@ -20,7 +20,8 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [
       "APP",
@@ -48,7 +49,8 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [],
     "available_data": []

--- a/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
@@ -20,7 +20,8 @@
       "link_url": "https://jax.org/strain/4807"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [
       "App",
@@ -54,7 +55,8 @@
       "link_url": "https://jax.org/strain/8730"
     },
     "center": {
-      "link_text": "UCI"
+      "link_text": "UCI",
+      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
     },
     "modified_genes": [],
     "available_data": [

--- a/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
@@ -84,7 +84,8 @@
       "link_url": "https://jax.org/strain/27894"
     },
     "center": {
-      "link_text": "IU/JAX/PITT"
+      "link_text": "IU/JAX/PITT",
+      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
     },
     "modified_genes": [],
     "available_data": [

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -549,3 +549,64 @@ class TestGetListOfAvailableData:
         }
         result = get_list_of_available_data(model)
         assert result == ["Gene Expression"]
+
+
+class TestGetCenterLinkUrl:
+    def test_uci_contributing_group(self):
+        from agoradatatools.etl.transform.model_overview import get_center_link_url
+
+        result = get_center_link_url("UCI")
+        expected = "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+        assert result == expected
+
+    def test_iu_jax_pitt_contributing_group(self):
+        from agoradatatools.etl.transform.model_overview import get_center_link_url
+
+        result = get_center_link_url("IU/Jax/Pitt")
+        expected = "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
+        assert result == expected
+
+    def test_iu_jax_pitt_uppercase_contributing_group(self):
+        from agoradatatools.etl.transform.model_overview import get_center_link_url
+
+        result = get_center_link_url("IU/JAX/PITT")
+        expected = "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
+        assert result == expected
+
+    def test_invalid_contributing_group_raises_value_error(self):
+        from agoradatatools.etl.transform.model_overview import get_center_link_url
+
+        with pytest.raises(ValueError, match="Invalid contributing group: InvalidCenter"):
+            get_center_link_url("InvalidCenter")
+
+    def test_empty_string_raises_value_error(self):
+        from agoradatatools.etl.transform.model_overview import get_center_link_url
+
+        with pytest.raises(ValueError, match="Invalid contributing group: "):
+            get_center_link_url("")
+
+    def test_none_contributing_group_raises_value_error(self):
+        from agoradatatools.etl.transform.model_overview import get_center_link_url
+
+        with pytest.raises(ValueError, match="Invalid contributing group: None"):
+            get_center_link_url(None)
+
+    def test_case_sensitive_uci_variations(self):
+        from agoradatatools.etl.transform.model_overview import get_center_link_url
+
+        # Test that only exact "UCI" works
+        with pytest.raises(ValueError, match="Invalid contributing group: uci"):
+            get_center_link_url("uci")
+        
+        with pytest.raises(ValueError, match="Invalid contributing group: Uci"):
+            get_center_link_url("Uci")
+
+    def test_partial_matches_raise_value_error(self):
+        from agoradatatools.etl.transform.model_overview import get_center_link_url
+
+        # Test partial matches that should not work
+        with pytest.raises(ValueError, match="Invalid contributing group: IU/Jax"):
+            get_center_link_url("IU/Jax")
+        
+        with pytest.raises(ValueError, match="Invalid contributing group: IU/JAX"):
+            get_center_link_url("IU/JAX")

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -226,7 +226,7 @@ class TestTransformModelOverview:
                 "name": ["test_model"],
                 "matched_controls": ["C57BL6J"],
                 "model_type": ["Familial AD"],
-                "contributing_group": ["Test Center"],
+                "contributing_group": ["UCI"],
                 "study_synid": ["syn123456"],
                 "rrid": ["IMSR_JAX:123456"],
                 "jax_id": [123456],
@@ -289,7 +289,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
-                "center": {"link_text": "Test Center"},
+                "center": {"link_text": "UCI", "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"},
                 "modified_genes": ["TestGene"],
                 "available_data": ["Gene Expression", "Pathology"],
             }
@@ -305,7 +305,7 @@ class TestTransformModelOverview:
                 "name": ["test_model"],
                 "matched_controls": [None],
                 "model_type": ["Familial AD"],
-                "contributing_group": ["Test Center"],
+                "contributing_group": ["IU/Jax/Pitt"],
                 "study_synid": ["syn123456"],
                 "rrid": ["IMSR_JAX:123456"],
                 "jax_id": [123456],
@@ -366,7 +366,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
-                "center": {"link_text": "Test Center"},
+                "center": {"link_text": "IU/Jax/Pitt", "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"},
                 "modified_genes": [],
                 "available_data": [],
             }
@@ -382,7 +382,7 @@ class TestTransformModelOverview:
                 "name": ["model1", "model2"],
                 "matched_controls": ["C57BL6J", "B6129"],
                 "model_type": ["Familial AD", "Tauopathy"],
-                "contributing_group": ["Center1", "Center2"],
+                "contributing_group": ["UCI", "IU/Jax/Pitt"],
                 "study_synid": ["syn111", "syn222"],
                 "rrid": ["IMSR_JAX:111", "IMSR_JAX:222"],
                 "jax_id": [111, 222],
@@ -451,7 +451,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn111"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/111"},
-                "center": {"link_text": "Center1"},
+                "center": {"link_text": "UCI", "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"},
                 "modified_genes": ["Gene1", "Gene2"],
                 "available_data": ["Gene Expression", "Pathology"],
             },
@@ -469,7 +469,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn222"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/222"},
-                "center": {"link_text": "Center2"},
+                "center": {"link_text": "IU/Jax/Pitt", "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"},
                 "modified_genes": ["Gene3"],
                 "available_data": ["Disease Correlation", "Pathology", "Biomarkers"],
             },

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -289,7 +289,10 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
-                "center": {"link_text": "UCI", "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"},
+                "center": {
+                    "link_text": "UCI",
+                    "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/",
+                },
                 "modified_genes": ["TestGene"],
                 "available_data": ["Gene Expression", "Pathology"],
             }
@@ -366,7 +369,10 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
-                "center": {"link_text": "IU/Jax/Pitt", "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"},
+                "center": {
+                    "link_text": "IU/Jax/Pitt",
+                    "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/",
+                },
                 "modified_genes": [],
                 "available_data": [],
             }
@@ -451,7 +457,10 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn111"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/111"},
-                "center": {"link_text": "UCI", "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"},
+                "center": {
+                    "link_text": "UCI",
+                    "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/",
+                },
                 "modified_genes": ["Gene1", "Gene2"],
                 "available_data": ["Gene Expression", "Pathology"],
             },
@@ -469,7 +478,10 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn222"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/222"},
-                "center": {"link_text": "IU/Jax/Pitt", "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"},
+                "center": {
+                    "link_text": "IU/Jax/Pitt",
+                    "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/",
+                },
                 "modified_genes": ["Gene3"],
                 "available_data": ["Disease Correlation", "Pathology", "Biomarkers"],
             },
@@ -556,16 +568,20 @@ class TestGetCenterLinkUrl:
         from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         result = get_center_link_url("UCI")
-        expected = "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+        expected = (
+            "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+        )
         assert result == expected
-    
+
     def test_uci_contributing_group_lowercase(self):
         from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         result = get_center_link_url("uci")
-        expected = "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+        expected = (
+            "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+        )
         assert result == expected
-    
+
     def test_iu_jax_pitt_contributing_group_lowercase(self):
         from agoradatatools.etl.transform.model_overview import get_center_link_url
 
@@ -583,7 +599,9 @@ class TestGetCenterLinkUrl:
     def test_invalid_contributing_group_raises_value_error(self):
         from agoradatatools.etl.transform.model_overview import get_center_link_url
 
-        with pytest.raises(ValueError, match="Invalid contributing group: InvalidCenter"):
+        with pytest.raises(
+            ValueError, match="Invalid contributing group: InvalidCenter"
+        ):
             get_center_link_url("InvalidCenter")
 
     def test_empty_string_raises_value_error(self):
@@ -604,6 +622,6 @@ class TestGetCenterLinkUrl:
         # Test partial matches that should not work
         with pytest.raises(ValueError, match="Invalid contributing group: IU/Jax"):
             get_center_link_url("IU/Jax")
-        
+
         with pytest.raises(ValueError, match="Invalid contributing group: IU/JAX"):
             get_center_link_url("IU/JAX")

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -558,8 +558,15 @@ class TestGetCenterLinkUrl:
         result = get_center_link_url("UCI")
         expected = "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
         assert result == expected
+    
+    def test_uci_contributing_group_lowercase(self):
+        from agoradatatools.etl.transform.model_overview import get_center_link_url
 
-    def test_iu_jax_pitt_contributing_group(self):
+        result = get_center_link_url("uci")
+        expected = "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
+        assert result == expected
+    
+    def test_iu_jax_pitt_contributing_group_lowercase(self):
         from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         result = get_center_link_url("IU/Jax/Pitt")
@@ -590,16 +597,6 @@ class TestGetCenterLinkUrl:
 
         with pytest.raises(ValueError, match="Invalid contributing group: None"):
             get_center_link_url(None)
-
-    def test_case_sensitive_uci_variations(self):
-        from agoradatatools.etl.transform.model_overview import get_center_link_url
-
-        # Test that only exact "UCI" works
-        with pytest.raises(ValueError, match="Invalid contributing group: uci"):
-            get_center_link_url("uci")
-        
-        with pytest.raises(ValueError, match="Invalid contributing group: Uci"):
-            get_center_link_url("Uci")
 
     def test_partial_matches_raise_value_error(self):
         from agoradatatools.etl.transform.model_overview import get_center_link_url


### PR DESCRIPTION
## Problem
We want to add a link_url to the existing center field in model_overview:
Current:
```
"center": {"link_text": "<center name>"}
```

Expected
```
    "center": {
      "link_text": "<center name>",
      "link_url": "<center-specific URL>"
    }
```
The link_url value varies depending on the link_text value:
IU/Jax/Pitt:
`https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/`
UCI:
`http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/`

## Solution
Added `get_center_link_url()` to get the correct center-link and it does not expect case-sensitive center names.

## Testing
Updated tests to include the `link_url` and added a testing for the new function `get_center_link_url()`.