### PR TITLE
[AG-1813]: Autopopulate provenance with source files

### DIFF
--- a/configs/agora_preprod.yaml
+++ b/configs/agora_preprod.yaml
@@ -51,7 +51,6 @@ datasets:
       files: *genes_biodomains_files
       final_format: json
       custom_transformations: transform_biodomain_info
-      provenance: *genes_biodomains_provenance
       column_rename:
         biodomain: name
       destination: *dest
@@ -61,7 +60,6 @@ datasets:
       files: *genes_biodomains_files
       final_format: json
       custom_transformations: transform_genes_biodomains
-      provenance: *genes_biodomains_provenance
       column_rename:
         ensembl_id: ensembl_gene_id
         goterm_name: go_terms
@@ -76,8 +74,6 @@ datasets:
           id: syn22017882.5
           format: csv
       final_format: json
-      provenance:
-        - syn22017882.5
       column_rename:
         ensg: ensembl_gene_id
         gname: hgnc_gene_id
@@ -91,7 +87,6 @@ datasets:
       files: *agora_proteomics_files
       final_format: json
       custom_transformations: transform_proteomics
-      provenance: *agora_proteomics_provenance
       column_rename:
         genename: hgnc_symbol
         ensg: ensembl_gene_id
@@ -102,7 +97,6 @@ datasets:
       files: *agora_proteomics_tmt_files
       final_format: json
       custom_transformations: transform_proteomics
-      provenance: *agora_proteomics_tmt_provenance
       column_rename:
         genename: hgnc_symbol
         ensg: ensembl_gene_id
@@ -113,7 +107,6 @@ datasets:
       files: *agora_proteomics_srm_files
       final_format: json
       custom_transformations: transform_proteomics
-      provenance: *agora_proteomics_srm_provenance
       column_rename:
         genename: hgnc_symbol
         ensg: ensembl_gene_id
@@ -126,8 +119,6 @@ datasets:
           id: syn24184512.9
           format: csv
       final_format: json
-      provenance:
-        - syn24184512.9
       destination: *dest
       gx_enabled: true
 
@@ -137,8 +128,6 @@ datasets:
           id: syn26064497.1
           format: feather
       final_format: json
-      provenance:
-        - syn26064497.1
       destination: *dest
       gx_enabled: true
 
@@ -193,20 +182,6 @@ datasets:
         permalink: ensembl_permalink
         uniprotkb_accession: uniprotkb_accessions
         resource_identifier: ensembl_gene_id
-      provenance:
-        - syn25953363.16
-        - syn12514826.5
-        - syn12514912.3
-        - *agora_proteomics_provenance
-        - *agora_proteomics_tmt_provenance
-        - *agora_proteomics_srm_provenance
-        - *rna_diff_expr_data_provenance
-        - syn12540368.54
-        - syn27211878.2
-        - *genes_biodomains_provenance
-        - syn51942280.6
-        - syn54113663.5
-        - syn64123611.2
       agora_rename:
         symbol: hgnc_symbol
       destination: *dest
@@ -227,9 +202,6 @@ datasets:
           format: csv
       final_format: json
       custom_transformations: transform_team_info
-      provenance:
-        - syn12615624.18
-        - syn12615633.20
       destination: *dest
       gx_enabled: true
       gx_nested_columns:
@@ -241,7 +213,6 @@ datasets:
       custom_transformations: transform_overall_scores
       column_rename:
         genename: hgnc_gene_id
-      provenance: *overall_scores_provenance
       agora_rename:
         ensg: ensembl_gene_id
         hgnc_gene_id: hgnc_symbol
@@ -258,7 +229,6 @@ datasets:
           format: csv
       final_format: json
       provenance:
-        - syn11685347.1
         - syn27211942.1
       agora_rename:
         genea_ensembl_gene_id: geneA_ensembl_gene_id
@@ -273,7 +243,6 @@ datasets:
       files: *rna_diff_expr_data_files
       final_format: json
       custom_transformations: transform_rnaseq_differential_expression
-      provenance: *rna_diff_expr_data_provenance
       destination: *dest
       gx_enabled: true
 
@@ -285,7 +254,6 @@ datasets:
             overall_max_score: 5
             genetics_max_score: 3
             omics_max_score: 2
-      provenance: *overall_scores_provenance
       column_rename:
         overall: target_risk_score
         geneticsscore: genetics_score
@@ -301,7 +269,6 @@ datasets:
       files: *rna_diff_expr_data_files
       final_format: json
       custom_transformations: transform_rna_distribution_data
-      provenance: *rna_diff_expr_data_provenance
       destination: *dest
       gx_enabled: true
 
@@ -312,9 +279,5 @@ datasets:
         - <<: *agora_proteomics_srm_files
       final_format: json
       custom_transformations: transform_proteomics_distribution_data
-      provenance:
-        - *agora_proteomics_provenance
-        - *agora_proteomics_tmt_provenance
-        - *agora_proteomics_srm_provenance
       destination: *dest
       gx_enabled: true

--- a/configs/agora_prod.yaml
+++ b/configs/agora_prod.yaml
@@ -51,7 +51,6 @@ datasets:
       files: *genes_biodomains_files
       final_format: json
       custom_transformations: transform_biodomain_info
-      provenance: *genes_biodomains_provenance
       column_rename:
         biodomain: name
       destination: *dest
@@ -61,7 +60,6 @@ datasets:
       files: *genes_biodomains_files
       final_format: json
       custom_transformations: transform_genes_biodomains
-      provenance: *genes_biodomains_provenance
       column_rename:
         ensembl_id: ensembl_gene_id
         goterm_name: go_terms
@@ -76,8 +74,6 @@ datasets:
           id: syn22017882.5
           format: csv
       final_format: json
-      provenance:
-        - syn22017882.5
       column_rename:
         ensg: ensembl_gene_id
         gname: hgnc_gene_id
@@ -91,7 +87,6 @@ datasets:
       files: *agora_proteomics_files
       final_format: json
       custom_transformations: transform_proteomics
-      provenance: *agora_proteomics_provenance
       column_rename:
         genename: hgnc_symbol
         ensg: ensembl_gene_id
@@ -102,7 +97,6 @@ datasets:
       files: *agora_proteomics_tmt_files
       final_format: json
       custom_transformations: transform_proteomics
-      provenance: *agora_proteomics_tmt_provenance
       column_rename:
         genename: hgnc_symbol
         ensg: ensembl_gene_id
@@ -113,7 +107,6 @@ datasets:
       files: *agora_proteomics_srm_files
       final_format: json
       custom_transformations: transform_proteomics
-      provenance: *agora_proteomics_srm_provenance
       column_rename:
         genename: hgnc_symbol
         ensg: ensembl_gene_id
@@ -126,8 +119,6 @@ datasets:
           id: syn24184512.9
           format: csv
       final_format: json
-      provenance:
-        - syn24184512.9
       destination: *dest
       gx_enabled: true
 
@@ -137,8 +128,6 @@ datasets:
           id: syn26064497.1
           format: feather
       final_format: json
-      provenance:
-        - syn26064497.1
       destination: *dest
       gx_enabled: true
 
@@ -193,20 +182,6 @@ datasets:
         permalink: ensembl_permalink
         uniprotkb_accession: uniprotkb_accessions
         resource_identifier: ensembl_gene_id
-      provenance:
-        - syn25953363.16
-        - syn12514826.5
-        - syn12514912.3
-        - *agora_proteomics_provenance
-        - *agora_proteomics_tmt_provenance
-        - *agora_proteomics_srm_provenance
-        - *rna_diff_expr_data_provenance
-        - syn12540368.54
-        - syn27211878.2
-        - *genes_biodomains_provenance
-        - syn51942280.6
-        - syn54113663.5
-        - syn64123611.2
       agora_rename:
         symbol: hgnc_symbol
       destination: *dest
@@ -227,9 +202,6 @@ datasets:
           format: csv
       final_format: json
       custom_transformations: transform_team_info
-      provenance:
-        - syn12615624.18
-        - syn12615633.20
       destination: *dest
       gx_enabled: true
       gx_nested_columns:
@@ -241,7 +213,6 @@ datasets:
       custom_transformations: transform_overall_scores
       column_rename:
         genename: hgnc_gene_id
-      provenance: *overall_scores_provenance
       agora_rename:
         ensg: ensembl_gene_id
         hgnc_gene_id: hgnc_symbol
@@ -258,7 +229,6 @@ datasets:
           format: csv
       final_format: json
       provenance:
-        - syn11685347.1
         - syn27211942.1
       agora_rename:
         genea_ensembl_gene_id: geneA_ensembl_gene_id
@@ -273,7 +243,6 @@ datasets:
       files: *rna_diff_expr_data_files
       final_format: json
       custom_transformations: transform_rnaseq_differential_expression
-      provenance: *rna_diff_expr_data_provenance
       destination: *dest
       gx_enabled: true
 
@@ -285,7 +254,6 @@ datasets:
             overall_max_score: 5
             genetics_max_score: 3
             omics_max_score: 2
-      provenance: *overall_scores_provenance
       column_rename:
         overall: target_risk_score
         geneticsscore: genetics_score
@@ -301,7 +269,6 @@ datasets:
       files: *rna_diff_expr_data_files
       final_format: json
       custom_transformations: transform_rna_distribution_data
-      provenance: *rna_diff_expr_data_provenance
       destination: *dest
       gx_enabled: true
 
@@ -312,9 +279,5 @@ datasets:
         - <<: *agora_proteomics_srm_files
       final_format: json
       custom_transformations: transform_proteomics_distribution_data
-      provenance:
-        - *agora_proteomics_provenance
-        - *agora_proteomics_tmt_provenance
-        - *agora_proteomics_srm_provenance
       destination: *dest
       gx_enabled: true

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -9,8 +9,6 @@ datasets:
           id: syn61250724
           format: csv
       final_format: json
-      provenance:
-        - syn61250724
       destination: *dest
       custom_transformations: immunohisto_transform
       column_rename:
@@ -26,8 +24,6 @@ datasets:
           id: syn61357279
           format: csv
       final_format: json
-      provenance:
-        - syn61357279
       destination: *dest
       custom_transformations: immunohisto_transform
       column_rename:
@@ -58,12 +54,6 @@ datasets:
           id: syn68377668
           format: csv
       final_format: json
-      provenance:
-        - syn61378590
-        - syn64618791
-        - syn61357279
-        - syn61250724
-        - syn64846805
       destination: *dest
       custom_transformations: transform_model_details
       column_rename:
@@ -92,10 +82,6 @@ datasets:
           id: syn64618791
           format: csv
       final_format: json
-      provenance:
-        - syn65467849
-        - syn61378590
-        - syn64618791
       destination: *dest
       custom_transformations: transform_disease_correlation
       column_rename:
@@ -107,8 +93,6 @@ datasets:
           id: syn66527739
           format: json
       final_format: json
-      provenance:
-        - syn66527739
       destination: *dest
       gx_enabled: true
       gx_nested_columns:
@@ -129,11 +113,6 @@ datasets:
           id: syn64846805
           format: csv
       final_format: json
-      provenance:
-        - syn61378590
-        - syn68377668
-        - syn64618791
-        - syn64846805
       destination: *dest
       custom_transformations: transform_model_overview
       column_rename:

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -9,8 +9,6 @@ datasets:
           id: syn61250724
           format: csv
       final_format: json
-      provenance:
-        - syn61250724
       destination: *dest
       custom_transformations: immunohisto_transform
       column_rename:
@@ -26,8 +24,6 @@ datasets:
           id: syn61357279
           format: csv
       final_format: json
-      provenance:
-        - syn61357279
       destination: *dest
       custom_transformations: immunohisto_transform
       column_rename:
@@ -58,12 +54,6 @@ datasets:
           id: syn68377668
           format: csv
       final_format: json
-      provenance:
-        - syn61378590
-        - syn64618791
-        - syn61357279
-        - syn61250724
-        - syn64846805
       destination: *dest
       custom_transformations: transform_model_details
       column_rename:
@@ -92,10 +82,6 @@ datasets:
           id: syn64618791
           format: csv
       final_format: json
-      provenance:
-        - syn65467849
-        - syn61378590
-        - syn64618791
       destination: *dest
       custom_transformations: transform_disease_correlation
       column_rename:
@@ -107,8 +93,6 @@ datasets:
           id: syn66527739
           format: json
       final_format: json
-      provenance:
-        - syn66527739
       destination: *dest
       gx_enabled: true
       gx_nested_columns:
@@ -129,11 +113,6 @@ datasets:
           id: syn64846805
           format: csv
       final_format: json
-      provenance:
-        - syn61378590
-        - syn68377668
-        - syn64618791
-        - syn64846805
       destination: *dest
       custom_transformations: transform_model_overview
       column_rename:

--- a/src/agoradatatools/great_expectations/gx/expectations/ui_config.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/ui_config.json
@@ -9,7 +9,7 @@
         "length_threshold": 0,
         "operator": ">",
         "target_field": "tooltip",
-        "valid_threshold": 0.35
+        "valid_threshold": 0.2
       },
       "meta": {}
     }

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -24,7 +24,7 @@ def check_provenance_id_file_id_consistency(
     If file id and provenance id share the same base id, their versions must match.
 
     Args:
-        dataset_obj: Dataset configuration object
+        provenance_ids: List of provenance IDs defined in the configuration (after flattening)
         file_ids: List of file IDs defined in the configuration
     
     Raises:

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -17,28 +17,41 @@ from agoradatatools.constants import Platform
 logger = logging.getLogger(__name__)
 
 
-def get_provenance_ids(dataset_obj: dict, dataset_name: str, file_ids: list) -> list:
+def get_provenance_ids(
+    dataset_obj: Dict[str, Any], dataset_name: str, file_ids: list[str]
+) -> list[str]:
     """Get combined provenance IDs from config and file IDs.
 
     Args:
         dataset_obj: Dataset configuration object
         dataset_name: Name of the dataset
-        file_ids: List of file IDs from the dataset
+        file_ids: List of file IDs defined in the configuration
 
     Returns:
         Combined list of provenance IDs (file IDs + config provenance)
     """
-    provenance_ids = file_ids.copy()
-
     provenance = dataset_obj[dataset_name].get("provenance", [])
+    flattened_provenance = []
 
     if provenance:
         if not isinstance(provenance, list):
             raise ValueError(f"Provenance for dataset '{dataset_name}' must be a list")
-        provenance_ids.extend(provenance)
+        for item in provenance:
+            if isinstance(item, list):
+                flattened_provenance.extend(item)
+            elif isinstance(item, str):
+                flattened_provenance.append(item)
+        provenance_ids = file_ids + flattened_provenance
+    else:
+        provenance_ids = file_ids
 
     # Remove duplicates while preserving order
-    return list(dict.fromkeys(provenance_ids))
+    try:
+        return list(dict.fromkeys(provenance_ids))
+    except Exception:
+        raise ValueError(
+            f"Error occurred while getting provenance IDs: {provenance_ids} for this dataset: {dataset_name}"
+        )
 
 
 def apply_custom_transformations(

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -42,8 +42,6 @@ def check_provenance_id_file_id_consistency(
     file_id_map = defaultdict(set)
     for file_id in file_ids:
         base_id = file_id.split(".")[0]
-        if base_id not in file_id_map:
-            file_id_map[base_id] = set()
         file_id_map[base_id].add(file_id)
 
     # Raise error if any provenance ID has different version than the corresponding file ID

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -17,6 +17,46 @@ from agoradatatools.constants import Platform
 logger = logging.getLogger(__name__)
 
 
+def check_provenance_id_file_id_consistency(
+    provenance_ids: list[str], file_ids: list[str]
+) -> None:
+    """Check that provenance IDs in config are consistent with file IDs.
+    If file id and provenance id share the same base id, their versions must match.
+
+    Args:
+        dataset_obj: Dataset configuration object
+        file_ids: List of file IDs defined in the configuration
+    
+    Raises:
+        ValueError: If any provenance ID has different version than the corresponding file ID
+
+    Example:
+        file_ids = ["syn123.4", "syn456.2"]
+        provenance_ids = ["syn123.4", "syn789.1"]  # OK - syn123 versions match
+        provenance_ids = ["syn123.5", "syn789.1"]  # ERROR - syn123 versions differ
+    """
+    if not provenance_ids:
+        return
+    # Build a mapping of base ID to full ID(s) for file IDs
+    file_id_map = {}
+    for file_id in file_ids:
+        base_id = file_id.split(".")[0]
+        if base_id not in file_id_map:
+            file_id_map[base_id] = set()
+        file_id_map[base_id].add(file_id)
+    
+    # Raise error if any provenance ID has different version than the corresponding file ID
+    for prov_id in provenance_ids:
+        base_id = prov_id.split(".")[0]
+        if base_id in file_id_map:
+            if prov_id not in file_id_map[base_id]:
+                file_versions_str = ", ".join(sorted(file_id_map[base_id]))
+                raise ValueError(
+                    f"Version mismatch: Provenance ID '{prov_id}' conflicts with "
+                    f"file ID(s) '{file_versions_str}'. When the same Synapse entity "
+                    f"appears in both provenance and files, their versions must match."
+                )
+
 def get_provenance_ids(
     dataset_obj: Dict[str, Any], dataset_name: str, file_ids: list[str]
 ) -> list[str]:
@@ -42,6 +82,9 @@ def get_provenance_ids(
             elif isinstance(item, str):
                 flattened_provenance.add(item)
         provenance_ids = set(file_ids).union(flattened_provenance)
+        check_provenance_id_file_id_consistency(
+            provenance_ids=list(flattened_provenance), file_ids=file_ids
+        )
     else:
         provenance_ids = file_ids
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -26,7 +26,7 @@ def check_provenance_id_file_id_consistency(
     Args:
         provenance_ids: List of provenance IDs defined in the configuration (after flattening)
         file_ids: List of file IDs defined in the configuration
-    
+
     Raises:
         ValueError: If any provenance ID has different version than the corresponding file ID
 
@@ -44,7 +44,7 @@ def check_provenance_id_file_id_consistency(
         if base_id not in file_id_map:
             file_id_map[base_id] = set()
         file_id_map[base_id].add(file_id)
-    
+
     # Raise error if any provenance ID has different version than the corresponding file ID
     for prov_id in provenance_ids:
         base_id = prov_id.split(".")[0]
@@ -56,6 +56,7 @@ def check_provenance_id_file_id_consistency(
                     f"file ID(s) '{file_versions_str}'. When the same Synapse entity "
                     f"appears in both provenance and files, their versions must match."
                 )
+
 
 def get_provenance_ids(
     dataset_obj: Dict[str, Any], dataset_name: str, file_ids: list[str]

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -142,12 +142,22 @@ def process_dataset(
     """
     dataset_name = list(dataset_obj.keys())[0]
     dataset_report = DatasetReport(data_set=dataset_name)
+    provenance_ids = []
+
+    # get provenance if any
+    provenance = dataset_obj[dataset_name].get("provenance", [])
+    if provenance:
+        provenance_ids.extend(provenance)
 
     entities_as_df = {}
     for entity in dataset_obj[dataset_name]["files"]:
         entity_id = entity["id"]
         entity_format = entity["format"]
         entity_name = entity["name"]
+
+        # save file ids for provenance
+        if entity_id not in provenance_ids:
+            provenance_ids.append(entity_id)
 
         df = extract.get_entity_as_df(syn_id=entity_id, source=entity_format, syn=syn)
         df = utils.standardize_column_names(df=df)
@@ -159,7 +169,6 @@ def process_dataset(
             )
 
         entities_as_df[entity_name] = df
-
     if "custom_transformations" in dataset_obj[dataset_name].keys():
         transform_result = apply_custom_transformations(
             datasets=entities_as_df,
@@ -225,7 +234,7 @@ def process_dataset(
         if upload and not gx_runner.failures:
             file_id, file_version = load.load(
                 file_path=json_path,
-                provenance=dataset_obj[dataset_name]["provenance"],
+                provenance=provenance_ids,
                 destination=dataset_obj[dataset_name]["destination"],
                 syn=syn,
             )
@@ -243,7 +252,7 @@ def process_dataset(
         if upload:
             file_id, file_version = load.load(
                 file_path=json_path,
-                provenance=dataset_obj[dataset_name]["provenance"],
+                provenance=provenance_ids,
                 destination=dataset_obj[dataset_name]["destination"],
                 syn=syn,
             )

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -1,5 +1,6 @@
 import logging
 import warnings
+from collections import defaultdict
 from typing import Optional, Union, Dict, Any, List
 import inspect
 import synapseclient
@@ -38,7 +39,7 @@ def check_provenance_id_file_id_consistency(
     if not provenance_ids:
         return
     # Build a mapping of base ID to full ID(s) for file IDs
-    file_id_map = {}
+    file_id_map = defaultdict(set)  
     for file_id in file_ids:
         base_id = file_id.split(".")[0]
         if base_id not in file_id_map:

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -31,27 +31,21 @@ def get_provenance_ids(
         Combined list of provenance IDs (file IDs + config provenance)
     """
     provenance = dataset_obj[dataset_name].get("provenance", [])
-    flattened_provenance = []
+    flattened_provenance = set()
 
     if provenance:
         if not isinstance(provenance, list):
             raise ValueError(f"Provenance for dataset '{dataset_name}' must be a list")
         for item in provenance:
             if isinstance(item, list):
-                flattened_provenance.extend(item)
+                flattened_provenance.update(item)
             elif isinstance(item, str):
-                flattened_provenance.append(item)
-        provenance_ids = file_ids + flattened_provenance
+                flattened_provenance.add(item)
+        provenance_ids = set(file_ids).union(flattened_provenance)
     else:
         provenance_ids = file_ids
 
-    # Remove duplicates while preserving order
-    try:
-        return list(dict.fromkeys(provenance_ids))
-    except Exception:
-        raise ValueError(
-            f"Error occurred while getting provenance IDs: {provenance_ids} for this dataset: {dataset_name}"
-        )
+    return list(provenance_ids)
 
 
 def apply_custom_transformations(

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -39,7 +39,7 @@ def check_provenance_id_file_id_consistency(
     if not provenance_ids:
         return
     # Build a mapping of base ID to full ID(s) for file IDs
-    file_id_map = defaultdict(set)  
+    file_id_map = defaultdict(set)
     for file_id in file_ids:
         base_id = file_id.split(".")[0]
         if base_id not in file_id_map:

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -17,6 +17,30 @@ from agoradatatools.constants import Platform
 logger = logging.getLogger(__name__)
 
 
+def get_provenance_ids(dataset_obj: dict, dataset_name: str, file_ids: list) -> list:
+    """Get combined provenance IDs from config and file IDs.
+
+    Args:
+        dataset_obj: Dataset configuration object
+        dataset_name: Name of the dataset
+        file_ids: List of file IDs from the dataset
+
+    Returns:
+        Combined list of provenance IDs (file IDs + config provenance)
+    """
+    provenance_ids = file_ids.copy()
+
+    provenance = dataset_obj[dataset_name].get("provenance", [])
+
+    if provenance:
+        if not isinstance(provenance, list):
+            raise ValueError(f"Provenance for dataset '{dataset_name}' must be a list")
+        provenance_ids.extend(provenance)
+
+    # Remove duplicates while preserving order
+    return list(dict.fromkeys(provenance_ids))
+
+
 def apply_custom_transformations(
     datasets: Dict[str, Any],
     dataset_name: str,
@@ -142,12 +166,7 @@ def process_dataset(
     """
     dataset_name = list(dataset_obj.keys())[0]
     dataset_report = DatasetReport(data_set=dataset_name)
-    provenance_ids = []
-
-    # get provenance if any
-    provenance = dataset_obj[dataset_name].get("provenance", [])
-    if provenance:
-        provenance_ids.extend(provenance)
+    file_ids = []
 
     entities_as_df = {}
     for entity in dataset_obj[dataset_name]["files"]:
@@ -155,9 +174,8 @@ def process_dataset(
         entity_format = entity["format"]
         entity_name = entity["name"]
 
-        # save file ids for provenance
-        if entity_id not in provenance_ids:
-            provenance_ids.append(entity_id)
+        if entity_id not in file_ids:
+            file_ids.append(entity_id)
 
         df = extract.get_entity_as_df(syn_id=entity_id, source=entity_format, syn=syn)
         df = utils.standardize_column_names(df=df)
@@ -169,6 +187,10 @@ def process_dataset(
             )
 
         entities_as_df[entity_name] = df
+
+    # get provenance if any
+    provenance_ids = get_provenance_ids(dataset_obj, dataset_name, file_ids)
+
     if "custom_transformations" in dataset_obj[dataset_name].keys():
         transform_result = apply_custom_transformations(
             datasets=entities_as_df,

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -173,9 +173,7 @@ def process_dataset(
         entity_id = entity["id"]
         entity_format = entity["format"]
         entity_name = entity["name"]
-
-        if entity_id not in file_ids:
-            file_ids.append(entity_id)
+        file_ids.append(entity_id)
 
         df = extract.get_entity_as_df(syn_id=entity_id, source=entity_format, syn=syn)
         df = utils.standardize_column_names(df=df)

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -32,6 +32,7 @@ def dataset_object_no_provenance():
         }
     }
 
+
 @pytest.fixture
 def dataset_object_with_provenance():
     """Dataset object with provenance configuration."""
@@ -45,6 +46,7 @@ def dataset_object_with_provenance():
         }
     }
 
+
 @pytest.fixture
 def dataset_object_with_duplicated_provenance():
     """Dataset object with duplicated provenance IDs."""
@@ -57,6 +59,8 @@ def dataset_object_with_duplicated_provenance():
             "gx_enabled": False,
         }
     }
+
+
 class TestUploadDataversionMetadata:
     file_id = "syn1111111"
     file_version = "1"
@@ -126,26 +130,42 @@ class TestUploadDataversionMetadata:
             destination=self.destination,
             syn=syn,
         )
+
+
 class TestGetProvenanceIds:
     def test_get_provenance_ids_no_provenance(self, dataset_object_no_provenance):
         """Test that when no provenance is provided in the config, only file ids are returned."""
         file_ids = ["syn1111111"]
         expected_provenance_ids = ["syn1111111"]
-        provenance_ids = process.get_provenance_ids(dataset_object_no_provenance, dataset_name="neuropath_corr", file_ids=file_ids)
+        provenance_ids = process.get_provenance_ids(
+            dataset_object_no_provenance,
+            dataset_name="neuropath_corr",
+            file_ids=file_ids,
+        )
         assert provenance_ids == expected_provenance_ids
 
     def test_get_provenance_ids_with_provenance(self, dataset_object_with_provenance):
         """Test that when provenance is provided in the config, both file ids and provenance ids are returned."""
         file_ids = ["syn1111111"]
         expected_provenance_ids = ["syn1111111", "syn11111145"]
-        provenance_ids = process.get_provenance_ids(dataset_object_with_provenance, dataset_name="neuropath_corr", file_ids=file_ids)
+        provenance_ids = process.get_provenance_ids(
+            dataset_object_with_provenance,
+            dataset_name="neuropath_corr",
+            file_ids=file_ids,
+        )
         assert sorted(provenance_ids) == sorted(expected_provenance_ids)
 
-    def test_get_provenance_ids_with_duplicated_provenance(self, dataset_object_with_duplicated_provenance):
+    def test_get_provenance_ids_with_duplicated_provenance(
+        self, dataset_object_with_duplicated_provenance
+    ):
         """Test that when duplicated provenance is provided as both file id and provenance, unique values are returned."""
         file_ids = ["syn11111145"]
         expected_provenance_ids = ["syn11111145"]
-        provenance_ids = process.get_provenance_ids(dataset_object_with_duplicated_provenance, dataset_name="neuropath_corr", file_ids=file_ids)
+        provenance_ids = process.get_provenance_ids(
+            dataset_object_with_duplicated_provenance,
+            dataset_name="neuropath_corr",
+            file_ids=file_ids,
+        )
         assert provenance_ids == expected_provenance_ids
 
     def test_error_get_provenance_ids_empty_dataset(self):
@@ -160,8 +180,14 @@ class TestGetProvenanceIds:
                 "gx_enabled": False,
             }
         }
-        with pytest.raises(ValueError, match="Provenance for dataset 'neuropath_corr' must be a list"):
-            process.get_provenance_ids(wrong_format_dataset_obj, dataset_name="neuropath_corr", file_ids=file_ids)
+        with pytest.raises(
+            ValueError, match="Provenance for dataset 'neuropath_corr' must be a list"
+        ):
+            process.get_provenance_ids(
+                wrong_format_dataset_obj,
+                dataset_name="neuropath_corr",
+                file_ids=file_ids,
+            )
 
 
 class TestProcessProvenance:
@@ -192,7 +218,9 @@ class TestProcessProvenance:
         self.patch_load.stop()
         mock.patch.stopall()
 
-    def test_upload_data_without_provenance(self, syn: Any, dataset_object_no_provenance):
+    def test_upload_data_without_provenance(
+        self, syn: Any, dataset_object_no_provenance
+    ):
         """Test that when no provenance is provided in the config, the file id is used as provenance."""
         # WHEN I call upload_data_without_provenance
         process.process_dataset(
@@ -206,13 +234,13 @@ class TestProcessProvenance:
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn1111111"],
-            destination=dataset_object_no_provenance["neuropath_corr"][
-                "destination"
-            ],
+            destination=dataset_object_no_provenance["neuropath_corr"]["destination"],
             syn=syn,
         )
 
-    def test_upload_data_with_provenance(self, syn: Any, dataset_object_with_provenance):
+    def test_upload_data_with_provenance(
+        self, syn: Any, dataset_object_with_provenance
+    ):
         """Test that when provenance is provided in the config, it is used in the upload."""
         # WHEN I call upload_data_with_provenance
         process.process_dataset(
@@ -226,13 +254,13 @@ class TestProcessProvenance:
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn1111111", "syn11111145"],
-            destination=dataset_object_with_provenance["neuropath_corr"][
-                "destination"
-            ],
+            destination=dataset_object_with_provenance["neuropath_corr"]["destination"],
             syn=syn,
         )
 
-    def test_upload_data_with_duplicated_provenance(self, syn: Any, dataset_object_with_duplicated_provenance):
+    def test_upload_data_with_duplicated_provenance(
+        self, syn: Any, dataset_object_with_duplicated_provenance
+    ):
         """Test that when duplicated provenance is provided in the config, unique values are used in the upload."""
         # WHEN I call upload_data_with_duplicated_provenance
         process.process_dataset(
@@ -246,9 +274,9 @@ class TestProcessProvenance:
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn11111145"],
-            destination=dataset_object_with_duplicated_provenance[
-                "neuropath_corr"
-            ]["destination"],
+            destination=dataset_object_with_duplicated_provenance["neuropath_corr"][
+                "destination"
+            ],
             syn=syn,
         )
 

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -180,7 +180,7 @@ class TestProcessProvenance:
         # THEN I expect the load function to be called with file id and provenance from config
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
-            provenance=["syn11111145", "syn1111111"],
+            provenance=["syn1111111", "syn11111145"],
             destination=self.dataset_object_with_provenance["neuropath_corr"][
                 "destination"
             ],
@@ -195,13 +195,13 @@ class TestProcessProvenance:
             staging_path=STAGING_PATH,
             gx_folder=GX_FOLDER,
             upload=True,
-            dataset_obj=self.dataset_object_with_duplicated_provenance,
+            dataset_obj=self.dataset_object_with_duplicated_provenance_in_file_id,
         )
         # THEN I expect the load function to be called with file id and unique provenance from config
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn11111145"],
-            destination=self.dataset_object_with_duplicated_provenance[
+            destination=self.dataset_object_with_duplicated_provenance_in_file_id[
                 "neuropath_corr"
             ]["destination"],
             syn=syn,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -164,6 +164,55 @@ class TestUploadDataversionMetadata:
         )
 
 
+class TestCheckProvenanceIdFileIdConsistency:
+    """Test suite for check_provenance_id_file_id_consistency function."""
+
+    def test_no_provenance_ids(self):
+        """Test that empty provenance list returns without error."""
+        file_ids = ["syn123.4", "syn456.2"]
+        provenance_ids = []
+        
+        # Should not raise any exception
+        process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
+
+    def test_both_lists_empty(self):
+        """Test with both lists empty."""
+        file_ids = []
+        provenance_ids = []
+        
+        # Should not raise
+        process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
+
+    def test_matching_versions(self):
+        """Test that matching versions pass validation."""
+        file_ids = ["syn123.4", "syn456.2"]
+        provenance_ids = ["syn123.4", "syn789.1"]
+        
+        # Should not raise any exception
+        process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
+
+    def test_no_overlap_between_ids(self):
+        """Test that non-overlapping IDs pass validation."""
+        file_ids = ["syn123.4", "syn456.2"]
+        provenance_ids = ["syn789.1", "syn999.3"]  # No overlap
+        
+        # Should not raise any exception
+        process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
+
+    def test_version_mismatch_raises_error(self):
+        """Test that different versions for same entity raise ValueError."""
+        file_ids = ["syn123.4", "syn456.2"]
+        provenance_ids = ["syn123.5", "syn789.1"]  # syn123 versions differ
+        
+        with pytest.raises(ValueError) as exc_info:
+            process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
+        
+        assert "Version mismatch" in str(exc_info.value)
+        assert "syn123.5" in str(exc_info.value)
+        assert "syn123.4" in str(exc_info.value)
+
+ 
+
 class TestGetProvenanceIds:
     def test_get_provenance_ids_no_provenance(
         self, dataset_object_no_provenance: dict[str, Any]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -32,6 +32,18 @@ def dataset_object_no_provenance():
         }
     }
 
+@pytest.fixture
+def dataset_provenance_file_ids_mismatch():
+    """Dataset object with mismatched provenance and file IDs."""
+    return {
+        "neuropath_corr": {
+            "files": [{"name": "test_file_1", "id": "syn1111111.1", "format": "csv"}],
+            "final_format": "json",
+            "provenance": ["syn1111111.18"],
+            "destination": "syn1111113",
+            "gx_enabled": False,
+        }
+    }
 
 @pytest.fixture
 def dataset_object_with_provenance():
@@ -228,6 +240,20 @@ class TestGetProvenanceIds:
             file_ids=file_ids,
         )
         assert sorted(provenance_ids) == sorted(expected_provenance_ids)
+
+    def test_get_provenance_ids_mismatch_file_ids_version(
+        self, dataset_provenance_file_ids_mismatch: dict[str, Any]
+    ) -> None:
+        """Test that when file IDs and provenance IDs have mismatched versions, an error is raised."""
+        file_ids = ["syn1111111.1"]
+        with pytest.raises(
+            ValueError, match="Version mismatch: "
+        ):
+            process.get_provenance_ids(
+                dataset_provenance_file_ids_mismatch,
+                dataset_name="neuropath_corr",
+                file_ids=file_ids,
+            )
 
 
 class TestProcessProvenance:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -293,8 +293,13 @@ class TestProcessProvenance:
         # THEN I expect the load function to be called with file id and provenance from config
         call_args = self.patch_load.call_args
         assert call_args[1]["file_path"] == "path/to/json"
-        assert sorted(call_args[1]["provenance"]) == sorted(["syn1111111", "syn11111145"])
-        assert call_args[1]["destination"] == dataset_object_with_provenance["neuropath_corr"]["destination"]
+        assert sorted(call_args[1]["provenance"]) == sorted(
+            ["syn1111111", "syn11111145"]
+        )
+        assert (
+            call_args[1]["destination"]
+            == dataset_object_with_provenance["neuropath_corr"]["destination"]
+        )
 
     def test_upload_data_with_duplicated_provenance(
         self, syn: Any, dataset_object_with_duplicated_provenance: dict[str, Any]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -32,6 +32,7 @@ def dataset_object_no_provenance():
         }
     }
 
+
 @pytest.fixture
 def dataset_provenance_file_ids_mismatch():
     """Dataset object with mismatched provenance and file IDs."""
@@ -44,6 +45,7 @@ def dataset_provenance_file_ids_mismatch():
             "gx_enabled": False,
         }
     }
+
 
 @pytest.fixture
 def dataset_object_with_provenance():
@@ -246,9 +248,7 @@ class TestGetProvenanceIds:
     ) -> None:
         """Test that when file IDs and provenance IDs have mismatched versions, an error is raised."""
         file_ids = ["syn1111111.1"]
-        with pytest.raises(
-            ValueError, match="Version mismatch: "
-        ):
+        with pytest.raises(ValueError, match="Version mismatch: "):
             process.get_provenance_ids(
                 dataset_provenance_file_ids_mismatch,
                 dataset_name="neuropath_corr",

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -20,6 +20,43 @@ STAGING_PATH = "./staging"
 GX_FOLDER = "test_folder"
 
 
+@pytest.fixture
+def dataset_object_no_provenance():
+    """Dataset object without provenance configuration."""
+    return {
+        "neuropath_corr": {
+            "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
+            "final_format": "json",
+            "destination": "syn1111113",
+            "gx_enabled": False,
+        }
+    }
+
+@pytest.fixture
+def dataset_object_with_provenance():
+    """Dataset object with provenance configuration."""
+    return {
+        "neuropath_corr": {
+            "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
+            "final_format": "json",
+            "provenance": ["syn11111145"],
+            "destination": "syn1111113",
+            "gx_enabled": False,
+        }
+    }
+
+@pytest.fixture
+def dataset_object_with_duplicated_provenance():
+    """Dataset object with duplicated provenance IDs."""
+    return {
+        "neuropath_corr": {
+            "files": [{"name": "test_file_1", "id": "syn11111145", "format": "csv"}],
+            "final_format": "json",
+            "provenance": ["syn11111145", "syn11111145"],
+            "destination": "syn1111113",
+            "gx_enabled": False,
+        }
+    }
 class TestUploadDataversionMetadata:
     file_id = "syn1111111"
     file_version = "1"
@@ -89,37 +126,45 @@ class TestUploadDataversionMetadata:
             destination=self.destination,
             syn=syn,
         )
+class TestGetProvenanceIds:
+    def test_get_provenance_ids_no_provenance(self, dataset_object_no_provenance):
+        """Test that when no provenance is provided in the config, only file ids are returned."""
+        file_ids = ["syn1111111"]
+        expected_provenance_ids = ["syn1111111"]
+        provenance_ids = process.get_provenance_ids(dataset_object_no_provenance, dataset_name="neuropath_corr", file_ids=file_ids)
+        assert provenance_ids == expected_provenance_ids
+
+    def test_get_provenance_ids_with_provenance(self, dataset_object_with_provenance):
+        """Test that when provenance is provided in the config, both file ids and provenance ids are returned."""
+        file_ids = ["syn1111111"]
+        expected_provenance_ids = ["syn1111111", "syn11111145"]
+        provenance_ids = process.get_provenance_ids(dataset_object_with_provenance, dataset_name="neuropath_corr", file_ids=file_ids)
+        assert sorted(provenance_ids) == sorted(expected_provenance_ids)
+
+    def test_get_provenance_ids_with_duplicated_provenance(self, dataset_object_with_duplicated_provenance):
+        """Test that when duplicated provenance is provided as both file id and provenance, unique values are returned."""
+        file_ids = ["syn11111145"]
+        expected_provenance_ids = ["syn11111145"]
+        provenance_ids = process.get_provenance_ids(dataset_object_with_duplicated_provenance, dataset_name="neuropath_corr", file_ids=file_ids)
+        assert provenance_ids == expected_provenance_ids
+
+    def test_error_get_provenance_ids_empty_dataset(self):
+        """Test that an error is raised when the dataset object is empty."""
+        file_ids = ["syn1111111"]
+        wrong_format_dataset_obj = {
+            "neuropath_corr": {
+                "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
+                "final_format": "json",
+                "provenance": "not a list",
+                "destination": "syn1111113",
+                "gx_enabled": False,
+            }
+        }
+        with pytest.raises(ValueError, match="Provenance for dataset 'neuropath_corr' must be a list"):
+            process.get_provenance_ids(wrong_format_dataset_obj, dataset_name="neuropath_corr", file_ids=file_ids)
 
 
 class TestProcessProvenance:
-    dataset_object_no_provenance = {
-        "neuropath_corr": {
-            "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
-            "final_format": "json",
-            "destination": "syn1111113",
-            "gx_enabled": False,
-        }
-    }
-    dataset_object_with_provenance = {
-        "neuropath_corr": {
-            "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
-            "final_format": "json",
-            "provenance": ["syn11111145"],
-            "destination": "syn1111113",
-            "gx_enabled": False,
-        }
-    }
-
-    dataset_object_with_duplicated_provenance_in_file_id = {
-        "neuropath_corr": {
-            "files": [{"name": "test_file_1", "id": "syn11111145", "format": "csv"}],
-            "final_format": "json",
-            "provenance": ["syn11111145", "syn11111145"],
-            "destination": "syn1111113",
-            "gx_enabled": False,
-        }
-    }
-
     def setup_method(self):
         self.patch_get_entity_as_df = patch.object(
             extract, "get_entity_as_df", return_value=pd.DataFrame
@@ -147,7 +192,7 @@ class TestProcessProvenance:
         self.patch_load.stop()
         mock.patch.stopall()
 
-    def test_upload_data_without_provenance(self, syn: Any):
+    def test_upload_data_without_provenance(self, syn: Any, dataset_object_no_provenance):
         """Test that when no provenance is provided in the config, the file id is used as provenance."""
         # WHEN I call upload_data_without_provenance
         process.process_dataset(
@@ -155,19 +200,19 @@ class TestProcessProvenance:
             staging_path=STAGING_PATH,
             gx_folder=GX_FOLDER,
             upload=True,
-            dataset_obj=self.dataset_object_no_provenance,
+            dataset_obj=dataset_object_no_provenance,
         )
         # THEN I expect the load function to be called with file id
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn1111111"],
-            destination=self.dataset_object_no_provenance["neuropath_corr"][
+            destination=dataset_object_no_provenance["neuropath_corr"][
                 "destination"
             ],
             syn=syn,
         )
 
-    def test_upload_data_with_provenance(self, syn: Any):
+    def test_upload_data_with_provenance(self, syn: Any, dataset_object_with_provenance):
         """Test that when provenance is provided in the config, it is used in the upload."""
         # WHEN I call upload_data_with_provenance
         process.process_dataset(
@@ -175,19 +220,19 @@ class TestProcessProvenance:
             staging_path=STAGING_PATH,
             gx_folder=GX_FOLDER,
             upload=True,
-            dataset_obj=self.dataset_object_with_provenance,
+            dataset_obj=dataset_object_with_provenance,
         )
         # THEN I expect the load function to be called with file id and provenance from config
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn1111111", "syn11111145"],
-            destination=self.dataset_object_with_provenance["neuropath_corr"][
+            destination=dataset_object_with_provenance["neuropath_corr"][
                 "destination"
             ],
             syn=syn,
         )
 
-    def test_upload_data_with_duplicated_provenance(self, syn: Any):
+    def test_upload_data_with_duplicated_provenance(self, syn: Any, dataset_object_with_duplicated_provenance):
         """Test that when duplicated provenance is provided in the config, unique values are used in the upload."""
         # WHEN I call upload_data_with_duplicated_provenance
         process.process_dataset(
@@ -195,13 +240,13 @@ class TestProcessProvenance:
             staging_path=STAGING_PATH,
             gx_folder=GX_FOLDER,
             upload=True,
-            dataset_obj=self.dataset_object_with_duplicated_provenance_in_file_id,
+            dataset_obj=dataset_object_with_duplicated_provenance,
         )
         # THEN I expect the load function to be called with file id and unique provenance from config
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn11111145"],
-            destination=self.dataset_object_with_duplicated_provenance_in_file_id[
+            destination=dataset_object_with_duplicated_provenance[
                 "neuropath_corr"
             ]["destination"],
             syn=syn,

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -171,7 +171,7 @@ class TestCheckProvenanceIdFileIdConsistency:
         """Test that empty provenance list returns without error."""
         file_ids = ["syn123.4", "syn456.2"]
         provenance_ids = []
-        
+
         # Should not raise any exception
         process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
 
@@ -179,7 +179,7 @@ class TestCheckProvenanceIdFileIdConsistency:
         """Test with both lists empty."""
         file_ids = []
         provenance_ids = []
-        
+
         # Should not raise
         process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
 
@@ -187,7 +187,7 @@ class TestCheckProvenanceIdFileIdConsistency:
         """Test that matching versions pass validation."""
         file_ids = ["syn123.4", "syn456.2"]
         provenance_ids = ["syn123.4", "syn789.1"]
-        
+
         # Should not raise any exception
         process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
 
@@ -195,7 +195,7 @@ class TestCheckProvenanceIdFileIdConsistency:
         """Test that non-overlapping IDs pass validation."""
         file_ids = ["syn123.4", "syn456.2"]
         provenance_ids = ["syn789.1", "syn999.3"]  # No overlap
-        
+
         # Should not raise any exception
         process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
 
@@ -203,15 +203,14 @@ class TestCheckProvenanceIdFileIdConsistency:
         """Test that different versions for same entity raise ValueError."""
         file_ids = ["syn123.4", "syn456.2"]
         provenance_ids = ["syn123.5", "syn789.1"]  # syn123 versions differ
-        
+
         with pytest.raises(ValueError) as exc_info:
             process.check_provenance_id_file_id_consistency(provenance_ids, file_ids)
-        
+
         assert "Version mismatch" in str(exc_info.value)
         assert "syn123.5" in str(exc_info.value)
         assert "syn123.4" in str(exc_info.value)
 
- 
 
 class TestGetProvenanceIds:
     def test_get_provenance_ids_no_provenance(

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -153,7 +153,7 @@ class TestUploadDataversionMetadata:
 class TestGetProvenanceIds:
     def test_get_provenance_ids_no_provenance(
         self, dataset_object_no_provenance: dict[str, Any]
-    ):
+    ) -> None:
         """Test that when no provenance is provided in the config, only file ids are returned."""
         file_ids = ["syn1111111"]
         expected_provenance_ids = ["syn1111111"]
@@ -166,7 +166,7 @@ class TestGetProvenanceIds:
 
     def test_get_provenance_ids_with_provenance(
         self, dataset_object_with_provenance: dict[str, Any]
-    ):
+    ) -> None:
         """Test that when provenance is provided in the config, both file ids and provenance ids are returned."""
         file_ids = ["syn1111111"]
         expected_provenance_ids = ["syn1111111", "syn11111145"]
@@ -179,7 +179,7 @@ class TestGetProvenanceIds:
 
     def test_get_provenance_ids_with_duplicated_provenance(
         self, dataset_object_with_duplicated_provenance: dict[str, Any]
-    ):
+    ) -> None:
         """Test that when duplicated provenance is provided as both file id and provenance, unique values are returned."""
         file_ids = ["syn11111145"]
         expected_provenance_ids = ["syn11111145"]
@@ -190,7 +190,7 @@ class TestGetProvenanceIds:
         )
         assert provenance_ids == expected_provenance_ids
 
-    def test_error_get_provenance_ids_empty_dataset(self):
+    def test_error_get_provenance_ids_empty_dataset(self) -> None:
         """Test that an error is raised when the dataset object is empty."""
         file_ids = ["syn1111111"]
         wrong_format_dataset_obj = {
@@ -213,7 +213,7 @@ class TestGetProvenanceIds:
 
     def test_get_provenance_ids_mixed_list(
         self, dataset_object_provenance_mix_list: dict[str, Any]
-    ):
+    ) -> None:
         """Test that when provenance is provided as a mix of lists and strings, all values are flattened and returned."""
         file_ids = ["syn1111111"]
         expected_provenance_ids = [
@@ -260,7 +260,7 @@ class TestProcessProvenance:
 
     def test_upload_data_without_provenance(
         self, syn: Any, dataset_object_no_provenance: dict[str, Any]
-    ):
+    ) -> None:
         """Test that when no provenance is provided in the config, the file id is used as provenance."""
         # WHEN I call upload_data_without_provenance
         process.process_dataset(
@@ -280,7 +280,7 @@ class TestProcessProvenance:
 
     def test_upload_data_with_provenance(
         self, syn: Any, dataset_object_with_provenance: dict[str, Any]
-    ):
+    ) -> None:
         """Test that when provenance is provided in the config, it is used in the upload."""
         # WHEN I call upload_data_with_provenance
         process.process_dataset(
@@ -300,7 +300,7 @@ class TestProcessProvenance:
 
     def test_upload_data_with_duplicated_provenance(
         self, syn: Any, dataset_object_with_duplicated_provenance: dict[str, Any]
-    ):
+    ) -> None:
         """Test that when duplicated provenance is provided in the config, unique values are used in the upload."""
         # WHEN I call upload_data_with_duplicated_provenance
         process.process_dataset(
@@ -322,7 +322,7 @@ class TestProcessProvenance:
 
     def test_get_provenance_ids_mixed_list(
         self, dataset_object_provenance_mix_list: dict[str, Any]
-    ):
+    ) -> None:
         """Test that when provenance is provided as a mix of lists and strings, all values are flattened and returned."""
         file_ids = ["syn1111111"]
         expected_provenance_ids = [

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -108,6 +108,16 @@ class TestProcessProvenance:
         }
     }
 
+    dataset_object_with_duplicated_provenance_in_file_id = {
+        "neuropath_corr": {
+            "files": [{"name": "test_file_1", "id": "syn11111145", "format": "csv"}],
+            "final_format": "json",
+            "provenance": ["syn11111145"],
+            "destination": "syn1111113",
+            "gx_enabled": False,
+        }
+    }
+
     def setup_method(self):
         self.patch_get_entity_as_df = patch.object(
             extract, "get_entity_as_df", return_value=pd.DataFrame
@@ -136,6 +146,7 @@ class TestProcessProvenance:
         mock.patch.stopall()
 
     def test_upload_data_without_provenance(self, syn: Any):
+        """Test that when no provenance is provided in the config, the file id is used as provenance."""
         # WHEN I call upload_data_without_provenance
         process.process_dataset(
             syn=syn,
@@ -153,7 +164,8 @@ class TestProcessProvenance:
         )
 
     def test_upload_data_with_provenance(self, syn: Any):
-        # WHEN I call upload_data_without_provenance
+        """Test that when provenance is provided in the config, it is used in the upload."""
+        # WHEN I call upload_data_with_provenance
         process.process_dataset(
             syn=syn,
             staging_path=STAGING_PATH,
@@ -168,6 +180,25 @@ class TestProcessProvenance:
             destination=self.dataset_object_with_provenance["neuropath_corr"]["destination"],
             syn=syn
         )
+    
+    def test_upload_data_with_duplicated_provenance(self, syn:Any):
+        """Test that when duplicated provenance is provided in the config, unique values are used in the upload."""
+        # WHEN I call upload_data_with_duplicated_provenance
+        process.process_dataset(
+            syn=syn,
+            staging_path=STAGING_PATH,
+            gx_folder=GX_FOLDER,
+            upload=True,
+            dataset_obj=self.dataset_object_with_duplicated_provenance,
+        )
+        # THEN I expect the load function to be called with file id and unique provenance from config
+        self.patch_load.assert_called_once_with(
+            file_path="path/to/json",
+            provenance=["syn11111145"],
+            destination=self.dataset_object_with_duplicated_provenance["neuropath_corr"]["destination"],
+            syn=syn
+        )
+
 
 class TestApplyCustomTransformations:
     """Test the apply_custom_transformations function."""

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -114,7 +114,7 @@ class TestProcessProvenance:
         "neuropath_corr": {
             "files": [{"name": "test_file_1", "id": "syn11111145", "format": "csv"}],
             "final_format": "json",
-            "provenance": ["syn11111145"],
+            "provenance": ["syn11111145", "syn11111145"],
             "destination": "syn1111113",
             "gx_enabled": False,
         }

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -61,6 +61,24 @@ def dataset_object_with_duplicated_provenance():
     }
 
 
+@pytest.fixture
+def dataset_object_provenance_mix_list():
+    """Dataset object with mixed provenance configuration."""
+    return {
+        "neuropath_corr": {
+            "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
+            "final_format": "json",
+            "destination": "syn1111113",
+            "provenance": [
+                ["syn11111145", "syn11111145"],
+                ["syn11111146"],
+                "syn11111147",
+            ],
+            "gx_enabled": False,
+        }
+    }
+
+
 class TestUploadDataversionMetadata:
     file_id = "syn1111111"
     file_version = "1"
@@ -133,7 +151,9 @@ class TestUploadDataversionMetadata:
 
 
 class TestGetProvenanceIds:
-    def test_get_provenance_ids_no_provenance(self, dataset_object_no_provenance):
+    def test_get_provenance_ids_no_provenance(
+        self, dataset_object_no_provenance: dict[str, Any]
+    ):
         """Test that when no provenance is provided in the config, only file ids are returned."""
         file_ids = ["syn1111111"]
         expected_provenance_ids = ["syn1111111"]
@@ -144,7 +164,9 @@ class TestGetProvenanceIds:
         )
         assert provenance_ids == expected_provenance_ids
 
-    def test_get_provenance_ids_with_provenance(self, dataset_object_with_provenance):
+    def test_get_provenance_ids_with_provenance(
+        self, dataset_object_with_provenance: dict[str, Any]
+    ):
         """Test that when provenance is provided in the config, both file ids and provenance ids are returned."""
         file_ids = ["syn1111111"]
         expected_provenance_ids = ["syn1111111", "syn11111145"]
@@ -156,7 +178,7 @@ class TestGetProvenanceIds:
         assert sorted(provenance_ids) == sorted(expected_provenance_ids)
 
     def test_get_provenance_ids_with_duplicated_provenance(
-        self, dataset_object_with_duplicated_provenance
+        self, dataset_object_with_duplicated_provenance: dict[str, Any]
     ):
         """Test that when duplicated provenance is provided as both file id and provenance, unique values are returned."""
         file_ids = ["syn11111145"]
@@ -189,6 +211,24 @@ class TestGetProvenanceIds:
                 file_ids=file_ids,
             )
 
+    def test_get_provenance_ids_mixed_list(
+        self, dataset_object_provenance_mix_list: dict[str, Any]
+    ):
+        """Test that when provenance is provided as a mix of lists and strings, all values are flattened and returned."""
+        file_ids = ["syn1111111"]
+        expected_provenance_ids = [
+            "syn1111111",
+            "syn11111145",
+            "syn11111146",
+            "syn11111147",
+        ]
+        provenance_ids = process.get_provenance_ids(
+            dataset_object_provenance_mix_list,
+            dataset_name="neuropath_corr",
+            file_ids=file_ids,
+        )
+        assert sorted(provenance_ids) == sorted(expected_provenance_ids)
+
 
 class TestProcessProvenance:
     def setup_method(self):
@@ -219,7 +259,7 @@ class TestProcessProvenance:
         mock.patch.stopall()
 
     def test_upload_data_without_provenance(
-        self, syn: Any, dataset_object_no_provenance
+        self, syn: Any, dataset_object_no_provenance: dict[str, Any]
     ):
         """Test that when no provenance is provided in the config, the file id is used as provenance."""
         # WHEN I call upload_data_without_provenance
@@ -239,7 +279,7 @@ class TestProcessProvenance:
         )
 
     def test_upload_data_with_provenance(
-        self, syn: Any, dataset_object_with_provenance
+        self, syn: Any, dataset_object_with_provenance: dict[str, Any]
     ):
         """Test that when provenance is provided in the config, it is used in the upload."""
         # WHEN I call upload_data_with_provenance
@@ -259,7 +299,7 @@ class TestProcessProvenance:
         )
 
     def test_upload_data_with_duplicated_provenance(
-        self, syn: Any, dataset_object_with_duplicated_provenance
+        self, syn: Any, dataset_object_with_duplicated_provenance: dict[str, Any]
     ):
         """Test that when duplicated provenance is provided in the config, unique values are used in the upload."""
         # WHEN I call upload_data_with_duplicated_provenance
@@ -279,6 +319,24 @@ class TestProcessProvenance:
             ],
             syn=syn,
         )
+
+    def test_get_provenance_ids_mixed_list(
+        self, dataset_object_provenance_mix_list: dict[str, Any]
+    ):
+        """Test that when provenance is provided as a mix of lists and strings, all values are flattened and returned."""
+        file_ids = ["syn1111111"]
+        expected_provenance_ids = [
+            "syn1111111",
+            "syn11111145",
+            "syn11111146",
+            "syn11111147",
+        ]
+        provenance_ids = process.get_provenance_ids(
+            dataset_object_provenance_mix_list,
+            dataset_name="neuropath_corr",
+            file_ids=file_ids,
+        )
+        assert sorted(provenance_ids) == sorted(expected_provenance_ids)
 
 
 class TestApplyCustomTransformations:

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -89,7 +89,85 @@ class TestUploadDataversionMetadata:
             destination=self.destination,
             syn=syn,
         )
+class TestProcessProvenance:
+    dataset_object_no_provenance = {
+        "neuropath_corr": {
+            "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
+            "final_format": "json",
+            "destination": "syn1111113",
+            "gx_enabled": False,
+        }
+    }
+    dataset_object_with_provenance = {
+        "neuropath_corr": {
+            "files": [{"name": "test_file_1", "id": "syn1111111", "format": "csv"}],
+            "final_format": "json",
+            "provenance": ["syn11111145"],
+            "destination": "syn1111113",
+            "gx_enabled": False,
+        }
+    }
 
+    def setup_method(self):
+        self.patch_get_entity_as_df = patch.object(
+            extract, "get_entity_as_df", return_value=pd.DataFrame
+        ).start()
+        self.patch_standardize_column_names = patch.object(
+            utils, "standardize_column_names", return_value=pd.DataFrame
+        ).start()
+        self.patch_standardize_values = patch.object(
+            utils, "standardize_values", return_value=pd.DataFrame
+        ).start()
+        self.patch_df_to_json = patch.object(
+            load, "df_to_json", return_value="path/to/json"
+        ).start()
+        self.patch_dict_to_json = patch.object(
+            load, "dict_to_json", return_value="path/to/json"
+        ).start()
+        self.patch_load = patch.object(load, "load", return_value=("syn123", 1)).start()
+
+    def teardown_method(self):
+        self.patch_get_entity_as_df.stop()
+        self.patch_standardize_column_names.stop()
+        self.patch_standardize_values.stop()
+        self.patch_df_to_json.stop()
+        self.patch_dict_to_json.stop()
+        self.patch_load.stop()
+        mock.patch.stopall()
+
+    def test_upload_data_without_provenance(self, syn: Any):
+        # WHEN I call upload_data_without_provenance
+        process.process_dataset(
+            syn=syn,
+            staging_path=STAGING_PATH,
+            gx_folder=GX_FOLDER,
+            upload=True,
+            dataset_obj=self.dataset_object_no_provenance,
+        )
+        # THEN I expect the load function to be called with file id
+        self.patch_load.assert_called_once_with(
+            file_path="path/to/json",
+            provenance=["syn1111111"],
+            destination=self.dataset_object_no_provenance["neuropath_corr"]["destination"],
+            syn=syn
+        )
+
+    def test_upload_data_with_provenance(self, syn: Any):
+        # WHEN I call upload_data_without_provenance
+        process.process_dataset(
+            syn=syn,
+            staging_path=STAGING_PATH,
+            gx_folder=GX_FOLDER,
+            upload=True,
+            dataset_obj=self.dataset_object_with_provenance,
+        )
+        # THEN I expect the load function to be called with file id and provenance from config
+        self.patch_load.assert_called_once_with(
+            file_path="path/to/json",
+            provenance=["syn11111145", "syn1111111"],
+            destination=self.dataset_object_with_provenance["neuropath_corr"]["destination"],
+            syn=syn
+        )
 
 class TestApplyCustomTransformations:
     """Test the apply_custom_transformations function."""

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -291,12 +291,10 @@ class TestProcessProvenance:
             dataset_obj=dataset_object_with_provenance,
         )
         # THEN I expect the load function to be called with file id and provenance from config
-        self.patch_load.assert_called_once_with(
-            file_path="path/to/json",
-            provenance=["syn1111111", "syn11111145"],
-            destination=dataset_object_with_provenance["neuropath_corr"]["destination"],
-            syn=syn,
-        )
+        call_args = self.patch_load.call_args
+        assert call_args[1]["file_path"] == "path/to/json"
+        assert sorted(call_args[1]["provenance"]) == sorted(["syn1111111", "syn11111145"])
+        assert call_args[1]["destination"] == dataset_object_with_provenance["neuropath_corr"]["destination"]
 
     def test_upload_data_with_duplicated_provenance(
         self, syn: Any, dataset_object_with_duplicated_provenance: dict[str, Any]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -89,6 +89,8 @@ class TestUploadDataversionMetadata:
             destination=self.destination,
             syn=syn,
         )
+
+
 class TestProcessProvenance:
     dataset_object_no_provenance = {
         "neuropath_corr": {
@@ -159,8 +161,10 @@ class TestProcessProvenance:
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn1111111"],
-            destination=self.dataset_object_no_provenance["neuropath_corr"]["destination"],
-            syn=syn
+            destination=self.dataset_object_no_provenance["neuropath_corr"][
+                "destination"
+            ],
+            syn=syn,
         )
 
     def test_upload_data_with_provenance(self, syn: Any):
@@ -177,11 +181,13 @@ class TestProcessProvenance:
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn11111145", "syn1111111"],
-            destination=self.dataset_object_with_provenance["neuropath_corr"]["destination"],
-            syn=syn
+            destination=self.dataset_object_with_provenance["neuropath_corr"][
+                "destination"
+            ],
+            syn=syn,
         )
-    
-    def test_upload_data_with_duplicated_provenance(self, syn:Any):
+
+    def test_upload_data_with_duplicated_provenance(self, syn: Any):
         """Test that when duplicated provenance is provided in the config, unique values are used in the upload."""
         # WHEN I call upload_data_with_duplicated_provenance
         process.process_dataset(
@@ -195,8 +201,10 @@ class TestProcessProvenance:
         self.patch_load.assert_called_once_with(
             file_path="path/to/json",
             provenance=["syn11111145"],
-            destination=self.dataset_object_with_duplicated_provenance["neuropath_corr"]["destination"],
-            syn=syn
+            destination=self.dataset_object_with_duplicated_provenance[
+                "neuropath_corr"
+            ]["destination"],
+            syn=syn,
         )
 
 


### PR DESCRIPTION
# Problem
Users have to duplicate file ids for provenance in the config. See more detailed description in the ticket: https://sagebionetworks.jira.com/browse/AG-1813

# Solution
Allow provenance to be auto populated and additional provenance to be specified in the config. 

# Test
* Create a new virtual environment and install synapse python client 4.10: https://python-docs.synapse.org/en/stable/tutorials/installation/
* Create your own test project on Synapse with two separate folders. Name one folder: "dev" and another folder "ag-1813". 
* Check out the dev branch and update agora pre-prod config to point to your **dev folder**. Then, run `adt configs/agora_preprod.yaml --upload`
* Check out this branch and update agora pre-prod config to point to your **ag-1813 folder**. Then, run `adt configs/agora_preprod.yaml --upload`
* Make sure that provenances are the same in both folder using synapse
* Use the code below to test

```
import asyncio
from synapseclient import Synapse
from synapseclient.api import get_children, get_entity_provenance, get_entity
from synapseclient.models import File

syn = Synapse()
syn.login()

DEV_BRANCH_FOLDER = ""
TESTING_BRANCH_FOLDER = ""

async def build_child_dict(parent):
    branch_provenance = {}
    async for child in get_children(parent=parent):
        if child["type"] != "org.sagebionetworks.repo.model.FileEntity":
            continue
        entity_info = await get_entity_provenance(child['id'])
        entity_used = entity_info["used"]
        for info in entity_used:
            provenance = info.get('reference', {})
            if child["id"] not in branch_provenance:
                branch_provenance[child["name"]] = [provenance]
            else:
                branch_provenance[child["name"]].append(provenance)
    return branch_provenance

def list_comparison(dev_list, test_list):
    dev_set = set((item['targetId'], item.get('versionNumber')) for item in dev_list)
    test_set = set((item['targetId'], item.get('versionNumber')) for item in test_list)
    
    only_in_dev = dev_set - test_set
    only_in_test = test_set - dev_set
    
    return only_in_dev, only_in_test

async def main():
    dev_branch_provenance = await build_child_dict(DEV_BRANCH_FOLDER)
    test_branch_provenance = await build_child_dict(TESTING_BRANCH_FOLDER)

    for child_name, dev_provenance in dev_branch_provenance.items():
        if child_name in test_branch_provenance:
            testing_provenance = test_branch_provenance[child_name]
            only_dev, only_test = list_comparison(dev_list=dev_provenance, test_list=testing_provenance)
            if only_dev or only_test:
                print(f"Provenance mismatch for {child_name}:")
                print(f"  Dev provenance: {only_dev}")
                print(f"  Testing provenance: {only_test}")
            else:
                print(f"Provenance match for {child_name}.")

asyncio.run(main())
```
I saw: 
```
Welcome, Lingling Peng! You are using the 'default' profile.
Provenance match for biodomain_info.json.
Provenance mismatch for data_manifest.csv:
  Dev provenance: {('syn71062219', None)}
  Testing provenance: {('syn71057907', None)}
Provenance mismatch for dataversion.json:
  Dev provenance: {('syn71062234', None)}
  Testing provenance: {('syn71057910', None)}
Provenance match for distribution_data.json.
Provenance match for gene_info.json.
Provenance match for genes_biodomains.json.
Provenance match for metabolomics.json.
Provenance match for network.json.
Provenance match for neuropath_corr.json.
Provenance match for overall_scores.json.
Provenance match for proteomics.json.
Provenance match for proteomics_distribution_data.json.
Provenance match for proteomics_srm.json.
Provenance match for proteomics_tmt.json.
Provenance match for rna_distribution_data.json.
Provenance match for rnaseq_differential_expression.json.
Provenance match for target_exp_validation_harmonized.json.
Provenance match for team_info.json.
```
`data_manifest.csv` and `dataversion.json` are not actually dataset files listed in the config so they can be ignored. 