### PR TITLE
AG-1889: Suppress Typer autocompletion options in help output

### DIFF
--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -384,7 +384,7 @@ def process_all_files(
     reporter.update_table()
 
 
-app = Typer()
+app = Typer(add_completion=False)
 
 input_path_arg = Argument(
     ..., help="Path to configuration file for processing run (Required)."


### PR DESCRIPTION
## Problem
By default, Typer adds autocompletion-related options to `--help`, but those options do not work as we haven't implemented autocompletion logic for this CLI.

<img width="980" height="299" alt="Screenshot 2025-10-20 at 10 46 39 AM" src="https://github.com/user-attachments/assets/c721d0e9-f6b2-4566-a076-3ddb717c3796" />


## Solution
Update the Typer constructor to disable the `add_completion` logic that controls the visibility of these options. The CLI now reports only the supported commands in the `--help` output:

<img width="525" height="259" alt="Screenshot 2025-10-20 at 10 45 49 AM" src="https://github.com/user-attachments/assets/cb91eeaf-bf0b-4990-a910-888eed6edfc6" />
