### PR TITLE
MG-389: Refactor Biomarkers & Pathology notebooks

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-389_immunohisto_expected_row_counts
+++ b/data_analysis/model_ad/notebooks/MG-389_immunohisto_expected_row_counts
@@ -229,7 +229,9 @@ cat("\nNfL (nss): ", unique(nfl_legacy_nss$Mouse.Model), sep=", ")
 ```
 
 ## Determine number of legacy results per model for pathology & biomarkers
-These values are used to validate that the correct results are included in the harmonized source files generated via the 'MG-88-biomarkers' notebook.
+These values are used to validate that the correct results are included in the harmonized source files generated via these notebooks:
+* MG-40_pathology
+* MG-88_biomarkers
 
 ```{r}
 # *********
@@ -300,7 +302,3 @@ count_legacy_rows("5xFADAbca7*V1599M", "5xFAD", sol_ab42_legacy_abca7, "Soluble 
 count_legacy_rows("Abca7*V1599M", "C57BL/6J", nfl_legacy_abca7, "NfL (abca7)")
 count_legacy_rows("5xFADAbca7*V1599M", "5xFAD", nfl_legacy_abca7, "NfL (abca7)")
 ```
-
-
-
-

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -77,6 +77,9 @@ Run this to initialize shared variables and functions.
 # Measures (stain values) that we want to include
 stain_keeps <- c("GFAP", "S100B", "LAMP1", "IBA1", "ThioS", "HT7", "AT8")
 
+# ages that we want to display results for
+age_keeps <- c(4, 12, 18)
+
 # column specs for intermediate per-model files
 # For result files without individualID column: 3xTG-AD, NSS, Abca7
 keeps_with_pool_join_field <- c('specimenID', 'model', 'type', 'measurement', 'units')
@@ -84,7 +87,7 @@ keeps_with_pool_join_field <- c('specimenID', 'model', 'type', 'measurement', 'u
 keeps_with_join_fields <- c('individualID', 'specimenID', 'model', 'type', 'measurement', 'units')
 
 # column spec for final harmonized output file
-keeps <- c('individualID', 'specimenID', 'model', 'type', 'measurement', 'units', 'ageDeath', 'tissue', 'sex', 'genotype')
+keeps <- c('individual_id', 'model', 'type', 'measurement', 'units', 'age_death', 'tissue', 'sex', 'genotype')
 
 # Pathology display names
 IBA1_display_name <- 'Microglia Cell Density (IBA1)'
@@ -101,7 +104,7 @@ objectDensity_display_name <- '# objects / square mm'
 averageObjectVolume_display_name <- 'mean object volume (cubic mm)'
 totalObjectVolume_display_name <- 'total object volume (cubic mm)'
 meanObjectArea_display_name <- 'mean object area (square mm)'
-areaPercent_display_name <- '%'
+areaPercent_display_name <- 'area %'
 
 # Vector to store all downloaded synIds for Synapse provenance (populated via download_csv function)
 data_sources <- character()
@@ -198,29 +201,64 @@ transform_results <- function(results, measurement_columns, model_name, fields_t
 # - df: A dataframe containing result rows
 # - individual_metadata: A dataframe containing individual-level metadata
 # - biospecimen_metadata: A dataframe containing specimen metadata
-join_to_metadata <- function(df, individual_metadata, biospecimen_metadata) {
+join_to_metadata <- function(results, individual_metadata, biospecimen_metadata) {
 
+  # Join metadata files by individualID
   individual_metadata <- subset(individual_metadata, select=c(individualID, sex, ageDeath, genotype))
   biospecimen_metadata <- subset(biospecimen_metadata, select=c(individualID, specimenID, tissue))
-
-  # Join biospecimen metadata to individual metadata
-  merged_metadata <- merge(individual_metadata, biospecimen_metadata, by = 'individualID')
+  metadata <- merge(individual_metadata, biospecimen_metadata, by = 'individualID')
 
   # Figure out what columns to merge by
-  join_by <- if(all(c('specimenID', 'individualID') %in% colnames(df)) &&
-              all(c('specimenID', 'individualID') %in% colnames(merged_metadata))) {
+  join_by <- if(all(c('specimenID', 'individualID') %in% colnames(results)) &&
+              all(c('specimenID', 'individualID') %in% colnames(metadata))) {
     c('specimenID', 'individualID')
   } else {
     c('specimenID')
   }
 
-  # Prevent creating duplicate data rows for 'Pool-X' specimenIDs by matching only first metadata row
-  df_out <- df %>% left_join(merged_metadata, by=join_by, multiple="first")
+  # Join results to metadata; prevent creating duplicate data rows for 'Pool-X' specimenIDs by matching only first metadata row
+  results %>% left_join(metadata, by=join_by, multiple="first"
 
-  # make sure we didn't change the number of data rows
-  stopifnot(nrow(df) == nrow(df_out))
+            # Print out nrow of results before age filtering
+            ) %>% { print(nrow(.)) ;.
 
-  df_out
+            # Filter out results for unwanted ages
+            } %>% filter(ageDeath %in% age_keeps
+
+            # Print out nrow of results after age filtering
+            ) %>% { print(nrow(.)) ;.
+
+            # Convert all individualID columns to string type
+            } %>% mutate(individualID = as.character(individualID)
+
+            # Rename columns
+            ) %>% rename(., c('individualID' = 'individual_id',
+                              'ageDeath' = 'age_death')
+
+            # Drop unneeded columns
+            ) %>% select(keeps
+
+            # Correct genotypes to align with target display values
+            ) %>% mutate(biomarkers_merged,
+                           genotype = case_when(
+
+                                   # 3xTG-AD genotypes
+                                   genotype == "3xTg-AD_homozygous"  ~ "3xTg-AD",
+                                   genotype == "3XTg-AD_noncarrier" ~ "B6129",
+
+                                   # 5xFAD genotypes
+                                   genotype %in% c("5XFAD_hemizygous","5XFAD_carrier") ~ "5xFAD",
+                                   genotype == "5XFAD_noncarrier"  ~ "C57BL/6J",
+
+                                   # NSS genotypes
+                                   genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
+                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS.5xFAD",
+
+                                   # Abca7 genotypes
+                                   genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
+                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "Abca7*V1559M.5xFAD",
+
+                                   TRUE ~ genotype))
 }
 ```
 
@@ -267,7 +305,7 @@ https://docs.google.com/spreadsheets/d/1B3ZMReC7nR2CGgpFNJuxJTj__lF2h6dt/edit?gi
 
 ### 3xTG-AD
 ```{r}
-threex_pathology <- threex_pathology_source %>%
+threex_final <- threex_pathology_source %>%
 
         # Filter out rows with unused 'Stain' values
         filter(stain %in% stain_keeps
@@ -276,7 +314,10 @@ threex_pathology <- threex_pathology_source %>%
         ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "3xTg-AD", keeps_with_pool_join_field
 
         # Drop rows with NA measurements
-        ) %>% filter(!is.na(measurement))
+        ) %>% filter(!is.na(measurement)
+
+        # Join results to metadata
+        ) %>% join_to_metadata(threex_individual, threex_biospecimen)
 ```
 
 
@@ -317,7 +358,7 @@ fivex_iba1_pivot <- transform_results(fivex_iba1, c('X.objects..sqmm'), model, k
 fivex_thios_pivot <- transform_results(fivex_thios, c('X.objects..sqmm', 'mean.object.area..squm.'), model, keeps_with_join_fields)
 
 # Merge all results into a single data frame
-fivex_pathology <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_iba1_pivot, fivex_thios_pivot
+fivex_final <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_iba1_pivot, fivex_thios_pivot
 
     # MG-12: drop rows with "N/A" specimenIDs
     ) %>% filter(
@@ -326,12 +367,14 @@ fivex_pathology <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_ib
     # MG-268: Replace N/A measurement values with 0s
     ) %>% mutate(
             measurement = ifelse(is.na(measurement), 0, measurement)
-)
+
+    # Join results to metadata
+    ) %>% join_to_metadata(fivex_individual, fivex_biospecimen)
 ```
 
 ### Trem2-R47H_NSS
 ```{r}
-nss_pathology <- nss_pathology_source %>%
+nss_final <- nss_pathology_source %>%
 
         # Filter out rows with unused 'Stain' values
         filter(stain %in% stain_keeps
@@ -340,12 +383,15 @@ nss_pathology <- nss_pathology_source %>%
         ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "Trem2-R47H_NSS", keeps_with_pool_join_field
 
         # Drop rows with NA measurements
-        ) %>% filter(!is.na(measurement))
+        ) %>% filter(!is.na(measurement)
+
+        # Join results to metadata
+        ) %>% join_to_metadata(nss_individual, nss_biospecimen)
 ```
 
 ### Abca7*V1599M
 ```{r}
-abca7_pathology <- abca7_pathology_source %>%
+abca7_final <- abca7_pathology_source %>%
 
         # Filter out rows with unused 'Stain' values
         filter(stain %in% stain_keeps
@@ -357,17 +403,18 @@ abca7_pathology <- abca7_pathology_source %>%
         ) %>% filter(!is.na(measurement)
 
         # Drop LAMP1 rows with measurements other than total object volume (cubic mm)
-        ) %>% filter(!(type == LAMP1_display_name & (units == objectDensity_display_name | units == averageObjectVolume_display_name)))
+        ) %>% filter(!(type == LAMP1_display_name & (units == objectDensity_display_name | units == averageObjectVolume_display_name))
+
+        # Join results to metadata
+        ) %>% join_to_metadata(abca7_individual, abca7_biospecimen)
 ```
 
 ## Sanity check generated files
 Checks that ensure that the processed data includes the expected number of results per model, per result type:
 1. Source data vs processed data: nrow(filtered_source_data) == nrow(processed_data)
 2. Source data vs expected rows: nrow(nrow(processed_data)) == nrow(legacy_explorer_data)
+   - Expected row values are calculated in the 'Immunohisto expected row counts' notebook
 
-Expected rows:
-* Values were determined by downloading data from the legacy explorer's Pathlogy interface, where available
-* Exported legacy data files are in syn68930581
 
 ```{r}
 # *******
@@ -375,68 +422,74 @@ Expected rows:
 # *******
 # IBA1
 threex_iba1 <- threex_pathology_source[threex_pathology_source$stain == 'IBA1',]
-stopifnot(nrow(threex_pathology[threex_pathology$type == IBA1_display_name,]) == nrow(threex_iba1))
+stopifnot(nrow(threex_final[threex_final$type == IBA1_display_name,]) == nrow(threex_iba1))
 stopifnot(nrow(threex_iba1) == 144) # IBA1 :  3xTg-AD + B6129  ==  144
 
 # GFAP
 threex_gfap <- threex_pathology_source[threex_pathology_source$stain == 'GFAP',]
-stopifnot(nrow(threex_pathology[threex_pathology$type == GFAP_display_name,]) == nrow(threex_gfap))
+stopifnot(nrow(threex_final[threex_final$type == GFAP_display_name,]) == nrow(threex_gfap))
 stopifnot(nrow(threex_gfap) == 144) #  GFAP :  3xTg-AD + B6129  ==  144
 
 # S100B
 threex_s100b <- threex_pathology_source[threex_pathology_source$stain == 'S100B',]
-stopifnot(nrow(threex_pathology[threex_pathology$type == S100B_display_name,]) == nrow(threex_s100b))
+stopifnot(nrow(threex_final[threex_final$type == S100B_display_name,]) == nrow(threex_s100b))
 stopifnot(nrow(threex_s100b) == 144) #  S100B :  3xTg-AD + B6129  ==  144
 
 # LAMP1
 threex_lamp1 <- threex_pathology_source[threex_pathology_source$stain == 'LAMP1',]
-stopifnot(nrow(threex_pathology[threex_pathology$type == LAMP1_display_name,]) == nrow(threex_lamp1))
+stopifnot(nrow(threex_final[threex_final$type == LAMP1_display_name,]) == nrow(threex_lamp1))
 stopifnot(nrow(threex_lamp1) == 142) # LAMP1 :  3xTg-AD + B6129  ==  142
 
 # AT8
 threex_at8 <- threex_pathology_source[threex_pathology_source$stain == 'AT8',]
-stopifnot(nrow(threex_pathology[threex_pathology$type == AT8_display_name,]) == nrow(threex_at8))
+stopifnot(nrow(threex_final[threex_final$type == AT8_display_name,]) == nrow(threex_at8))
 stopifnot(nrow(threex_at8) == 72) # AT8 :  3xTg-AD + B6129  ==  72
 
 # HT7
 threex_ht7 <- threex_pathology_source[threex_pathology_source$stain == 'HT7',]
-stopifnot(nrow(threex_pathology[threex_pathology$type == HT7_display_name,]) == nrow(threex_ht7))
+stopifnot(nrow(threex_final[threex_final$type == HT7_display_name,]) == nrow(threex_ht7))
 stopifnot(nrow(threex_ht7) == 72) # HT7 :  3xTg-AD + B6129  ==  72
 
 # ThioS size & density
 threex_thioss <- threex_pathology_source[threex_pathology_source$stain == 'ThioS',]
-stopifnot(nrow(threex_pathology[threex_pathology$type == ThioS_size_display_name,]) == nrow(threex_thioss))
-stopifnot(nrow(threex_pathology[threex_pathology$type == ThioS_density_display_name,]) == nrow(threex_thioss))
+stopifnot(nrow(threex_final[threex_final$type == ThioS_size_display_name,]) == nrow(threex_thioss))
+stopifnot(nrow(threex_final[threex_final$type == ThioS_density_display_name,]) == nrow(threex_thioss))
 stopifnot(nrow(threex_thioss) == 144) #  ThioS size :  3xTg-AD + B6129  ==  144
 
 # *****
 # 5xFAD
 # *****
 # IBA1
-fivex_ibas <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'Iba1',]
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == IBA1_display_name,]) == nrow(fivex_ibas))
+# Correct for 56 rows removed via age filtering
+fivex_ibas <- nrow(fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'Iba1',]) - 56
+stopifnot(nrow(fivex_final[fivex_final$type == IBA1_display_name,]) == fivex_ibas)
 stopifnot(nrow(fivex_ibas) == 280) # IBA1 :  5xFAD + C57BL/6J ==  280 rows expected
 
 # GFAP
-fivex_gfap <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain == 'GFAP',]
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == GFAP_display_name,]) == nrow(fivex_gfap))
+# Correct for 54 rows removed via age filtering
+fivex_gfap <- nrow(fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain == 'GFAP',]) - 54
+stopifnot(nrow(fivex_final[fivex_final$type == GFAP_display_name,]) == fivex_gfap)
 stopifnot(nrow(fivex_gfap) == 215) # GFAP :  5xFAD + C57BL/6J  ==  215 rows expected
 
 # S100B
-fivex_s100bs <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain == 'S100B',]
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == S100B_display_name,]) == nrow(fivex_s100bs))
+# Correct for 54 rows removed via age filtering
+fivex_s100bs <- nrow(fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain == 'S100B',]) -54
+stopifnot(nrow(fivex_final[fivex_final$type == S100B_display_name,]) == fivex_s100bs)
 stopifnot(nrow(fivex_s100bs) == 215) #  S100B :  5xFAD + C57BL/6J  ==  215  rows expected
 
 # LAMP1
-fivex_lamp1 <- fivex_lamp1_source[fivex_lamp1_source$Stain == 'LAMP1',]
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == LAMP1_display_name,]) == nrow(fivex_lamp1))
+# Correct for 56 rows removed via age filtering
+fivex_lamp1 <- nrow(fivex_lamp1_source[fivex_lamp1_source$Stain == 'LAMP1',]) - 56
+stopifnot(nrow(fivex_final[fivex_final$type == LAMP1_display_name,]) == fivex_lamp1)
 stopifnot(nrow(fivex_lamp1) == 264) # LAMP1 :  5xFAD + C57BL/6J  ==  264  rows expected
 
 # ThioS size & density
 fivex_thios <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'ThioS',]
 fivex_thios <-  filter(fivex_thios, SpecimenID != 'N/A') # Remove rows with specimenID == "N/A"
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == ThioS_size_display_name,]) == nrow(fivex_thios))
-stopifnot(nrow(fivex_pathology[fivex_pathology$type == ThioS_density_display_name,]) == nrow(fivex_thios))
+# Correct for 56 rows removed via age filtering
+fivex_thios <- nrow(fivex_thios) - 56
+stopifnot(nrow(fivex_final[fivex_final$type == ThioS_size_display_name,]) ==fivex_thios)
+stopifnot(nrow(fivex_final[fivex_final$type == ThioS_density_display_name,]) == fivex_thios)
 stopifnot(nrow(fivex_thios) == 278) #  ThioS (size == density):  5xFAD + C57BL/6J  ==  278 rows expected
 
 # **************
@@ -444,30 +497,30 @@ stopifnot(nrow(fivex_thios) == 278) #  ThioS (size == density):  5xFAD + C57BL/6
 # **************
 # IBA1
 nss_iba1 <- nss_pathology_source[nss_pathology_source$stain == 'IBA1',]
-stopifnot(nrow(nss_pathology[nss_pathology$type == IBA1_display_name,]) == nrow(nss_iba1))
+stopifnot(nrow(nss_final[nss_final$type == IBA1_display_name,]) == nrow(nss_iba1))
 # results not in legacy explorer
 
 # GFAP
 nss_gfap <- nss_pathology_source[nss_pathology_source$stain == 'GFAP',]
-stopifnot(nrow(nss_pathology[nss_pathology$type == GFAP_display_name,]) == nrow(nss_gfap))
+stopifnot(nrow(nss_final[nss_final$type == GFAP_display_name,]) == nrow(nss_gfap))
 # results not in legacy explorer
 
 # S100B
 nss_s100b <- nss_pathology_source[nss_pathology_source$stain == 'S100B',]
-stopifnot(nrow(nss_pathology[nss_pathology$type == S100B_display_name,]) == nrow(nss_s100b))
+stopifnot(nrow(nss_final[nss_final$type == S100B_display_name,]) == nrow(nss_s100b))
 # results not in legacy explorer
 
 # LAMP1
 nss_lamp1 <- nss_pathology_source[nss_pathology_source$stain == 'LAMP1',]
-stopifnot(nrow(nss_pathology[nss_pathology$type == LAMP1_display_name,]) == nrow(nss_lamp1))
+stopifnot(nrow(nss_final[nss_final$type == LAMP1_display_name,]) == nrow(nss_lamp1))
 # results not in legacy explorer
 
 # ThioS size & density
 nss_thios <- nss_pathology_source[nss_pathology_source$stain == 'ThioS',]
 nss_thioss <-  filter(nss_thios, !is.na(nss_thios$averageObjectVolume)) # Remove source rows with NA measurements
 nss_thiosd <-  filter(nss_thios, !is.na(nss_thios$objectDensity)) # Remove sourcerows with NA measurements
-stopifnot(nrow(nss_pathology[nss_pathology$type == ThioS_size_display_name,]) == nrow(nss_thioss))
-stopifnot(nrow(nss_pathology[nss_pathology$type == ThioS_density_display_name,]) == nrow(nss_thiosd))
+stopifnot(nrow(nss_final[nss_final$type == ThioS_size_display_name,]) == nrow(nss_thioss))
+stopifnot(nrow(nss_final[nss_final$type == ThioS_density_display_name,]) == nrow(nss_thiosd))
 # results not in legacy explorer
 
 # ************
@@ -475,98 +528,41 @@ stopifnot(nrow(nss_pathology[nss_pathology$type == ThioS_density_display_name,])
 # ************
 # IBA1
 abca7_iba1 <- abca7_pathology_source[abca7_pathology_source$stain == 'IBA1',]
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == IBA1_display_name,]) == nrow(abca7_iba1))
+stopifnot(nrow(abca7_final[abca7_final$type == IBA1_display_name,]) == nrow(abca7_iba1))
 # results not in legacy explorer
 
 # GFAP
 abca7_gfap <- abca7_pathology_source[abca7_pathology_source$stain == 'GFAP',]
 abca7_gfap <-  filter(abca7_gfap, abca7_gfap$objectDensity != 'N/A') # Remove source rows with 'N/A' measurements
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == GFAP_display_name,]) == nrow(abca7_gfap))
+stopifnot(nrow(abca7_final[abca7_final$type == GFAP_display_name,]) == nrow(abca7_gfap))
 # results not in legacy explorer
 
 # S100B
 abca7_s100b <- abca7_pathology_source[abca7_pathology_source$stain == 'S100B',]
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == S100B_display_name,]) == nrow(abca7_s100b))
+stopifnot(nrow(abca7_final[abca7_final$type == S100B_display_name,]) == nrow(abca7_s100b))
 # results not in legacy explorer
 
 # LAMP1
 abca7_lamp1 <- abca7_pathology_source[abca7_pathology_source$stain == 'LAMP1',]
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == LAMP1_display_name,]) == nrow(abca7_lamp1))
+stopifnot(nrow(abca7_final[abca7_final$type == LAMP1_display_name,]) == nrow(abca7_lamp1))
 # results not in legacy explorer
 
 # ThioS size & density
 abca7_thios <- abca7_pathology_source[abca7_pathology_source$stain == 'ThioS',]
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == ThioS_size_display_name,]) == nrow(abca7_thios))
-stopifnot(nrow(abca7_pathology[abca7_pathology$type == ThioS_density_display_name,]) == nrow(abca7_thios))
+stopifnot(nrow(abca7_final[abca7_final$type == ThioS_size_display_name,]) == nrow(abca7_thios))
+stopifnot(nrow(abca7_final[abca7_final$type == ThioS_density_display_name,]) == nrow(abca7_thios))
 # results not in legacy explorer
 ```
 
 
-
-## Join source files to metadata to populate age, tissue, and genotype values
+## Merge model-specific results files & write csv file to synapse
 ```{r}
-# 3xTG-AD
-threex_final <- join_to_metadata(threex_pathology, threex_individual, threex_biospecimen)[keeps]
+pathology_final <- bind_rows(
+  threex_final,
+  fivex_final,
+  nss_final,
+  abca7_final)
 
-# 5xFAD
-fivex_with_8mo <- join_to_metadata(fivex_pathology, fivex_individual, fivex_biospecimen)[keeps]
-# drop unwanted 8 month samples from 5xFAD
-fivex_final <- fivex_with_8mo[fivex_with_8mo$ageDeath != 8,]
-
-# Trem2-R47H_NSS
-nss_final <- join_to_metadata(nss_pathology, nss_individual, nss_biospecimen)[keeps]
-
-# Abca7*V1599M
-abca7_final <- join_to_metadata(abca7_pathology, abca7_individual, abca7_biospecimen)[keeps]
-```
-
-
-## Merge files
-```{r}
-pathology_merged <- bind_rows(
-  threex_final %>% mutate(individualID = as.character(individualID)),
-  fivex_final %>% mutate(individualID = as.character(individualID)),
-  nss_final %>% mutate(individualID = as.character(individualID)),
-  abca7_final %>% mutate(individualID = as.character(individualID))
-) %>%
-  dplyr::rename(
-    specimen_id = specimenID,
-    individual_id = individualID,
-    age_death = ageDeath
-  )
-
-# standardize genotype values for display
-pathology_final <- mutate(pathology_merged, genotype = case_when(
-
-        # 3xTG-AD genotypes
-        genotype == "3xTg-AD_homozygous"  ~ "3xTG-AD",
-        genotype == "3XTg-AD_noncarrier" ~ "B6129",
-
-        # 5xFAD genotypes
-        genotype %in% c("5XFAD_hemizygous","5XFAD_carrier") ~ "5xFAD",
-        genotype == "5XFAD_noncarrier"  ~ "C57BL/6J",
-
-        # NSS genotypes
-        genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
-        genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "5xFADTrem2-R47H_NSS",
-
-        # Abca7 genotypes
-        genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
-        genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "5xFADAbca7*V1599M",
-
-        TRUE ~ genotype))
-
-#Correct typos in source model and genotype values
-pathology_final$model <- gsub("3xTG-AD", "3xTg-AD", pathology_final$model)
-pathology_final$genotype <- gsub("3xTG-AD", "3xTg-AD", pathology_final$genotype)
-
-# print final data frame below
-pathology_final
-```
-
-
-## Write csv file and upload to synapse
-```{r}
 # MODEL-AD 2.0 harmonized source file directory
 # ADP Backend > Files > 2.ConsortiumStudies > MODEL-AD Data Explorer > Model AD Explorer 2.0 Source Files
 synapse_folder <- 'syn51498054'

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -195,10 +195,10 @@ transform_results <- function(results, measurement_columns, model_name, fields_t
 
 
 # Join a data file to a pair of metadata files to get required age, sex, ageDeath, and genotype values
+# - df: A dataframe containing result rows
 # - individual_metadata: A dataframe containing individual-level metadata
 # - biospecimen_metadata: A dataframe containing specimen metadata
-# - df: A dataframe containing result rows
-join_to_metadata <- function(individual_metadata, biospecimen_metadata, df) {
+join_to_metadata <- function(df, individual_metadata, biospecimen_metadata) {
 
   individual_metadata <- subset(individual_metadata, select=c(individualID, sex, ageDeath, genotype))
   biospecimen_metadata <- subset(biospecimen_metadata, select=c(individualID, specimenID, tissue))
@@ -506,18 +506,18 @@ stopifnot(nrow(abca7_pathology[abca7_pathology$type == ThioS_density_display_nam
 ## Join source files to metadata to populate age, tissue, and genotype values
 ```{r}
 # 3xTG-AD
-threex_final <- join_to_metadata(threex_individual, threex_biospecimen, threex_pathology)[keeps]
+threex_final <- join_to_metadata(threex_pathology, threex_individual, threex_biospecimen)[keeps]
 
 # 5xFAD
-fivex_with_8mo <- join_to_metadata(fivex_individual, fivex_biospecimen, fivex_pathology)[keeps]
+fivex_with_8mo <- join_to_metadata(fivex_pathology, fivex_individual, fivex_biospecimen)[keeps]
 # drop unwanted 8 month samples from 5xFAD
 fivex_final <- fivex_with_8mo[fivex_with_8mo$ageDeath != 8,]
 
 # Trem2-R47H_NSS
-nss_final <- join_to_metadata(nss_individual, nss_biospecimen, nss_pathology)[keeps]
+nss_final <- join_to_metadata(nss_pathology, nss_individual, nss_biospecimen)[keeps]
 
 # Abca7*V1599M
-abca7_final <- join_to_metadata(abca7_individual, abca7_biospecimen, abca7_pathology)[keeps]
+abca7_final <- join_to_metadata(abca7_pathology, abca7_individual, abca7_biospecimen)[keeps]
 ```
 
 

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -101,15 +101,15 @@ objectDensity_display_name <- '# objects / square mm'
 averageObjectVolume_display_name <- 'mean object volume (cubic mm)'
 totalObjectVolume_display_name <- 'total object volume (cubic mm)'
 meanObjectArea_display_name <- 'mean object area (square mm)'
-areaPercent_display_name <- 'area %'
+areaPercent_display_name <- '%'
 
-# Vector to store all downloaded synIds for Synapse provenance (populated via download_file function)
+# Vector to store all downloaded synIds for Synapse provenance (populated via download_csv function)
 data_sources <- character()
 
-# Download a file from Synapse by synId and read it into a dataframe
+# Download a csv file from Synapse by synId and read it into a dataframe
 # - synId: synapse ID of the file to download
 # - df_name: the name to use for the resulting dataframe
-download_file <- function(synId, df_name) {
+download_csv <- function(synId, df_name) {
 
   synLogin()
 
@@ -226,38 +226,38 @@ join_to_metadata <- function(individual_metadata, biospecimen_metadata, df) {
 
 
 ## Download data and metadata files from Synapse
-Note that each file's synId and version is added to the data_sources vector via the download_file function.
+Note that each file's synId and version is added to the data_sources vector via the download_csv function.
 The populated data_sources vector is used to populate Synapse provenance when the harmonized csv is uploaded.
 ```{r}
 # 3xTG-AD
 # metadata
-threex_biospecimen <- download_file('syn23532198.3')
-threex_individual <- download_file('syn23532199.4')
+threex_biospecimen <- download_csv('syn23532198.3')
+threex_individual <- download_csv('syn23532199.4')
 # data
-threex_pathology_source <- download_file('syn26601504.1')
+threex_pathology_source <- download_csv('syn26601504.1')
 
 # 5xFAD
 # metadata
-fivex_biospecimen <- download_file('syn18876530.10')
-fivex_individual <- download_file('syn18880070.14')
+fivex_biospecimen <- download_csv('syn18876530.10')
+fivex_individual <- download_csv('syn18880070.14')
 # data
-fivex_gfap_s100b_source <- download_file('syn22049816.3')
-fivex_lamp1_source <- download_file('syn22049817.2')
-fivex_iba1_thios_source <- download_file('syn22049825.4')
+fivex_gfap_s100b_source <- download_csv('syn22049816.3')
+fivex_lamp1_source <- download_csv('syn22049817.2')
+fivex_iba1_thios_source <- download_csv('syn22049825.4')
 
 #NSS
 # metadata
-nss_biospecimen <- download_file('syn29568452.3')
-nss_individual <- download_file('syn27147690.3')
+nss_biospecimen <- download_csv('syn29568452.3')
+nss_individual <- download_csv('syn27147690.3')
 # data
-nss_pathology_source <- download_file('syn42131930.1')
+nss_pathology_source <- download_csv('syn42131930.1')
 
 #Abca7
 # metadata
-abca7_biospecimen <- download_file('syn30859390.2')
-abca7_individual <- download_file('syn30859394.2')
+abca7_biospecimen <- download_csv('syn30859390.2')
+abca7_individual <- download_csv('syn30859394.2')
 # data
-abca7_pathology_source <- download_file('syn53127289.1')
+abca7_pathology_source <- download_csv('syn53127289.1')
 ```
 
 

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -74,6 +74,10 @@ library(tidyverse)
 ## Utility functions & variables
 Run this to initialize shared variables and functions.
 ```{r}
+# *******
+# FILTERS
+# *******
+
 # Measures (stain values) that we want to include
 stain_keeps <- c("GFAP", "S100B", "LAMP1", "IBA1", "ThioS", "HT7", "AT8")
 
@@ -88,6 +92,24 @@ keeps_with_join_fields <- c('individualID', 'specimenID', 'model', 'type', 'meas
 
 # column spec for final harmonized output file
 keeps <- c('individual_id', 'model', 'type', 'measurement', 'units', 'age_death', 'tissue', 'sex', 'genotype')
+
+# **************
+# DISPLAY LABELS
+# **************
+
+# Model and genotype display names (rnaseq_genotype_label_map.csv)
+threex_display_name <- '3xTg-AD'
+threex_control_display_name <- 'B6129'
+fivex_display_name <- '5xFAD (UCI)'
+fivex_control_display_name <- "C57BL/6J"
+abca7_display_name <- 'Abca7*V1599M'
+abca7_control_display_name <- "C57BL/6J"
+abca7fivex_display_name <- "Abca7*V1599M.5xFAD"
+abca7fivex_control_display_name <- '5xFAD'
+nss_display_name <- 'Trem2-R47H_NSS'
+nss_control_display_name <- "C57BL/6J"
+nssfivex_display_name <- "Trem2-R47H_NSS.5xFAD"
+nssfivex_control_display_name <- '5xFAD'
 
 # Pathology display names
 IBA1_display_name <- 'Microglia Cell Density (IBA1)'
@@ -105,6 +127,10 @@ averageObjectVolume_display_name <- 'mean object volume (cubic mm)'
 totalObjectVolume_display_name <- 'total object volume (cubic mm)'
 meanObjectArea_display_name <- 'mean object area (square mm)'
 areaPercent_display_name <- 'area %'
+
+# *********
+# FUNCTIONS
+# *********
 
 # Vector to store all downloaded synIds for Synapse provenance (populated via download_csv function)
 data_sources <- character()
@@ -201,6 +227,7 @@ transform_results <- function(results, measurement_columns, model_name, fields_t
 # - df: A dataframe containing result rows
 # - individual_metadata: A dataframe containing individual-level metadata
 # - biospecimen_metadata: A dataframe containing specimen metadata
+# This function prints out the number of rows before and after filtering results by age, which is useful for validation.
 join_to_metadata <- function(results, individual_metadata, biospecimen_metadata) {
 
   # Join metadata files by individualID
@@ -243,20 +270,20 @@ join_to_metadata <- function(results, individual_metadata, biospecimen_metadata)
                            genotype = case_when(
 
                                    # 3xTG-AD genotypes
-                                   genotype == "3xTg-AD_homozygous"  ~ "3xTg-AD",
-                                   genotype == "3XTg-AD_noncarrier" ~ "B6129",
+                                   genotype == "3xTg-AD_homozygous"  ~ threex_display_name,
+                                   genotype == "3XTg-AD_noncarrier" ~ threex_control_display_name,
 
                                    # 5xFAD genotypes
-                                   genotype %in% c("5XFAD_hemizygous","5XFAD_carrier") ~ "5xFAD",
-                                   genotype == "5XFAD_noncarrier"  ~ "C57BL/6J",
+                                   genotype %in% c("5XFAD_hemizygous","5XFAD_carrier") ~ fivex_display_name,
+                                   genotype == "5XFAD_noncarrier"  ~ fivex_control_display_name,
 
                                    # NSS genotypes
-                                   genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
-                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS.5xFAD",
+                                   genotype == "Trem2-R47H_NSS_homozygous"  ~ nss_display_name,
+                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ nssfivex_display_name,
 
                                    # Abca7 genotypes
-                                   genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
-                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "Abca7*V1559M.5xFAD",
+                                   genotype == "Abca7-V1599M_homozygous"  ~ abca7_display_name,
+                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ abca7fivex_display_name,
 
                                    TRUE ~ genotype))
 }
@@ -299,7 +326,7 @@ abca7_pathology_source <- download_csv('syn53127289.1')
 ```
 
 
-## Generate model-specific intermediate files
+## Generate model-specific files & join to metadata
 File-measurement-unit and display value mappings for legacy models are from the v1 data spreadsheet here:
 https://docs.google.com/spreadsheets/d/1B3ZMReC7nR2CGgpFNJuxJTj__lF2h6dt/edit?gid=1108411940#gid=1108411940
 
@@ -311,7 +338,7 @@ threex_final <- threex_pathology_source %>%
         filter(stain %in% stain_keeps
 
         # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-        ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "3xTg-AD", keeps_with_pool_join_field
+        ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), threex_display_name, keeps_with_pool_join_field
 
         # Drop rows with NA measurements
         ) %>% filter(!is.na(measurement)
@@ -351,11 +378,10 @@ fivex_thios <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'ThioS',
   fivex_rename_cols()
 
 # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-model = "5xFAD (UCI)"
-fivex_gfap_s100b_pivot <- transform_results(fivex_gfap_s100b, c('X.objects..sqmm'), model, keeps_with_join_fields)
-fivex_lamp1_pivot <- transform_results(fivex_lamp1, c('Area..'), model, keeps_with_join_fields)
-fivex_iba1_pivot <- transform_results(fivex_iba1, c('X.objects..sqmm'), model, keeps_with_join_fields)
-fivex_thios_pivot <- transform_results(fivex_thios, c('X.objects..sqmm', 'mean.object.area..squm.'), model, keeps_with_join_fields)
+fivex_gfap_s100b_pivot <- transform_results(fivex_gfap_s100b, c('X.objects..sqmm'), fivex_display_name, keeps_with_join_fields)
+fivex_lamp1_pivot <- transform_results(fivex_lamp1, c('Area..'), fivex_display_name, keeps_with_join_fields)
+fivex_iba1_pivot <- transform_results(fivex_iba1, c('X.objects..sqmm'), fivex_display_name, keeps_with_join_fields)
+fivex_thios_pivot <- transform_results(fivex_thios, c('X.objects..sqmm', 'mean.object.area..squm.'), fivex_display_name, keeps_with_join_fields)
 
 # Merge all results into a single data frame
 fivex_final <- bind_rows(fivex_gfap_s100b_pivot, fivex_lamp1_pivot, fivex_iba1_pivot, fivex_thios_pivot
@@ -380,7 +406,7 @@ nss_final <- nss_pathology_source %>%
         filter(stain %in% stain_keeps
 
         # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-        ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "Trem2-R47H_NSS", keeps_with_pool_join_field
+        ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), nss_display_name, keeps_with_pool_join_field
 
         # Drop rows with NA measurements
         ) %>% filter(!is.na(measurement)
@@ -397,7 +423,7 @@ abca7_final <- abca7_pathology_source %>%
         filter(stain %in% stain_keeps
 
         # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-        ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), "Abca7*V1599M", keeps_with_pool_join_field
+        ) %>% transform_results(c('objectDensity', 'averageObjectVolume', 'totalObjectVolume'), abca7_display_name, keeps_with_pool_join_field
 
         # Drop rows with NA measurements
         ) %>% filter(!is.na(measurement)
@@ -517,8 +543,9 @@ stopifnot(nrow(nss_final[nss_final$type == LAMP1_display_name,]) == nrow(nss_lam
 
 # ThioS size & density
 nss_thios <- nss_pathology_source[nss_pathology_source$stain == 'ThioS',]
-nss_thioss <-  filter(nss_thios, !is.na(nss_thios$averageObjectVolume)) # Remove source rows with NA measurements
-nss_thiosd <-  filter(nss_thios, !is.na(nss_thios$objectDensity)) # Remove sourcerows with NA measurements
+# Remove source rows with NA measurements
+nss_thioss <-  filter(nss_thios, !is.na(nss_thios$averageObjectVolume))
+nss_thiosd <-  filter(nss_thios, !is.na(nss_thios$objectDensity))
 stopifnot(nrow(nss_final[nss_final$type == ThioS_size_display_name,]) == nrow(nss_thioss))
 stopifnot(nrow(nss_final[nss_final$type == ThioS_density_display_name,]) == nrow(nss_thiosd))
 # results not in legacy explorer
@@ -573,7 +600,7 @@ if(!dir.exists(output_dir)){
   dir.create(output_dir)
 }
 write.csv(pathology_final, file.path(output_dir, "pathology.csv"), row.names = FALSE)
-
+```
 # upload to synapse
 syn_file <- File(file.path(output_dir, "pathology.csv"),
                  description = "Harmonized Pathology data for Model-AD Explorer 2.0.",

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -600,7 +600,7 @@ if(!dir.exists(output_dir)){
   dir.create(output_dir)
 }
 write.csv(pathology_final, file.path(output_dir, "pathology.csv"), row.names = FALSE)
-```
+
 # upload to synapse
 syn_file <- File(file.path(output_dir, "pathology.csv"),
                  description = "Harmonized Pathology data for Model-AD Explorer 2.0.",

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -67,12 +67,17 @@ library(tidyverse)
 
 ## Utility functions & variables
 ```{r}
-# Harmonized column spec for intermediate per-model files
+# column spec for intermediate per-model result files
 intermediate_keeps <- c('specimenID', 'individualID', 'model', 'type', 'measurement', 'units')
+
+# column specs for final harmonized output file
+keeps <- c('individual_id', 'model', 'type', 'measurement', 'units', 'age_death', 'tissue', 'sex', 'genotype')
+
+# ages that we want to display results for
+age_keeps <- c(4, 12, 18)
 
 # Vector to store all downloaded synIds for Synapse provenance (populated via download_csv function)
 data_sources <- character()
-
 
 # Download a csv file from Synapse by synId and read it into a dataframe
 # - synId: synapse ID of the file to download
@@ -137,15 +142,56 @@ results %>% pivot_longer(
 # - df: A dataframe containing result rows
 # - individual_metadata: A dataframe containing individual-level metadata
 # - biospecimen_metadata: A dataframe containing specimen metadata
-join_to_metadata <- function(df, individual_metadata, biospecimen_metadata) {
+join_to_metadata <- function(results, individual_metadata, biospecimen_metadata) {
 
+  # Join metadata files by individualID
   individual_metadata <- subset(individual_metadata, select=c(individualID, sex, ageDeath, genotype))
   biospecimen_metadata <- subset(biospecimen_metadata, select=c(individualID, specimenID, tissue))
   metadata <- merge(individual_metadata, biospecimen_metadata, by = 'individualID')
 
-  df_out <- merge(df, metadata)
+  # Join results to metadata
+  results %>% left_join(metadata, by = c('individualID', 'specimenID')
 
-  df_out
+            # Print out nrow of results before age filtering
+            ) %>% { print(nrow(.)) ;.
+
+            # Filter out results for unwanted ages
+            } %>% filter(ageDeath %in% age_keeps
+
+            # Print out nrow of results after age filtering
+            ) %>% { print(nrow(.)) ;.
+
+            # Convert all individualID columns to string type
+            } %>% mutate(individualID = as.character(individualID)
+
+            # Rename columns
+            ) %>% rename(., c('individualID' = 'individual_id',
+                              'ageDeath' = 'age_death')
+
+            # Drop unneeded columns
+            ) %>% select(keeps
+
+            # Correct genotypes to align with target display values
+            ) %>% mutate(biomarkers_merged,
+                           genotype = case_when(
+
+                                   # 3xTG-AD genotypes
+                                   genotype == "3xTg-AD_homozygous"  ~ "3xTg-AD",
+                                   genotype == "3XTg-AD_noncarrier" ~ "B6129",
+
+                                   # 5xFAD genotypes
+                                   genotype %in% c("5XFAD_hemizygous","5XFAD_carrier") ~ "5xFAD",
+                                   genotype == "5XFAD_noncarrier"  ~ "C57BL/6J",
+
+                                   # NSS genotypes
+                                   genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
+                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS.5xFAD",
+
+                                   # Abca7 genotypes
+                                   genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
+                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "Abca7*V1559M.5xFAD",
+
+                                   TRUE ~ genotype))
 }
 ```
 
@@ -210,10 +256,14 @@ threex_abs_sol <- threex_abs_sol_source %>% mutate(fraction_type = 'Soluble')
 threex_abs_insol <- threex_abs_insol_source %>% mutate(fraction_type = 'Insoluble')
 threex_abs_merged <- bind_rows(threex_abs_sol, threex_abs_insol)
 
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
 threex_abs <- transform_results(threex_abs_merged, c("Abeta40", "Abeta42"), '3xTg-AD', intermediate_keeps)
 
 # No NfL measures for this model
 threex_biomarkers <- threex_abs
+
+# Join results to metadata
+threex_final <- join_to_metadata(threex_biomarkers, threex_individual, threex_biospecimen)
 ```
 
 ### 5xFAD
@@ -222,13 +272,24 @@ threex_biomarkers <- threex_abs
 # Capture fraction types from file names in temp 'fraction_type' column and merge resulting dfs
 fivex_abs_sol <- fivex_abs_sol_source %>% mutate(fraction_type = 'Soluble')
 fivex_abs_insol <- fivex_abs_insol_source %>% mutate(fraction_type = 'Insoluble')
-fivex_abs_merged <- bind_rows(fivex_abs_sol, fivex_abs_insol)
+fivex_abs_merged <- bind_rows(fivex_abs_sol, fivex_abs_insol
 
+    # MG-268: Replace N/A measurement values with 0s
+    ) %>% mutate(
+            Abeta40 = ifelse(is.na(Abeta40), 0, Abeta40),
+            Abeta42 = ifelse(is.na(Abeta42), 0, Abeta42)
+)
+
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
 fivex_abs <- transform_results(fivex_abs_merged, c("Abeta40", "Abeta42"), '5xFAD (UCI)', intermediate_keeps)
 
 # No NfL measures for this model
 fivex_biomarkers <- fivex_abs
+
+# Join results to metadata
+fivex_final <- join_to_metadata(fivex_biomarkers, fivex_individual, fivex_biospecimen)
 ```
+
 
 ### Trem2-R47H_NSS
 ```{r}
@@ -245,16 +306,21 @@ nss_abs_insol_4mo <- nss_abs_insol_4mo_source %>% mutate(fraction_type = 'Insolu
 nss_abs_insol_12mo <- nss_abs_insol_12mo_source %>% mutate(fraction_type = 'Insoluble')
 nss_abs_merged <- bind_rows(nss_abs_sol_4mo, nss_abs_sol_12mo, nss_abs_insol_4mo, nss_abs_insol_12mo)
 
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
 nss_abs <- transform_results(nss_abs_merged, c("Abeta40", "Abeta42"), 'Trem2-R47H_NSS', intermediate_keeps)
 
 # NfL measures
 # Merge source dfs
 nss_nfl_merged <- bind_rows(nss_nfl_cortex_source, nss_nfl_plasma_source)
 
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
 nss_nfl <- transform_results(nss_nfl_merged, c("NfL"), 'Trem2-R47H_NSS', intermediate_keeps)
 
 # Merge Abetas and NfL
 nss_biomarkers <- bind_rows(nss_abs, nss_nfl)
+
+# Join results to metadata
+nss_final <- join_to_metadata(nss_biomarkers, nss_individual, nss_biospecimen)
 ```
 
 ### Abca7*V1599M
@@ -279,114 +345,63 @@ abca7_nfl <- transform_results(abca7_nfl_merged, c("NfL"), 'Abca7*V1599M', inter
 
 # Merge Abeta and NfL measures
 abca7_biomarkers <- bind_rows(abca7_abs, abca7_nfl)
+
+# Join results to metadata
+abca7_final <- join_to_metadata(abca7_biomarkers, abca7_individual, abca7_biospecimen)
 ```
 
-## Join source files to metadata to populate age, tissue, and genotype values
-```{r}
-keeps <- c('individualID', 'specimenID', 'model', 'type', 'measurement', 'units', 'ageDeath', 'tissue', 'sex', 'genotype')
+## Sanity check generated files
+Checks that ensure that the processed data includes the expected number of results per model, per result type:
+1. Source data vs processed data: nrow(filtered_source_data) == nrow(processed_data)
+2. Source data vs expected rows: nrow(nrow(processed_data)) == nrow(legacy_explorer_data)
+   - Expected row values are calculated in the 'Immunohisto expected row counts' notebook
 
-# 3xTG-AD
-threex_final <- join_to_metadata(threex_biomarkers, threex_individual, threex_biospecimen)[keeps]
-
-# 5xFAD
-fivex_with_8mo <- join_to_metadata(fivex_biomarkers, fivex_individual, fivex_biospecimen)[keeps]
-# drop unwanted 8 month samples from 5xFAD
-fivex_final <- fivex_with_8mo[fivex_with_8mo$ageDeath != 8,]
-
-# Trem2-R47H_NSS
-nss_final <- join_to_metadata(nss_biomarkers, nss_individual, nss_biospecimen)[keeps]
-
-# Abca7*V1599M
-abca7_final <- join_to_metadata(abca7_biomarkers, abca7_individual, abca7_biospecimen)[keeps]
-```
-
-## Sanity check nrow in generated files
 ```{r}
 # 3xTG-AD
-# before dropping NA values
-stopifnot(nrow(threex_abs_sol) + nrow(threex_abs_insol) == nrow(threex_abs_merged))
-stopifnot(nrow(threex_abs_merged) * 2 == nrow(threex_abs_pivot))
-# after dropping NA values
-stopifnot(nrow(threex_abs) == nrow(threex_biomarkers))
-stopifnot(nrow(threex_biomarkers) == nrow(threex_final))
+# Correct for NA values in source data
+threex_expected <- nrow(threex_abs_merged[!is.na(threex_abs_merged$Abeta40),]) + nrow(threex_abs_merged[!is.na(threex_abs_merged$Abeta42),])
+# Check corrected source data vs processed data
+stopifnot(threex_expected == nrow(threex_final))
+# Source data vs Expected rows
+stopifnot(nrow(threex_final) == 439) # 3xTg-AD + B6129: 439
 
 # 5xFAD
-# before dropping NA values
-stopifnot(nrow(fivex_abs_sol) + nrow(fivex_abs_insol) == nrow(fivex_abs_merged))
-stopifnot(nrow(fivex_abs_merged) * 2 == nrow(fivex_abs_with_nas))
-# after dropping NA values
-stopifnot(nrow(fivex_abs) == nrow(fivex_biomarkers))
-# correct for rows lost due to MG-12 (missing biospecimen metadata) and 8mo age filtering
-stopifnot(nrow(fivex_biomarkers) == nrow(fivex_final) + 4 + nrow(fivex_with_8mo[fivex_with_8mo$ageDeath == 8,]))
+# Correct for 104 rows removed via age filtering (from join_to_metadata print statement)
+fivex_expected <- nrow(fivex_abs_merged) * 2 - 104
+# Check corrected source data vs processed data
+stopifnot(fivex_expected == nrow(fivex_final))
+# Source data vs Expected rows
+stopifnot(nrow(fivex_final) == 288) # 5xFAD + C57BL/6J (w/o 8mo): 288
 
 # Trem2-R47H_NSS
-# before dropping NA values
-stopifnot(nrow(nss_abs_sol_4mo) + nrow(nss_abs_sol_12mo) + nrow(nss_abs_insol_4mo) + nrow(nss_abs_insol_12mo) == nrow(nss_abs_merged))
-stopifnot(nrow(nss_abs_merged) * 2 == nrow(nss_abs_with_nas))
-stopifnot(nrow(nss_nfl_cortex_source) + nrow(nss_nfl_plasma_source) == nrow(nss_nfl_with_nas))
-stopifnot(nrow(nss_nfl_cortex_source) + nrow(nss_nfl_plasma_source) == nrow(nss_nfl_with_nas))
-# after dropping NA values
-stopifnot(nrow(nss_nfl) + nrow(nss_abs) == nrow(nss_biomarkers))
-stopifnot(nrow(nss_biomarkers) == nrow(nss_final))
+# Correct for NA values in source data
+nss_expected_abs <- nrow(nss_abs_merged[!is.na(nss_abs_merged$Abeta40),]) + nrow(nss_abs_merged[!is.na(nss_abs_merged$Abeta42),])
+nss_expected_nfl <- nrow(nss_nfl_merged[!is.na(nss_nfl_merged$NfL),])
+# Check corrected source data vs processed data
+stopifnot(nss_expected_abs + nss_expected_nfl == nrow(nss_final))
+# Source data vs Expected rows
+stopifnot(nrow(nss_final) == 493) # 5xFADTrem2-R47H_NSS + 5xFAD + Trem2-R47H_NSS + C57BL/6J: 493
 
 # Abca7*V1599M
-# before dropping NA values
-stopifnot(nrow(abca7_abs_sol_4mo) + nrow(abca7_abs_sol_12mo) + nrow(abca7_abs_insol_4mo) + nrow(abca7_abs_insol_12mo) == nrow(abca7_abs_merged))
-stopifnot(nrow(abca7_abs_merged) * 2 == nrow(abca7_abs_with_nas))
-stopifnot(nrow(abca7_nfl_cortex_source) + nrow(abca7_nfl_plasma_source) == nrow(abca7_nfl_with_nas))
-# after dropping NA values
-stopifnot(nrow(abca7_nfl) + nrow(abca7_abs) == nrow(abca7_biomarkers))
-stopifnot(nrow(abca7_biomarkers) == nrow(abca7_final))
+# Correct for NA values in source data
+abca7_expected_abs <- nrow(abca7_abs_merged[!is.na(abca7_abs_merged$Abeta40),]) + nrow(abca7_abs_merged[!is.na(abca7_abs_merged$Abeta42),])
+abca7_expected_nfl <- nrow(abca7_nfl_merged)
+# Check corrected source data vs processed data
+stopifnot(abca7_expected_abs + abca7_expected_nfl == nrow(abca7_final))
+# Source data vs Expected rows
+stopifnot(nrow(abca7_final) == 543) # 5xFADAbca7*V1599M + 5xFAD + Abca7*V1599M + C57BL/6J: 543
 ```
 
-## Merge files and make final adjustments to colnames and values
+## Merge model-specific results files & write csv file and upload to synapse
 ```{r}
 # Merge results for all models
-biomarkers_merged <- bind_rows(
-      threex_final %>% mutate(individualID = as.character(individualID)),
-      fivex_final %>% mutate(individualID = as.character(individualID)),
-      nss_final %>% mutate(individualID = as.character(individualID)),
-      abca7_final %>% mutate(individualID = as.character(individualID))
+biomarkers_final <- bind_rows(
+      threex_final,
+      fivex_final,
+      nss_final,
+      abca7_final
+)
 
-  # Rename columns
-  ) %>% dplyr::rename(
-    individual_id = individualID,
-    specimen_id = specimenID,
-    age_death = ageDeath
-  )
-
-
-# Standardize genotype values for display
-biomarkers_final <- mutate(biomarkers_merged,
-                           genotype = case_when(
-
-                                   # 3xTG-AD genotypes
-                                   genotype == "3xTg-AD_homozygous"  ~ "3xTg-AD",
-                                   genotype == "3XTg-AD_noncarrier" ~ "B6129",
-
-                                   # 5xFAD genotypes
-                                   genotype %in% c("5XFAD_hemizygous","5XFAD_carrier") ~ "5xFAD",
-                                   genotype == "5XFAD_noncarrier"  ~ "C57BL/6J",
-
-                                   # NSS genotypes
-                                   genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
-                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS.5xFAD",
-
-                                   # Abca7 genotypes
-                                   genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
-                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "Abca7*V1559M.5xFAD",
-
-                                   TRUE ~ genotype))
-
-
-# print final data frame below
-biomarkers_final
-
-```
-
-
-## Write csv file and upload to synapse
-```{r}
 # write csv file
 output_dir <- file.path("./", "output")
 if(!dir.exists(output_dir)){

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -67,6 +67,10 @@ library(tidyverse)
 
 ## Utility functions & variables
 ```{r}
+# *******
+# FILTERS
+# *******
+
 # column spec for intermediate per-model result files
 intermediate_keeps <- c('specimenID', 'individualID', 'model', 'type', 'measurement', 'units')
 
@@ -75,6 +79,28 @@ keeps <- c('individual_id', 'model', 'type', 'measurement', 'units', 'age_death'
 
 # ages that we want to display results for
 age_keeps <- c(4, 12, 18)
+
+# **************
+# DISPLAY LABELS
+# **************
+
+# Model and genotype display names (rnaseq_genotype_label_map.csv)
+threex_display_name <- '3xTg-AD'
+threex_control_display_name <- 'B6129'
+fivex_display_name <- '5xFAD (UCI)'
+fivex_control_display_name <- "C57BL/6J"
+abca7_display_name <- 'Abca7*V1599M'
+abca7_control_display_name <- "C57BL/6J"
+abca7fivex_display_name <- "Abca7*V1599M.5xFAD"
+abca7fivex_control_display_name <- '5xFAD'
+nss_display_name <- 'Trem2-R47H_NSS'
+nss_control_display_name <- "C57BL/6J"
+nssfivex_display_name <- "Trem2-R47H_NSS.5xFAD"
+nssfivex_control_display_name <- '5xFAD'
+
+# *********
+# FUNCTIONS
+# *********
 
 # Vector to store all downloaded synIds for Synapse provenance (populated via download_csv function)
 data_sources <- character()
@@ -175,21 +201,21 @@ join_to_metadata <- function(results, individual_metadata, biospecimen_metadata)
             ) %>% mutate(biomarkers_merged,
                            genotype = case_when(
 
-                                   # 3xTG-AD genotypes
-                                   genotype == "3xTg-AD_homozygous"  ~ "3xTg-AD",
-                                   genotype == "3XTg-AD_noncarrier" ~ "B6129",
+                                   # 3xTg-AD genotypes
+                                   genotype == "3xTg-AD_homozygous"  ~ threex_display_name,
+                                   genotype == "3XTg-AD_noncarrier" ~ threex_control_display_name,
 
                                    # 5xFAD genotypes
-                                   genotype %in% c("5XFAD_hemizygous","5XFAD_carrier") ~ "5xFAD",
-                                   genotype == "5XFAD_noncarrier"  ~ "C57BL/6J",
+                                   genotype %in% c("5XFAD_hemizygous","5XFAD_carrier") ~ fivex_display_name,
+                                   genotype == "5XFAD_noncarrier"  ~ fivex_control_display_name,
 
                                    # NSS genotypes
-                                   genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
-                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS.5xFAD",
+                                   genotype == "Trem2-R47H_NSS_homozygous"  ~ nss_display_name,
+                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ nssfivex_control_display_name,
 
                                    # Abca7 genotypes
-                                   genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
-                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "Abca7*V1559M.5xFAD",
+                                   genotype == "Abca7-V1599M_homozygous"  ~ abca7_display_name,
+                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ abca7fivex_display_name,
 
                                    TRUE ~ genotype))
 }
@@ -257,7 +283,7 @@ threex_abs_insol <- threex_abs_insol_source %>% mutate(fraction_type = 'Insolubl
 threex_abs_merged <- bind_rows(threex_abs_sol, threex_abs_insol)
 
 # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-threex_abs <- transform_results(threex_abs_merged, c("Abeta40", "Abeta42"), '3xTg-AD', intermediate_keeps)
+threex_abs <- transform_results(threex_abs_merged, c("Abeta40", "Abeta42"), threex_display_name, intermediate_keeps)
 
 # No NfL measures for this model
 threex_biomarkers <- threex_abs
@@ -281,7 +307,7 @@ fivex_abs_merged <- bind_rows(fivex_abs_sol, fivex_abs_insol
 )
 
 # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-fivex_abs <- transform_results(fivex_abs_merged, c("Abeta40", "Abeta42"), '5xFAD (UCI)', intermediate_keeps)
+fivex_abs <- transform_results(fivex_abs_merged, c("Abeta40", "Abeta42"), fivex_display_name, intermediate_keeps)
 
 # No NfL measures for this model
 fivex_biomarkers <- fivex_abs
@@ -307,14 +333,14 @@ nss_abs_insol_12mo <- nss_abs_insol_12mo_source %>% mutate(fraction_type = 'Inso
 nss_abs_merged <- bind_rows(nss_abs_sol_4mo, nss_abs_sol_12mo, nss_abs_insol_4mo, nss_abs_insol_12mo)
 
 # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-nss_abs <- transform_results(nss_abs_merged, c("Abeta40", "Abeta42"), 'Trem2-R47H_NSS', intermediate_keeps)
+nss_abs <- transform_results(nss_abs_merged, c("Abeta40", "Abeta42"), nss_display_name, intermediate_keeps)
 
 # NfL measures
 # Merge source dfs
 nss_nfl_merged <- bind_rows(nss_nfl_cortex_source, nss_nfl_plasma_source)
 
 # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-nss_nfl <- transform_results(nss_nfl_merged, c("NfL"), 'Trem2-R47H_NSS', intermediate_keeps)
+nss_nfl <- transform_results(nss_nfl_merged, c("NfL"), nss_display_name, intermediate_keeps)
 
 # Merge Abetas and NfL
 nss_biomarkers <- bind_rows(nss_abs, nss_nfl)
@@ -334,14 +360,14 @@ abca7_abs_insol_12mo <- abca7_abs_insol_12mo_source %>% mutate(fraction_type = '
 abca7_abs_merged <- bind_rows(abca7_abs_sol_4mo, abca7_abs_sol_12mo, abca7_abs_insol_4mo, abca7_abs_insol_12mo)
 
 # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-abca7_abs <- transform_results(abca7_abs_merged, c("Abeta40", "Abeta42"), 'Abca7*V1599M', intermediate_keeps)
+abca7_abs <- transform_results(abca7_abs_merged, c("Abeta40", "Abeta42"), abca7_display_name, intermediate_keeps)
 
 # NfL measures
 # Merge source dfs
 abca7_nfl_merged <- bind_rows(abca7_nfl_cortex_source, abca7_nfl_plasma_source)
 
 # Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
-abca7_nfl <- transform_results(abca7_nfl_merged, c("NfL"), 'Abca7*V1599M', intermediate_keeps)
+abca7_nfl <- transform_results(abca7_nfl_merged, c("NfL"), abca7_display_name, intermediate_keeps)
 
 # Merge Abeta and NfL measures
 abca7_biomarkers <- bind_rows(abca7_abs, abca7_nfl)
@@ -392,7 +418,7 @@ stopifnot(abca7_expected_abs + abca7_expected_nfl == nrow(abca7_final))
 stopifnot(nrow(abca7_final) == 543) # 5xFADAbca7*V1599M + 5xFAD + Abca7*V1599M + C57BL/6J: 543
 ```
 
-## Merge model-specific results files & write csv file and upload to synapse
+## Merge model-specific results files & write csv file to synapse
 ```{r}
 # Merge results for all models
 biomarkers_final <- bind_rows(
@@ -408,7 +434,7 @@ if(!dir.exists(output_dir)){
   dir.create(output_dir)
 }
 write.csv(biomarkers_final, file.path(output_dir, "biomarkers.csv"), row.names = FALSE)
-
+```
 # upload to synapse
 syn_file <- File(file.path(output_dir, "biomarkers.csv"),
                  description = "Harmonized Biomarker data for Model-AD Explorer 2.0.",
@@ -421,4 +447,3 @@ res <- synStore(syn_file, forceVersion = FALSE,
 print(paste0("ID: ", res$id, " v", res$versionNumber, ", Name: ", res$name))
 
 ```
-

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -106,7 +106,37 @@ download_csv <- function(synId, df_name) {
   df_name <- as.data.frame(data)
 }
 
+transform_results <- function(results, measurement_columns, model_name, fields_to_keep) {
+
+# If no fraction_type column, add one with empty strings
+if (!"fraction_type" %in% names(results)) { results$fraction_type <- "" }
+
+results %>% pivot_longer(
+                cols = measurement_columns,
+                names_to = "type",
+                values_to = "measurement"
+
+       #
+       ) %>% mutate(type = if_else(type %in% c("Abeta40", "Abeta42"), paste(fraction_type, type), type)
+
+        # drop rows with no measurement
+        ) %>% filter(
+                !is.na(measurement)
+
+        # Populate model column
+        ) %>% add_column(
+                model = model_name
+
+        # Drop unused columns
+        ) %>% select(
+                all_of(fields_to_keep)
+        )
+}
+
 # Join a data file to a pair of metadata files to get required age, sex, ageDeath, and genotype values
+# - df: A dataframe containing result rows
+# - individual_metadata: A dataframe containing individual-level metadata
+# - biospecimen_metadata: A dataframe containing specimen metadata
 join_to_metadata <- function(df, individual_metadata, biospecimen_metadata) {
 
   individual_metadata <- subset(individual_metadata, select=c(individualID, sex, ageDeath, genotype))
@@ -180,26 +210,9 @@ threex_abs_sol <- threex_abs_sol_source %>% mutate(fraction_type = 'Soluble')
 threex_abs_insol <- threex_abs_insol_source %>% mutate(fraction_type = 'Insoluble')
 threex_abs_merged <- bind_rows(threex_abs_sol, threex_abs_insol)
 
-# populate 'model' column
-threex_abs_merged$model <- '3xTG-AD'
-
-# Pivot Abeta columns; capture temp 'abeta_type' values and populate the target 'measurement' column
-threex_abs_pivot <- threex_abs_merged %>%
-        pivot_longer(
-                cols = c(Abeta40, Abeta42),
-                names_to = "abeta_type",
-                values_to = "measurement"
-        )
-
-# Concatenate 'fraction_type' and 'abeta_type' columns to populate target 'type' column values
-threex_abs_pivot$type <- paste(threex_abs_pivot$fraction_type, threex_abs_pivot$abeta_type)
-
-# Drop unwanted columns and rows with no measurement value
-threex_abs_with_nas <- threex_abs_pivot[intermediate_keeps]
-threex_abs <- threex_abs_with_nas[!is.na(threex_abs_with_nas$measurement),]
+threex_abs <- transform_results(threex_abs_merged, c("Abeta40", "Abeta42"), '3xTg-AD', intermediate_keeps)
 
 # No NfL measures for this model
-
 threex_biomarkers <- threex_abs
 ```
 
@@ -211,24 +224,7 @@ fivex_abs_sol <- fivex_abs_sol_source %>% mutate(fraction_type = 'Soluble')
 fivex_abs_insol <- fivex_abs_insol_source %>% mutate(fraction_type = 'Insoluble')
 fivex_abs_merged <- bind_rows(fivex_abs_sol, fivex_abs_insol)
 
-# populate 'model' column
-# Since only UCI contributes pathology/biomarker data, we can assign all 5xFAD results to that center.
-fivex_abs_merged$model <- '5xFAD (UCI)'
-
-# Pivot Abeta columns; capture temp 'abeta_type' values and populate the target 'measurement' column
-fivex_abs_pivot <- fivex_abs_merged %>%
-        pivot_longer(
-                cols = c(Abeta40, Abeta42),
-                names_to = "abeta_type",
-                values_to = "measurement"
-        )
-
-# Concatenate 'fraction_type' and 'abeta_type' columns to populate target 'type' column values
-fivex_abs_pivot$type <- paste(fivex_abs_pivot$fraction_type, fivex_abs_pivot$abeta_type)
-
-# Drop unwanted columns and rows with no measurement value
-fivex_abs_with_nas <- fivex_abs_pivot[intermediate_keeps]
-fivex_abs <- fivex_abs_with_nas[!is.na(fivex_abs_with_nas$measurement),]
+fivex_abs <- transform_results(fivex_abs_merged, c("Abeta40", "Abeta42"), '5xFAD (UCI)', intermediate_keeps)
 
 # No NfL measures for this model
 fivex_biomarkers <- fivex_abs
@@ -236,7 +232,6 @@ fivex_biomarkers <- fivex_abs
 
 ### Trem2-R47H_NSS
 ```{r}
-
 # Abeta measures
 # Convert columns to consistent types
 nss_abs_sol_12mo_source$individualID <- as.character(nss_abs_sol_12mo_source$individualID)
@@ -250,46 +245,16 @@ nss_abs_insol_4mo <- nss_abs_insol_4mo_source %>% mutate(fraction_type = 'Insolu
 nss_abs_insol_12mo <- nss_abs_insol_12mo_source %>% mutate(fraction_type = 'Insoluble')
 nss_abs_merged <- bind_rows(nss_abs_sol_4mo, nss_abs_sol_12mo, nss_abs_insol_4mo, nss_abs_insol_12mo)
 
-# populate 'model' column
-nss_abs_merged$model <- 'Trem2-R47H_NSS'
-
-# Pivot Abeta columns; capture temp 'abeta_type' values and populate the target 'measurement' column
-nss_abs_pivot <- nss_abs_merged %>%
-        pivot_longer(
-                cols = c(Abeta40, Abeta42),
-                names_to = "abeta_type",
-                values_to = "measurement"
-        )
-
-# Concatenate 'fraction_type' and 'abeta_type' columns to populate target 'type' column values
-nss_abs_pivot$type <- paste(nss_abs_pivot$fraction_type, nss_abs_pivot$abeta_type)
-
-# Drop unwanted columns and rows with no measurement value
-nss_abs_with_nas <- nss_abs_pivot[intermediate_keeps]
-nss_abs <- nss_abs_with_nas[!is.na(nss_abs_with_nas$measurement),]
+nss_abs <- transform_results(nss_abs_merged, c("Abeta40", "Abeta42"), 'Trem2-R47H_NSS', intermediate_keeps)
 
 # NfL measures
 # Merge source dfs
 nss_nfl_merged <- bind_rows(nss_nfl_cortex_source, nss_nfl_plasma_source)
 
-# Populate 'model' column
-nss_nfl_merged$model <- 'Trem2-R47H_NSS'
-
-# Pivot nfl column and populate the target 'measurement' column
-nss_nfl_pivot <- nss_nfl_merged %>%
-        pivot_longer(
-                cols = c(NfL),
-                names_to = "type",
-                values_to = "measurement"
-        )
-
-# Drop unwanted columns and rows with no measurement value
-nss_nfl_with_nas <- nss_nfl_pivot[intermediate_keeps]
-nss_nfl <- nss_nfl_with_nas[!is.na(nss_nfl_with_nas$measurement),]
+nss_nfl <- transform_results(nss_nfl_merged, c("NfL"), 'Trem2-R47H_NSS', intermediate_keeps)
 
 # Merge Abetas and NfL
 nss_biomarkers <- bind_rows(nss_abs, nss_nfl)
-
 ```
 
 ### Abca7*V1599M
@@ -302,47 +267,19 @@ abca7_abs_insol_4mo <- abca7_abs_insol_4mo_source %>% mutate(fraction_type = 'In
 abca7_abs_insol_12mo <- abca7_abs_insol_12mo_source %>% mutate(fraction_type = 'Insoluble')
 abca7_abs_merged <- bind_rows(abca7_abs_sol_4mo, abca7_abs_sol_12mo, abca7_abs_insol_4mo, abca7_abs_insol_12mo)
 
-# populate 'model' column
-abca7_abs_merged$model <- 'Abca7*V1599M'
-
-# Pivot Abeta columns; capture temp 'abeta_type' values and populate the target 'measurement' column
-abca7_abs_pivot <- abca7_abs_merged %>%
-        pivot_longer(
-                cols = c(Abeta40, Abeta42),
-                names_to = "abeta_type",
-                values_to = "measurement"
-        )
-
-# Concatenate 'fraction_type' and 'abeta_type' columns to populate target 'type' column values
-abca7_abs_pivot$type <- paste(abca7_abs_pivot$fraction_type, abca7_abs_pivot$abeta_type)
-
-# Drop unwanted columns and rows with no measurement value
-abca7_abs_with_nas <- abca7_abs_pivot[intermediate_keeps]
-abca7_abs <- abca7_abs_with_nas[!is.na(abca7_abs_with_nas$measurement),]
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+abca7_abs <- transform_results(abca7_abs_merged, c("Abeta40", "Abeta42"), 'Abca7*V1599M', intermediate_keeps)
 
 # NfL measures
 # Merge source dfs
 abca7_nfl_merged <- bind_rows(abca7_nfl_cortex_source, abca7_nfl_plasma_source)
 
-# Populate 'model' column
-abca7_nfl_merged$model <- 'Abca7*V1599M'
+# Pivot targeted measurement columns; capture colname as 'unit' and value as 'measurement'
+abca7_nfl <- transform_results(abca7_nfl_merged, c("NfL"), 'Abca7*V1599M', intermediate_keeps)
 
-# Pivot nfl column and populate the target 'measurement' column
-abca7_nfl_pivot <- abca7_nfl_merged %>%
-        pivot_longer(
-                cols = c(NfL),
-                names_to = "type",
-                values_to = "measurement"
-        )
-
-# Drop unwanted columns and rows with no measurement value
-abca7_nfl_with_nas <- abca7_nfl_pivot[intermediate_keeps]
-abca7_nfl <- abca7_nfl_with_nas[!is.na(abca7_nfl_with_nas$measurement),]
-
-# Merge abs and nfl
+# Merge Abeta and NfL measures
 abca7_biomarkers <- bind_rows(abca7_abs, abca7_nfl)
 ```
-
 
 ## Join source files to metadata to populate age, tissue, and genotype values
 ```{r}
@@ -404,24 +341,27 @@ stopifnot(nrow(abca7_biomarkers) == nrow(abca7_final))
 
 ## Merge files and make final adjustments to colnames and values
 ```{r}
+# Merge results for all models
 biomarkers_merged <- bind_rows(
-  threex_final %>% mutate(individualID = as.character(individualID)),
-  fivex_final %>% mutate(individualID = as.character(individualID)),
-  nss_final %>% mutate(individualID = as.character(individualID)),
-  abca7_final %>% mutate(individualID = as.character(individualID))
-) %>% dplyr::rename(
+      threex_final %>% mutate(individualID = as.character(individualID)),
+      fivex_final %>% mutate(individualID = as.character(individualID)),
+      nss_final %>% mutate(individualID = as.character(individualID)),
+      abca7_final %>% mutate(individualID = as.character(individualID))
+
+  # Rename columns
+  ) %>% dplyr::rename(
     individual_id = individualID,
     specimen_id = specimenID,
     age_death = ageDeath
   )
 
 
-# standardize genotype values for display
+# Standardize genotype values for display
 biomarkers_final <- mutate(biomarkers_merged,
                            genotype = case_when(
 
                                    # 3xTG-AD genotypes
-                                   genotype == "3xTg-AD_homozygous"  ~ "3xTG-AD",
+                                   genotype == "3xTg-AD_homozygous"  ~ "3xTg-AD",
                                    genotype == "3XTg-AD_noncarrier" ~ "B6129",
 
                                    # 5xFAD genotypes
@@ -430,18 +370,14 @@ biomarkers_final <- mutate(biomarkers_merged,
 
                                    # NSS genotypes
                                    genotype == "Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS",
-                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "5xFADTrem2-R47H_NSS",
+                                   genotype == "5XFAD_carrier, Trem2-R47H_NSS_homozygous"  ~ "Trem2-R47H_NSS.5xFAD",
 
                                    # Abca7 genotypes
                                    genotype == "Abca7-V1599M_homozygous"  ~ "Abca7*V1599M",
-                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "5xFADAbca7*V1599M",
+                                   genotype == "5XFAD_carrier, Abca7-V1599M_homozygous"  ~ "Abca7*V1559M.5xFAD",
 
                                    TRUE ~ genotype))
 
-
-#Correct typos
-biomarkers_final$model <- gsub("3xTG-AD", "3xTg-AD", biomarkers_final$model)
-biomarkers_final$genotype <- gsub("3xTG-AD", "3xTg-AD", biomarkers_final$genotype)
 
 # print final data frame below
 biomarkers_final

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -70,12 +70,14 @@ library(tidyverse)
 # Harmonized column spec for intermediate per-model files
 intermediate_keeps <- c('specimenID', 'individualID', 'model', 'type', 'measurement', 'units')
 
-# Vector to store all downloaded synIds for Synapse provenance
+# Vector to store all downloaded synIds for Synapse provenance (populated via download_csv function)
 data_sources <- character()
 
 
-# Download a file from Synapse by synId and read it into a dataframe
-download_file <- function(synId, df_name, type) {
+# Download a csv file from Synapse by synId and read it into a dataframe
+# - synId: synapse ID of the file to download
+# - df_name: the name to use for the resulting dataframe
+download_csv <- function(synId, df_name) {
 
   synLogin()
 
@@ -93,7 +95,6 @@ download_file <- function(synId, df_name, type) {
 
   cat(paste0("Downloading ", synId, "..."))
 
-
   file <- synGet(id_value, version = version_value, downloadLocation = input_dir, ifcollision='overwrite.local')
   path <- file$path
 
@@ -101,16 +102,8 @@ download_file <- function(synId, df_name, type) {
   cat("\n", synId, "\n- Modified on ", file$properties$modifiedOn, "\n- Version ", file$properties$versionNumber)
   cat("\npath: ", file$path, "\n")
 
-  if (type == 'f') {
-    data <- read_feather(path)
-  } else {
-    if (type == 'json') { data <- fromJSON(path) }
-    if (type == 'csv' || type == 'table') { data <- read.csv(path) }
-    if (type == 'tsv') { data <- read.csv(path, sep = "\t") }
-    if (type == 'rda') { data <- load(path)}
-    if (type == 'rds') {data <- readRDS(path)}
-    df_name <- as.data.frame(data)
-  }
+  data <- read.csv(path)
+  df_name <- as.data.frame(data)
 }
 
 # Join a data file to a pair of metadata files to get required age, sex, ageDeath, and genotype values
@@ -128,52 +121,52 @@ join_to_metadata <- function(df, individual_metadata, biospecimen_metadata) {
 
 
 ## Download data and metadata files from Synapse
-Note that each file's synId and version is added to the data_sources vector via the download_file function.
+Note that each file's synId and version is added to the data_sources vector via the download_csv function.
 The populated data_sources vector is used to populate Synapse provenance when the harmonized csv is uploaded.
 ```{r}
 # 3xTG-AD
 # metadata
-threex_biospecimen <- download_file('syn23532198.3', type = "csv")
-threex_individual <- download_file('syn23532199.4', type = "csv")
+threex_biospecimen <- download_csv('syn23532198.3')
+threex_individual <- download_csv('syn23532199.4')
 # Abetas
-threex_abs_sol_source <- download_file('syn25913411.7', type = "csv")
-threex_abs_insol_source <- download_file('syn25913418.8', type = "csv")
+threex_abs_sol_source <- download_csv('syn25913411.7')
+threex_abs_insol_source <- download_csv('syn25913418.8')
 # NO NFL DATA
 
 # 5xFAD
 # metadata
-fivex_biospecimen <- download_file('syn18876530.10', type = "csv")
-fivex_individual <- download_file('syn18880070.14', type = "csv")
+fivex_biospecimen <- download_csv('syn18876530.10')
+fivex_individual <- download_csv('syn18880070.14')
 # Abetas
-fivex_abs_sol_source <- download_file('syn22101767.3', type = "csv")
-fivex_abs_insol_source <- download_file('syn22101766.1', type = "csv")
+fivex_abs_sol_source <- download_csv('syn22101767.3')
+fivex_abs_insol_source <- download_csv('syn22101766.1')
 # NO NFL DATA
 
 #NSS
 # metadata
-nss_biospecimen <- download_file('syn29568452.3', type = "csv")
-nss_individual <- download_file('syn27147690.3', type = "csv")
+nss_biospecimen <- download_csv('syn29568452.3')
+nss_individual <- download_csv('syn27147690.3')
 # Abetas
-nss_abs_sol_4mo_source <- download_file('syn29568621.2', type = "csv")
-nss_abs_sol_12mo_source <- download_file('syn29568624.2', type = "csv")
-nss_abs_insol_4mo_source <- download_file('syn29568619.1', type = "csv")
-nss_abs_insol_12mo_source <- download_file('syn29568622.1', type = "csv")
+nss_abs_sol_4mo_source <- download_csv('syn29568621.2')
+nss_abs_sol_12mo_source <- download_csv('syn29568624.2')
+nss_abs_insol_4mo_source <- download_csv('syn29568619.1')
+nss_abs_insol_12mo_source <- download_csv('syn29568622.1')
 # NFL
-nss_nfl_cortex_source <- download_file('syn29568489.2', type = "csv")
-nss_nfl_plasma_source <- download_file('syn29568490.1', type = "csv")
+nss_nfl_cortex_source <- download_csv('syn29568489.2')
+nss_nfl_plasma_source <- download_csv('syn29568490.1')
 
 #Abca7
 # metadata
-abca7_biospecimen <- download_file('syn30859390.2', type = "csv")
-abca7_individual <- download_file('syn30859394.2', type = "csv")
+abca7_biospecimen <- download_csv('syn30859390.2')
+abca7_individual <- download_csv('syn30859394.2')
 # Abetas
-abca7_abs_sol_4mo_source <- download_file('syn30859386.1', type = "csv")
-abca7_abs_sol_12mo_source <- download_file('syn30859377.1', type = "csv")
-abca7_abs_insol_4mo_source <- download_file('syn30859383.1', type = "csv")
-abca7_abs_insol_12mo_source <- download_file('syn30859387.1', type = "csv")
+abca7_abs_sol_4mo_source <- download_csv('syn30859386.1')
+abca7_abs_sol_12mo_source <- download_csv('syn30859377.1')
+abca7_abs_insol_4mo_source <- download_csv('syn30859383.1')
+abca7_abs_insol_12mo_source <- download_csv('syn30859387.1')
 # NFL
-abca7_nfl_cortex_source <- download_file('syn30859379.1', type = "csv")
-abca7_nfl_plasma_source <- download_file('syn30859380.1', type = "csv")
+abca7_nfl_cortex_source <- download_csv('syn30859379.1')
+abca7_nfl_plasma_source <- download_csv('syn30859380.1')
 ```
 
 

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -434,7 +434,7 @@ if(!dir.exists(output_dir)){
   dir.create(output_dir)
 }
 write.csv(biomarkers_final, file.path(output_dir, "biomarkers.csv"), row.names = FALSE)
-```
+
 # upload to synapse
 syn_file <- File(file.path(output_dir, "biomarkers.csv"),
                  description = "Harmonized Biomarker data for Model-AD Explorer 2.0.",
@@ -447,3 +447,4 @@ res <- synStore(syn_file, forceVersion = FALSE,
 print(paste0("ID: ", res$id, " v", res$versionNumber, ", Name: ", res$name))
 
 ```
+

--- a/data_analysis/model_ad/notebooks/immunohisto_expected_row_counts
+++ b/data_analysis/model_ad/notebooks/immunohisto_expected_row_counts
@@ -1,0 +1,306 @@
+---
+title: "Immunohisto expected row counts"
+---
+This notebook determines the expected number of rows of pathology and biomarker data per model, based on data exported from the legacy explorer.
+
+Legacy data export files are stored in: syn68930581
+
+# Library setup
+Install required packages:
+- synapser (also requires a Synapse account with an auth token)
+- tidyverse
+```{r}
+if (!require("synapser", quietly = TRUE)) {
+  install.packages("synapser", repos = c("http://ran.synapse.org",
+                                         "https://cloud.r-project.org"))
+}
+
+if (!require("tidyverse", quietly = TRUE)) {
+  install.packages("tidyverse")
+}
+
+library(synapser)
+library(tidyverse)
+```
+
+# Utility functions & variables
+```{r}
+# Download a csv file from Synapse by synId and read it into a dataframe
+# - synId: synapse ID of the file to download
+# - df_name: the name to use for the resulting dataframe
+download_csv <- function(synId, df_name) {
+
+  synLogin()
+
+  # Capture all downloaded synIds for provenance
+  data_sources <<- c(data_sources, synId)
+
+  input_dir <- file.path("./", "input")
+  id_parts <- strsplit(synId, '.', fixed = TRUE)
+  id_value <- id_parts[[1]][1]
+  version_value <- id_parts[[1]][2]
+
+  if (is.na(version_value)) {
+    version_value <- NULL
+  }
+
+  cat(paste0("Downloading ", synId, "..."))
+
+  file <- synGet(id_value, version = version_value, downloadLocation = input_dir, ifcollision='overwrite.local')
+  path <- file$path
+
+  cat("\nDownload on:  ", date())
+  cat("\n", synId, "\n- Modified on ", file$properties$modifiedOn, "\n- Version ", file$properties$versionNumber)
+  cat("\npath: ", file$path, "\n")
+
+  data <- read.csv(path)
+  df_name <- as.data.frame(data)
+}
+
+# Count the number of rows for the specified model and it's matched control
+# - model: the Mouse.model value for model's results
+# - control: the Mouse.model value for matched control's results
+# - legacy_data: A dataframe containing exported legacy data
+# - label: The measurement type in legacy_data
+count_legacy_rows <- function(model, control, legacy_data, label) {
+  legacy_rows <- bind_rows(legacy_data[legacy_data$Mouse.Model== model,], legacy_data[legacy_data$Mouse.Model== control,])
+  cat("\n", label, ": ", model, "+", control, " == ", nrow(legacy_rows))
+}
+
+```
+
+# Determine expected number of results based on legacy explorer
+
+## Download legacy data exports from Synapse
+Data was exported from the legacy shiny app:
+- per measure
+- per model, for Abca7*V1559M and Trem2R47H_NSS (to avoid mixing results for shared control genotypes)
+- grouped, for 5xFAD and 3xTg-AD (models have unique control genotypes)
+
+Legacy data is stored in syn68930581.
+
+```{r}
+# *********
+# PATHOLOGY
+# *********
+
+# IBA1
+iba1_legacy_cc <- download_csv("syn68930649")
+iba1_legacy_h <- download_csv("syn68930647")
+iba1_legacy <- bind_rows(iba1_legacy_cc, iba1_legacy_h)
+
+# GFAP
+gfap_legacy_cc <- download_csv("syn68930637")
+gfap_legacy_h <- download_csv("syn68930640")
+gfap_legacy <- bind_rows(gfap_legacy_cc, gfap_legacy_h)
+
+# S100B
+s100b_legacy_cc <- download_csv("syn68930642")
+s100b_legacy_h <- download_csv("syn68930639")
+s100b_legacy <- bind_rows(s100b_legacy_cc, s100b_legacy_h)
+
+# LAMP1
+lamp1_legacy_cc <- download_csv("syn68930641")
+lamp1_legacy_h <- download_csv("syn68930638")
+lamp1_legacy <- bind_rows(lamp1_legacy_cc, lamp1_legacy_h)
+
+# AT8
+at8_legacy <- download_csv("syn68930651")
+
+# HT7
+ht7_legacy <- download_csv("syn68930659")
+
+# ThioS size
+thioss_legacy_cc <- download_csv("syn68930655")
+thioss_legacy_h <- download_csv("syn68930658")
+thioss_legacy <- bind_rows(thioss_legacy_cc, thioss_legacy_h)
+
+# ThioS density
+thiosd_legacy_cc <- download_csv("syn68930648")
+thiosd_legacy_h <- download_csv("syn68930657")
+thiosd_legacy <- bind_rows(thiosd_legacy_cc, thiosd_legacy_h)
+
+# **********
+# BIOMARKERS
+# **********
+# Abetas (5x, 3x)
+insol_ab40_legacy_cc <- download_csv("syn69075668")
+insol_ab40_legacy_h <- download_csv("syn69075651")
+insol_ab40_legacy <- bind_rows(insol_ab40_legacy_cc, insol_ab40_legacy_h)
+
+insol_ab42_legacy_cc <- download_csv("syn69075669")
+insol_ab42_legacy_h <- download_csv("syn69075650")
+insol_ab42_legacy <- bind_rows(insol_ab42_legacy_cc, insol_ab42_legacy_h)
+
+sol_ab40_legacy_cc <- download_csv("syn69075671")
+sol_ab40_legacy_h <- download_csv("syn69075659")
+sol_ab40_legacy <- bind_rows(sol_ab40_legacy_cc, sol_ab40_legacy_h)
+
+sol_ab42_legacy_cc <- download_csv("syn69075670")
+sol_ab42_legacy_h <- download_csv("syn69075663")
+sol_ab42_legacy <- bind_rows(sol_ab42_legacy_cc, sol_ab42_legacy_h)
+
+# have to keep these separate by model to avoid mixing control rows
+
+# Abetas (abca7)
+insol_ab40_legacy_cc_abca7 <- download_csv("syn69075654")
+insol_ab40_legacy_h_abca7 <- download_csv("syn69075649")
+insol_ab40_legacy_abca7 <- bind_rows(insol_ab40_legacy_cc_abca7, insol_ab40_legacy_h_abca7)
+
+insol_ab42_legacy_cc_abca7 <- download_csv("syn69075652")
+insol_ab42_legacy_h_abca7 <- download_csv("syn69075653")
+insol_ab42_legacy_abca7 <- bind_rows(insol_ab42_legacy_cc_abca7, insol_ab42_legacy_h_abca7)
+
+sol_ab40_legacy_cc_abca7 <- download_csv("syn69075660")
+sol_ab40_legacy_h_abca7 <- download_csv("syn69075657")
+sol_ab40_legacy_abca7 <- bind_rows(sol_ab40_legacy_cc_abca7, sol_ab40_legacy_h_abca7)
+
+sol_ab42_legacy_cc_abca7 <- download_csv("syn69075656")
+sol_ab42_legacy_h_abca7 <- download_csv("syn69075661")
+sol_ab42_legacy_abca7 <- bind_rows(sol_ab42_legacy_cc_abca7, sol_ab42_legacy_h_abca7)
+
+# NfL (abca7)
+nfl_legacy_cc_abca7 <- download_csv("syn68930938")
+nfl_legacy_p_abca7 <- download_csv("syn68930937")
+nfl_legacy_abca7 <- bind_rows(nfl_legacy_cc_abca7, nfl_legacy_p_abca7)
+
+# Abetas (nss)
+insol_ab40_legacy_cc_nss <- download_csv("syn69075677")
+insol_ab40_legacy_h_nss <- download_csv("syn69075648")
+insol_ab40_legacy_nss <- bind_rows(insol_ab40_legacy_cc_nss, insol_ab40_legacy_h_nss)
+
+insol_ab42_legacy_cc_nss <- download_csv("syn69075674")
+insol_ab42_legacy_h_nss <- download_csv("syn69075655")
+insol_ab42_legacy_nss <- bind_rows(insol_ab42_legacy_cc_nss, insol_ab42_legacy_h_nss)
+
+sol_ab40_legacy_cc_nss <- download_csv("syn69075675")
+sol_ab40_legacy_h_nss <- download_csv("syn69075662")
+sol_ab40_legacy_nss <- bind_rows(sol_ab40_legacy_cc_nss, sol_ab40_legacy_h_nss)
+
+sol_ab42_legacy_cc_nss <- download_csv("syn69075676")
+sol_ab42_legacy_h_nss <- download_csv("syn69075658")
+sol_ab42_legacy_nss <- bind_rows(sol_ab42_legacy_cc_nss, sol_ab42_legacy_h_nss)
+
+# NfL (nss)
+nfl_legacy_cc_nss <- download_csv("syn68930936")
+nfl_legacy_p_nss <- download_csv("syn68930939")
+nfl_legacy_nss <- bind_rows(nfl_legacy_cc_nss, nfl_legacy_p_nss)
+
+```
+
+## Legacy file Mouse.model (genotype) values
+
+```{r}
+# *********
+# PATHOLOGY
+# *********
+cat("\n\nPathology")
+cat("\nIBA1: ", unique(iba1_legacy$Mouse.Model), sep=", ")
+cat("\nGFAP: ", unique(gfap_legacy$Mouse.Model), sep=", ")
+cat("\nS100B: ", unique(s100b_legacy$Mouse.Model), sep=", ")
+cat("\nLAMP1: ", unique(lamp1_legacy$Mouse.Model), sep=", ")
+cat("\nAT8: ", unique(at8_legacy$Mouse.Model), sep=", ")
+cat("\nHT7: ", unique(ht7_legacy$Mouse.Model), sep=", ")
+cat("\nThioS-size: ", unique(thioss_legacy$Mouse.Model), sep=", ")
+cat("\nThioS-density: ", unique(thiosd_legacy$Mouse.Model), sep=", ")
+
+# **********
+# BIOMARKERS
+# **********
+cat("\n\nBiomarkers: 3xTg-AD + 5xFAD")
+cat("\nInsoluble Abeta40 (5x/3x): ", unique(insol_ab40_legacy$Mouse.Model), sep=", ")
+cat("\nInsoluble Abeta42 (5x/3x): ", unique(insol_ab42_legacy$Mouse.Model), sep=", ")
+cat("\nSoluble Abeta40 (5x/3x): ", unique(sol_ab40_legacy$Mouse.Model), sep=", ")
+cat("\nSoluble Abeta42 (5x/3x): ", unique(sol_ab42_legacy$Mouse.Model), sep=", ")
+
+cat("\n\nBiomarkers: Abca7")
+cat("\nInsoluble Abeta40 (abca7): ", unique(insol_ab40_legacy_abca7$Mouse.Model), sep=", ")
+cat("\nInsoluble Abeta42 (abca7): ", unique(insol_ab42_legacy_abca7$Mouse.Model), sep=", ")
+cat("\nSoluble Abeta40 (abca7): ", unique(sol_ab40_legacy_abca7$Mouse.Model), sep=", ")
+cat("\nSoluble Abeta42 (abca7): ", unique(sol_ab42_legacy_abca7$Mouse.Model), sep=", ")
+cat("\nNfL (abca7): ", unique(nfl_legacy_abca7$Mouse.Model), sep=", ")
+
+cat("\n\nBiomarkers: NSS")
+cat("\nInsoluble Abeta40 (nss): ", unique(insol_ab40_legacy_nss$Mouse.Model), sep=", ")
+cat("\nInsoluble Abeta42 (nss): ", unique(insol_ab42_legacy_nss$Mouse.Model), sep=", ")
+cat("\nSoluble Abeta40 (nss): ", unique(sol_ab40_legacy_nss$Mouse.Model), sep=", ")
+cat("\nSoluble Abeta42 (nss): ", unique(sol_ab42_legacy_nss$Mouse.Model), sep=", ")
+cat("\nNfL (nss): ", unique(nfl_legacy_nss$Mouse.Model), sep=", ")
+```
+
+## Determine number of legacy results per model for pathology & biomarkers
+These values are used to validate that the correct results are included in the harmonized source files generated via the 'MG-88-biomarkers' notebook.
+
+```{r}
+# *********
+# PATHOLOGY
+# *********
+cat("\n\nPATHOLOGY")
+# 3xTg-AD
+cat("\n\n3xTg-AD")
+count_legacy_rows("3xTg-AD", "B6129", iba1_legacy, "IBA1")
+count_legacy_rows("3xTg-AD", "B6129", gfap_legacy, "GFAP")
+count_legacy_rows("3xTg-AD", "B6129", s100b_legacy, "S100B")
+count_legacy_rows("3xTg-AD", "B6129", lamp1_legacy, "LAMP1")
+count_legacy_rows("3xTg-AD", "B6129", at8_legacy, "AT8")
+count_legacy_rows("3xTg-AD", "B6129", ht7_legacy, "HT7")
+count_legacy_rows("3xTg-AD", "B6129", thioss_legacy, "ThioS size")
+count_legacy_rows("3xTg-AD", "B6129", thiosd_legacy, "ThioS density")
+
+# 5xFAD
+cat("\n\n5xFAD")
+count_legacy_rows("5xFAD", "C57BL/6J", iba1_legacy, "IBA1")
+count_legacy_rows("5xFAD", "C57BL/6J", gfap_legacy, "GFAP")
+count_legacy_rows("5xFAD", "C57BL/6J", s100b_legacy, "S100B")
+count_legacy_rows("5xFAD", "C57BL/6J", lamp1_legacy, "LAMP1")
+count_legacy_rows("5xFAD", "C57BL/6J", thioss_legacy, "ThioS size")
+count_legacy_rows("5xFAD", "C57BL/6J", thiosd_legacy, "ThioS density")
+
+# **********
+# BIOMARKERS
+# **********
+cat("\n\nBIOMARKERS")
+# 3xTg-AD
+cat("\n\n3xTg-AD")
+count_legacy_rows("3xTg-AD", "B6129", insol_ab40_legacy, "Insoluble Abeta40")
+count_legacy_rows("3xTg-AD", "B6129", insol_ab42_legacy, "Insoluble Abeta42")
+count_legacy_rows("3xTg-AD", "B6129", sol_ab40_legacy, "Soluble Abeta40")
+count_legacy_rows("3xTg-AD", "B6129", sol_ab42_legacy, "Soluble Abeta42")
+
+# 5xFAD
+cat("\n\n5xFAD")
+# filter out 8mo results
+insol_ab40_legacy_5x <- insol_ab40_legacy[insol_ab40_legacy$Age != 8,]
+insol_ab42_legacy_5x <- insol_ab40_legacy[insol_ab40_legacy$Age != 8,]
+sol_ab40_legacy_5x <- insol_ab40_legacy[insol_ab40_legacy$Age != 8,]
+sol_ab42_legacy_5x <- insol_ab40_legacy[insol_ab40_legacy$Age != 8,]
+
+count_legacy_rows("5xFAD", "C57BL/6J", insol_ab40_legacy_5x, "Insoluble Abeta40")
+count_legacy_rows("5xFAD", "C57BL/6J", insol_ab42_legacy_5x, "Insoluble Abeta42")
+count_legacy_rows("5xFAD", "C57BL/6J", sol_ab40_legacy_5x, "Soluble Abeta40")
+count_legacy_rows("5xFAD", "C57BL/6J", sol_ab42_legacy_5x, "Soluble Abeta42")
+
+# NSS
+cat("\n\nNSS")
+count_legacy_rows("5xFADTrem2-R47H_NSS", "5xFAD", insol_ab40_legacy_nss, "Insoluble Abeta40")
+count_legacy_rows("5xFADTrem2-R47H_NSS", "5xFAD", insol_ab42_legacy_nss, "Insoluble Abeta42")
+count_legacy_rows("5xFADTrem2-R47H_NSS", "5xFAD", sol_ab40_legacy_nss, "Soluble Abeta40")
+count_legacy_rows("5xFADTrem2-R47H_NSS", "5xFAD", sol_ab42_legacy_nss, "Soluble Abeta42")
+
+count_legacy_rows("Trem2-R47H_NSS", "C57BL/6J", nfl_legacy_nss, "NfL (nss)")
+count_legacy_rows("5xFADTrem2-R47H_NSS", "5xFAD", nfl_legacy_nss, "NfL (nss)")
+
+# Abca7
+cat("\n\nAbca7")
+count_legacy_rows("5xFADAbca7*V1599M", "5xFAD", insol_ab40_legacy_abca7, "Insoluble Abeta40")
+count_legacy_rows("5xFADAbca7*V1599M", "5xFAD", insol_ab42_legacy_abca7, "Insoluble Abeta42")
+count_legacy_rows("5xFADAbca7*V1599M", "5xFAD", sol_ab40_legacy_abca7, "Soluble Abeta40")
+count_legacy_rows("5xFADAbca7*V1599M", "5xFAD", sol_ab42_legacy_abca7, "Soluble Abeta42")
+
+count_legacy_rows("Abca7*V1599M", "C57BL/6J", nfl_legacy_abca7, "NfL (abca7)")
+count_legacy_rows("5xFADAbca7*V1599M", "5xFAD", nfl_legacy_abca7, "NfL (abca7)")
+```
+
+
+
+


### PR DESCRIPTION
# Problem
The R notebooks that generate the harmonized Biomarkers and Pathology source files were quick and dirty implementations to unblock development. As we approach MVP, we need to ensure that the generated source data includes all, and only, the data that we actually want to release. 

Some initial cleanup of the Pathology notebook was done via [this PR](https://github.com/Sage-Bionetworks/agora-data-tools/pull/211), but the Biomarkers notebook was not addressed in those updates, and additional opportunities to streamline the code and improve data validation exist.

# Solution
This PR:

1. Updates the Biomarkers notebook with the changes previously applied to the Pathology notebook:
a. Refactor the notebook to extract common functionality into a shared `transform_results` function
b. Ensure required model-specific handling to address known edge cases: missing metadata values, duplicate measurements, NA measurements (which sometimes but not always mean 0), etc.
c. Improve data validation 

2. Updates both the Biomarkers and Pathology notebooks with additional improvements:
a. Refactor the `join_to_metadata` function to include additional common functionality
b. Extract genotype display strings to shared variable block

3. Adds a new `immunohisto_expected_row_counts` notebook, which was used to calculate legacy data result counts for data validation checks