### PR TITLE
MG-453: Correct type of gene_expression.model column in ui_config

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -153,7 +153,7 @@ ge_menu3 <- c("Sex - Females & Males", "Sex - Females", "Sex - Males")
 
 # Gene Expression Columns
 # -------------------------
-ge_static_row <- c("Model", "text", "Mouse Model", "Sort by Model value")
+ge_static_row <- c("Model", "link_internal", "Mouse Model", "Sort by Model value")
 ge_dynamic_row <- c("heat_map", "", "Sort by log2 fold change value")
 ge_dynamic_names_jax <- c("4 months", "12 months")
 ge_dynamic_names_uci <- c("4 months", "12 months", "18 months")


### PR DESCRIPTION
## Problem
Hallie reported a mismatch on actual vs expected (per designs) data type for the Gene Expression interface's Model column.

## Solution
Update the R notebook used to generate `ui_config` so that it specifies the `internal_link` type rather than the `text` type.