### PR TITLE
[AG-1852] Fix custom expectation rules report upload 

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -66,7 +66,7 @@ jobs:
       - run: pip install -U setuptools
       - run: pip install .
       - run: adt test_config.yaml --upload --platform GITHUB --run_id ${{ github.run_id }} --token ${{secrets.SYNAPSE_PAT}}
-      - run: adt modelad_test_config.yaml --upload --platform GITHUB --run_id ${{ github.run_id }} --token ${{secrets.SYNAPSE_PAT}}
+      - run: adt modelad_test_config.yaml --platform GITHUB --run_id ${{ github.run_id }} --token ${{secrets.SYNAPSE_PAT}}
 
   ghcr-publish:
     needs: [build, test]

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -66,7 +66,7 @@ jobs:
       - run: pip install -U setuptools
       - run: pip install .
       - run: adt test_config.yaml --upload --platform GITHUB --run_id ${{ github.run_id }} --token ${{secrets.SYNAPSE_PAT}}
-      - run: adt modelad_test_config.yaml --platform GITHUB --run_id ${{ github.run_id }} --token ${{secrets.SYNAPSE_PAT}}
+      - run: adt modelad_test_config.yaml --upload --platform GITHUB --run_id ${{ github.run_id }} --token ${{secrets.SYNAPSE_PAT}}
 
   ghcr-publish:
     needs: [build, test]

--- a/modelad_test_config.yaml
+++ b/modelad_test_config.yaml
@@ -71,6 +71,11 @@ datasets:
         measurement: value
         type: evidence_type
         model: name
+      gx_nested_columns:
+        - genetic_info
+        - biomarkers
+        - pathology
+      gx_enabled: true
 
   - disease_correlation:
       files:
@@ -102,6 +107,9 @@ datasets:
       provenance:
         - syn66527739
       destination: *dest
+      gx_enabled: true
+      gx_nested_columns:
+        - columns
 
   - model_overview:
       files:

--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -78,7 +78,7 @@ class GreatExpectationsRunner:
         from expectations.expect_column_nested_field_values_mostly_meet_string_requirement import (
             ExpectColumnNestedObjectStringLength,
         )
-        from expectations.expect_column_nested_field_values_mostly_meet_string_requirement import (
+        from expectations.expect_column_nested_field_values_mostly_regex import (
             ExpectColumnNestedObjectRegexRule,
         )
 

--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -75,6 +75,12 @@ class GreatExpectationsRunner:
         from expectations.expect_column_nested_field_values_to_be_mostly_not_null import (
             ExpectColumnNestedObjectNotNull,
         )
+        from expectations.expect_column_nested_field_values_mostly_meet_string_requirement import (
+            ExpectColumnNestedObjectStringLength,
+        )
+        from expectations.expect_column_nested_field_values_mostly_meet_string_requirement import (
+            ExpectColumnNestedObjectRegexRule,
+        )
 
     def _get_data_context_location(self) -> str:
         """Gets the path to the great_expectations directory"""

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -407,7 +407,7 @@ upload_opt = Option(
     False,
     "--upload",
     "-u",
-    help="Boolean value that toggles whether or not files will be uploaded to Synapse. The absence of this option means "
+    help="Boolean value that toggles whether or not files or GX reports will be uploaded to Synapse. The absence of this option means "
     "`False` - that neither output data files nor GX reports will be uploaded to Synapse. Setting "
     "`--upload` in the command will cause both to be uploaded. (Optional, defaults to False)",
     show_default=True,


### PR DESCRIPTION
## Problem
The GX reports are not showing up for "mostly string length" and "mostly regex" custom expectations

## Solution 
* Enabled `--upload` in Github action when running the test model AD config
* Modified test config
* Correctly import validation rules

## Test
See validation rules uploaded to my test folder on synapse with 
```
adt modelad_test_config.yaml --token <my token>
```

See here: https://www.synapse.org/Synapse:syn68784825
<img width="1433" height="690" alt="Screenshot 2025-08-22 at 3 42 24 PM" src="https://github.com/user-attachments/assets/1ab64070-265f-4137-837d-5f3378d144fc" />

