### PR TITLE
MG-445: Update Cluster display labels for Disease Correlation data

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
+++ b/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
@@ -79,13 +79,22 @@ The populated data_sources vector is used to populate Synapse provenance when th
 ```{r}
 disease_correlation_source <- download_file('syn65467849.1', type = "csv")
 ```
-
+## Update Cluster values (MG-445)
+Update the Cluster labels to the new display format, and fix 'Biogenesis' typo from legacy explorer data
+```{r}
+disease_correlation_final <- disease_correlation_source %>% mutate(Cluster = case_when(
+  Cluster == "Consensus Cluster A (ECM organization)" ~ "Consensus Cluster A - ECM Organization",
+  Cluster == "Consensus Cluster B (Immune system)" ~ "Consensus Cluster B - Immune system",
+  Cluster == "Consensus Cluster C (Neuronal system)" ~ "Consensus Cluster C - Neuronal system",
+  Cluster == "Consensus Cluster D (Cell Cycle, NMD)" ~ "Consensus Cluster D - Cell Cycle, NMD",
+  Cluster == "Consensus Cluster E (Organelle Biogensis, Cellular stress response)" ~ "Consensus Cluster E - Organelle Biogenesis, Cellular stress response"
+))
+```
 
 ## Update 5xFAD model_name to include center info
 Since only IU/Jax/Pitt contributed disease_correlation data, we can assign all 5xFAD results to that center.
 
 ```{r}
-disease_correlation_final <- copy(disease_correlation_source)
 disease_correlation_final$Mouse.Model[disease_correlation_final$Mouse.Model == '5xFAD'] <- '5xFAD (IU/Jax/Pitt)'
 ```
 
@@ -110,4 +119,3 @@ res <- synStore(syn_file, forceVersion = FALSE,
 print(paste0("ID: ", res$id, " v", res$versionNumber, ", Name: ", res$name))
 
 ```
-


### PR DESCRIPTION
# Problem
The cluster field values in the disease_correlation dataset are formatted with parens, but we want them to use hyphens instead.

In addition, there is a typo in the data that we exported from the legacy app that we want to correct: 'Biogensis' to 'Biogenesis'

# Solution
Update the R notebook used to generate the harmonized source file to address these issues. This will allow us to generate an updated version of the disease_correlation dataset without having to update the custom transform.