### PR TITLE
Trying to pin click to less than 8.3.0 as it worked in a previous CI run

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     PyYAML~=6.0
     pyarrow~=14.0.1
     typer~=0.7.0
+    click<8.3.0
     great-expectations==0.18.1
 python_requires = >=3.10, <3.12
 include_package_data = True


### PR DESCRIPTION
In the failed GH action https://github.com/Sage-Bionetworks/agora-data-tools/actions/runs/17840496223/job/50728686189 click was using 8.3.0

```
 Collecting Click!=8.1.4,>=7.1.2 (from great-expectations==0.18.1->agoradatatools==0.0.0)
  Downloading click-8.3.0-py3-none-any.whl.metadata (2.6 kB)
```

In a passed GH action it was using 8.2.1 https://github.com/Sage-Bionetworks/agora-data-tools/actions/runs/17808471966/job/50626260980

```
Collecting Click!=8.1.4,>=7.1.2 (from great-expectations==0.18.1->agoradatatools==0.0.0)
  Downloading click-8.2.1-py3-none-any.whl.metadata (2.5 kB)
```