### PR TITLE
MG-372: Adjust unit label for outlier measurement

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -264,7 +264,7 @@ join_to_metadata <- function(results, individual_metadata, biospecimen_metadata)
                               'ageDeath' = 'age_death')
 
             # Drop unneeded columns
-            ) %>% select(keeps
+            ) %>% select(all_of(keeps)
 
             # Correct genotypes to align with target display values
             ) %>% mutate(biomarkers_merged,
@@ -362,19 +362,19 @@ fivex_rename_cols <- function (results) {
 
 # Filter each source file to select desired rows by 'Stain' value, drop unneeded columns, and rename the remaining columns
 fivex_gfap_s100b <- fivex_gfap_s100b_source[fivex_gfap_s100b_source$Stain %in% c('GFAP', 'S100B'),] %>%
-  select(c(fivex_source_keeps, "X.objects..sqmm"))  %>%
+  select(all_of(c(fivex_source_keeps, "X.objects..sqmm")))  %>%
   fivex_rename_cols()
 
 fivex_lamp1 <- fivex_lamp1_source[fivex_lamp1_source$Stain == 'LAMP1',] %>%
-  select(c(fivex_source_keeps, "Area..")) %>%
+  select(all_of(c(fivex_source_keeps, "Area.."))) %>%
   fivex_rename_cols()
 
 fivex_iba1 <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'Iba1',] %>%
-  select(c(fivex_source_keeps, "X.objects..sqmm")) %>%
+  select(all_of(c(fivex_source_keeps, "X.objects..sqmm"))) %>%
   fivex_rename_cols()
 
 fivex_thios <- fivex_iba1_thios_source[fivex_iba1_thios_source$Stain == 'ThioS',] %>%
-  select(c(fivex_source_keeps, "X.objects..sqmm", "mean.object.area..squm.")) %>%
+  select(all_of(c(fivex_source_keeps, "X.objects..sqmm", "mean.object.area..squm."))) %>%
   mutate(X.objects..sqmm = ifelse(X.objects..sqmm == "N/A", 0, X.objects..sqmm)) %>%
   fivex_rename_cols()
 

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -127,7 +127,7 @@ objectDensity_display_name <- '# objects / square mm'
 averageObjectVolume_display_name <- 'mean object volume (cubic mm)'
 totalObjectVolume_display_name <- 'total object volume (cubic mm)'
 meanObjectArea_display_name <- 'mean object area (square mm)'
-areaPercent_display_name <- 'area %'
+areaPercent_display_name <- '%'
 
 # *********
 # FUNCTIONS

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     PyYAML~=6.0
     pyarrow~=14.0.1
     typer~=0.7.0
-   click<8.3.0
+    click<8.3.0
     great-expectations==0.18.1
 python_requires = >=3.10, <3.12
 include_package_data = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,6 +35,7 @@ install_requires =
     PyYAML~=6.0
     pyarrow~=14.0.1
     typer~=0.7.0
+   click<8.3.0
     great-expectations==0.18.1
 python_requires = >=3.10, <3.12
 include_package_data = True


### PR DESCRIPTION
## Problem

The 5xFAD model measured the LAMP1 stain using a different approach than that used for other models, resulting in a unique measurement and y-axis label for the model.

The source data generated by this R notebook specified an incorrect label (Area %) for that 5xFAD result type.

## Solution 

Adjust the UI label to align with the legacy explorer's UI label (%).

Additionally, this PR addresses a dplyr deprecation warning by adding `all_of` to chained select statements.