### PR TITLE
Updated gene metadata file version to use Ensembl 115 update

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -145,7 +145,7 @@ datasets:
   - gene_info:
       files:
         - name: gene_metadata
-          id: syn25953363.15
+          id: syn25953363.16
           format: feather
         - name: igap
           id: syn12514826.5
@@ -194,7 +194,7 @@ datasets:
         uniprotkb_accession: uniprotkb_accessions
         resource_identifier: ensembl_gene_id
       provenance:
-        - syn25953363.15
+        - syn25953363.16
         - syn12514826.5
         - syn12514912.3
         - *agora_proteomics_provenance

--- a/data_analysis/agora/notebooks/preprocessing/preprocessing_utils.py
+++ b/data_analysis/agora/notebooks/preprocessing/preprocessing_utils.py
@@ -298,7 +298,7 @@ def _extract_ensembl_ids(
 
     # Use column_renames from the config to convert most Ensembl ID column names to "ensembl_gene_id".
     df = utils.standardize_column_names(df=df)
-    df = utils.rename_columns(df=df, column_map=column_renames)
+    df = utils.rename_columns(data=df, column_map=column_renames)
 
     # Exception to the above comment: the 'networks' file has two ID columns (genea_ and geneb_ ensembl_gene_id)
     # which do not get renamed

--- a/data_analysis/model_ad/notebooks/MG-8_Create_ENSMUSG_Reference.rmd
+++ b/data_analysis/model_ad/notebooks/MG-8_Create_ENSMUSG_Reference.rmd
@@ -102,7 +102,7 @@ print(head(genes))
 ```{r}
 genes_df <- genes %>% group_by(ensembl_gene_id, external_gene_name) %>%
               summarise(alias = list(unique(external_synonym))) %>%
-              rename(gene_symbol = external_gene_name) %>%
+              dplyr::rename(gene_symbol = external_gene_name) %>%
               arrange(ensembl_gene_id)
 
 output_dir <- file.path("..", "output")

--- a/test_config.yaml
+++ b/test_config.yaml
@@ -145,7 +145,7 @@ datasets:
   - gene_info:
       files:
         - name: gene_metadata
-          id: syn25953363.15
+          id: syn25953363.16
           format: feather
         - name: igap
           id: syn12514826.5
@@ -194,7 +194,7 @@ datasets:
         uniprotkb_accession: uniprotkb_accessions
         resource_identifier: ensembl_gene_id
       provenance:
-        - syn25953363.15
+        - syn25953363.16
         - syn12514826.5
         - syn12514912.3
         - *agora_proteomics_provenance


### PR DESCRIPTION
Per [AG-1869](https://sagebionetworks.jira.com/browse/AG-1869), I updated Agora's [gene metadata file](https://www.synapse.org/Synapse:syn25953363) to Ensembl release 115. This PR bumps the version of the file in the configs to match.

It also fixes an argument in one of the pre-processing functions to work with Beatriz's `rename_columns` update.

[AG-1869]: https://sagebionetworks.jira.com/browse/AG-1869?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ