### PR TITLE
MG-329: Changed matched_controls output from a string to a list in model_overview

### DIFF
--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -181,6 +181,9 @@ def transform_model_overview(
         # Calculate available_data based on which links are actually present
         row["available_data"] = get_list_of_available_data(row)
 
+        # Convert matched_controlss from comma-delimited strings to lists
+        row["matched_controls"] = [x.strip() for x in str(row["matched_controls"]).split(",")] if pd.notna(row["matched_controls"]) and row["matched_controls"] != "" else []
+
         # Keep only the columns that will be in transformed_records in row
         keep_columns = [
             "name",

--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -182,7 +182,11 @@ def transform_model_overview(
         row["available_data"] = get_list_of_available_data(row)
 
         # Convert matched_controlss from comma-delimited strings to lists
-        row["matched_controls"] = [x.strip() for x in str(row["matched_controls"]).split(",")] if pd.notna(row["matched_controls"]) and row["matched_controls"] != "" else []
+        row["matched_controls"] = (
+            [x.strip() for x in str(row["matched_controls"]).split(",")]
+            if pd.notna(row["matched_controls"]) and row["matched_controls"] != ""
+            else []
+        )
 
         # Keep only the columns that will be in transformed_records in row
         keep_columns = [

--- a/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
@@ -2,7 +2,7 @@
   {
     "name": "3xTg-AD",
     "model_type": "Familial AD",
-    "matched_controls": "B6129",
+    "matched_controls": ["B6129"],
     "gene_expression": {
       "link_url": "comparison/expression?model=3xTg-AD"
     },
@@ -36,7 +36,7 @@
   {
     "name": "5xFAD (UCI)",
     "model_type": "Familial AD",
-    "matched_controls": "C57BL6J",
+    "matched_controls": ["C57BL6J"],
     "gene_expression": {
       "link_url": "comparison/expression?model=5xFAD (UCI)"
     },
@@ -66,7 +66,7 @@
   {
     "name": "APOE4",
     "model_type": "Late Onset AD",
-    "matched_controls": "C57BL6J",
+    "matched_controls": ["C57BL6J"],
     "gene_expression": {
       "link_url": "comparison/expression?model=APOE4"
     },

--- a/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
@@ -2,7 +2,7 @@
   {
     "name": "3xTg-AD",
     "model_type": "Familial AD",
-    "matched_controls": "B6129",
+    "matched_controls": ["B6129"],
     "gene_expression": {
       "link_url": "comparison/expression?model=3xTg-AD"
     },
@@ -36,7 +36,7 @@
   {
     "name": "5xFAD (UCI)",
     "model_type": "Familial AD",
-    "matched_controls": "C57BL6J",
+    "matched_controls": ["C57BL6J"],
     "gene_expression": {
       "link_url": "comparison/expression?model=5xFAD (UCI)"
     },
@@ -66,7 +66,7 @@
   {
     "name": "APOE4",
     "model_type": "Late Onset AD",
-    "matched_controls": "C57BL6J",
+    "matched_controls": ["C57BL6J"],
     "gene_expression": {
       "link_url": "comparison/expression?model=APOE4"
     },

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
@@ -2,7 +2,7 @@
   {
     "name": "3xTg-AD",
     "model_type": "Familial AD",
-    "matched_controls": null,
+    "matched_controls": [],
     "gene_expression": {
       "link_url": "comparison/expression?model=3xTg-AD"
     },
@@ -34,7 +34,7 @@
   {
     "name": "5xFAD (UCI)",
     "model_type": null,
-    "matched_controls": "C57BL6J",
+    "matched_controls": ["C57BL6J"],
     "gene_expression": {
       "link_url": "comparison/expression?model=5xFAD (UCI)"
     },
@@ -61,7 +61,7 @@
   {
     "name": "APOE4",
     "model_type": "Late Onset AD",
-    "matched_controls": "C57BL6J",
+    "matched_controls": ["C57BL6J"],
     "gene_expression": {
       "link_url": "comparison/expression?model=APOE4"
     },

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
@@ -2,7 +2,7 @@
   {
     "name": "3xTg-AD",
     "model_type": "Familial AD",
-    "matched_controls": "B6129",
+    "matched_controls": ["B6129"],
     "gene_expression": {
       "link_url": "comparison/expression?model=3xTg-AD"
     },
@@ -36,7 +36,7 @@
   {
     "name": "5xFAD (UCI)",
     "model_type": "Familial AD",
-    "matched_controls": "C57BL6J",
+    "matched_controls": ["C57BL6J"],
     "gene_expression": null,
     "disease_correlation": null,
     "pathology": null,

--- a/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
@@ -2,7 +2,7 @@
   {
     "name": "3xTg-AD",
     "model_type": "Familial AD",
-    "matched_controls": "B6129",
+    "matched_controls": ["B6129"],
     "gene_expression": {
       "link_url": "comparison/expression?model=3xTg-AD"
     },
@@ -36,7 +36,7 @@
   {
     "name": "5xFAD (UCI)",
     "model_type": "Familial AD",
-    "matched_controls": "C57BL6J",
+    "matched_controls": ["C57BL6J"],
     "gene_expression": {
       "link_url": "comparison/expression?model=5xFAD (UCI)"
     },
@@ -66,7 +66,7 @@
   {
     "name": "APOE4",
     "model_type": "Late Onset AD",
-    "matched_controls": "C57BL6J",
+    "matched_controls": ["C57BL6J"],
     "gene_expression": {
       "link_url": "comparison/expression?model=APOE4"
     },

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -377,6 +377,8 @@ class TestTransformModelOverview:
 
     def test_model_overview_transform_multiple_models(self):
         # Create test datasets with multiple models
+        # A column where one row has a single control and one has two.
+        # Testing that the "B6129,B6130" entry is properly split into a list in the JSON output.
         model_info = pd.DataFrame(
             {
                 "name": ["model1", "model2"],

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -278,7 +278,7 @@ class TestTransformModelOverview:
             {
                 "name": "test_model",
                 "model_type": "Familial AD",
-                "matched_controls": "C57BL6J",
+                "matched_controls": ["C57BL6J"],
                 "gene_expression": {
                     "link_url": "comparison/expression?model=test_model"
                 },
@@ -357,7 +357,7 @@ class TestTransformModelOverview:
             {
                 "name": "test_model",
                 "model_type": "Familial AD",
-                "matched_controls": None,
+                "matched_controls": [],
                 "gene_expression": None,
                 "disease_correlation": None,
                 "pathology": None,
@@ -380,7 +380,7 @@ class TestTransformModelOverview:
         model_info = pd.DataFrame(
             {
                 "name": ["model1", "model2"],
-                "matched_controls": ["C57BL6J", "B6129"],
+                "matched_controls": ["C57BL6J", "B6129,B6130"],
                 "model_type": ["Familial AD", "Tauopathy"],
                 "contributing_group": ["Center1", "Center2"],
                 "study_synid": ["syn111", "syn222"],
@@ -442,7 +442,7 @@ class TestTransformModelOverview:
             {
                 "name": "model1",
                 "model_type": "Familial AD",
-                "matched_controls": "C57BL6J",
+                "matched_controls": ["C57BL6J"],
                 "gene_expression": {"link_url": "comparison/expression?model=model1"},
                 "disease_correlation": None,
                 "pathology": {"link_url": "models/model1/pathology"},
@@ -458,7 +458,7 @@ class TestTransformModelOverview:
             {
                 "name": "model2",
                 "model_type": "Tauopathy",
-                "matched_controls": "B6129",
+                "matched_controls": ["B6129", "B6130"],
                 "gene_expression": None,
                 "disease_correlation": {
                     "link_url": "comparison/correlation?model=model2"


### PR DESCRIPTION
# MG-329: matched_controls output is now a list in model_overview

## Problem
`model_details` has a list of strings:
```
    "matched_controls": [
      "C57BL/6J",
      "5xFAD"
    ]
```
`model_overview` has a single string:
```
"matched_controls": "C57BL/6J, 5xFAD",
``` 
We want `matched_controls` to be a list of strings in model_overview.

## Solution
Changed `matched_controls` to a list of strings in model_overview:
```
# Convert matched_controlss from comma-delimited strings to lists
row["matched_controls"] = (
    [x.strip() for x in str(row["matched_controls"]).split(",")]
    if pd.notna(row["matched_controls"]) and row["matched_controls"] != ""
    else []
)
```

## Testing
Updated all `matched_controls` to lists of strings in the tests and assets.