### PR TITLE
MG-520: gene_expression transforms convert NaN p-values to 0s

### DIFF
--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -231,8 +231,8 @@ def transform_rna_de_aggregate(
             for row in group.itertuples(index=False):
                 age = str(row.age)
                 age_entries[age] = {
-                    "log2_fc": float(row.log2foldchange),
-                    "adj_p_val": 0.0 if pd.isna(row.padj) else float(row.padj),
+                    "log2_fc": float(row.log2foldchange) + 0.0,
+                    "adj_p_val": 0.0 if pd.isna(row.padj) else float(row.padj) + 0.0,
                 }
 
             # Validate and sort age entries

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -142,10 +142,10 @@ def _create_age_entries_from_group(
 
 
 def _create_output_entry_from_group(
-    group_key: tuple,
+    group_key: tuple[str, str, str, str, str, str],
     group: pd.DataFrame,
     gene_metadata_dict: Dict[str, str],
-    label_map_dict: Dict[tuple, str],
+    label_map_dict: Dict[tuple[str, str], str],
     model_group_dict: Dict[str, str],
     biodomain_dict: Dict[str, List[str]],
     model_info_dict: Dict[str, str],
@@ -215,7 +215,7 @@ def _process_single_data_file(
     data_file: pd.DataFrame,
     data_file_required_columns: List[str],
     gene_metadata_dict: Dict[str, str],
-    label_map_dict: Dict[tuple, str],
+    label_map_dict: Dict[tuple[str, str], str],
     model_group_dict: Dict[str, str],
     biodomain_dict: Dict[str, List[str]],
     model_info_dict: Dict[str, str],

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -6,22 +6,31 @@ It combines multiple datasets including gene metadata, model information, genoty
 and biodomain annotations to create a structured output format.
 
 The transformation:
-- Groups differential expression data by gene, model, tissue, and sex
+- Filters to mouse genes only (ENSMUSG*), excluding human genes (ENSG*)
+- Groups differential expression data by gene, model, tissue, sex, case, and control
 - Creates age-based entries containing log2 fold change and adjusted p-values
+- Validates and sorts age entries by numeric value
+- Normalizes zero values in log2 fold change for consistent representation
 - Enriches data with gene symbols, biodomains, and model metadata
 - Maps genotypes to display labels for better readability
-- Processes multiple data files efficiently to minimize memory usage
+- Applies special tissue name transformation for JAX models ("Right Cerebral Hemisphere" -> "Hemibrain")
+- Rounds numeric columns to 5 decimal places for consistency
+- Processes multiple data files sequentially to minimize memory usage
 
 Key Functions:
     transform_rna_de_aggregate: Main transformation function that orchestrates the data processing
     validate_and_sort_age_entries: Validates and sorts age entries by numeric value
+    _create_age_entries_from_group: Creates age-based entries from a grouped DataFrame with normalization and validation
+    _create_output_entry_from_group: Creates a complete output entry from a grouped DataFrame by enriching it with metadata
+    _process_single_data_file: Processes a single differential expression data file and transforms it into output entries
 
 Required Inputs:
     - rnaseq_genotype_label_map: Maps models and genotypes to display labels
     - mouse_gene_metadata: Gene symbols and aliases for Ensembl IDs
     - model_info: Model types and matched controls
     - biodom_genes_mm: Biodomain annotations for mouse genes
-    - Data files: One or more CSV files containing differential expression results
+    - Data files: One or more CSV files containing differential expression results with columns:
+      ensembl_gene_id, log2foldchange, padj, model, case, control, age, sex, tissue
 """
 
 import pandas as pd
@@ -249,26 +258,17 @@ def _create_output_entry_from_group(
     """
     ensembl_gene_id, model, tissue, sex, case, control = group_key
 
-    # Get gene metadata using dictionary lookup
     gene_symbol = gene_metadata_dict.get(ensembl_gene_id, "")
-
-    # Use dictionary lookups instead of .loc[] operations
     name = label_map_dict.get((model, case), model)
     matched_control = label_map_dict.get((model, control), model)
     model_group = model_group_dict.get(model)
-
-    # Get biodomains using dictionary lookup
     biodomains = biodomain_dict.get(ensembl_gene_id, [])
-
-    # Get model type using dictionary lookup
     model_type = model_info_dict.get(model, "")
 
-    # Create age-based entries
     age_entries = _create_age_entries_from_group(
         group, ensembl_gene_id, model, tissue, sex
     )
 
-    # Validate and sort age entries
     sorted_ages = validate_and_sort_age_entries(
         age_entries, ensembl_gene_id, model, tissue, sex
     )
@@ -277,7 +277,6 @@ def _create_output_entry_from_group(
     # Only expected for JAX models
     tissue = "Hemibrain" if tissue == "Right Cerebral Hemisphere" else tissue
 
-    # Create the output entry
     return {
         "ensembl_gene_id": ensembl_gene_id,
         "gene_symbol": gene_symbol,

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -232,7 +232,7 @@ def transform_rna_de_aggregate(
                 age = str(row.age)
                 age_entries[age] = {
                     "log2_fc": float(row.log2foldchange),
-                    "adj_p_val": float(row.padj),
+                    "adj_p_val": 0.0 if pd.isna(row.padj) else float(row.padj),
                 }
 
             # Validate and sort age entries

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -19,7 +19,7 @@ The transformation:
 
 Key Functions:
     transform_rna_de_aggregate: Main transformation function that orchestrates the data processing
-    validate_and_sort_age_entries: Validates and sorts age entries by numeric value
+    _validate_and_sort_age_entries: Validates and sorts age entries by numeric value
     _create_age_entries_from_group: Creates age-based entries from a grouped DataFrame with normalization and validation
     _create_output_entry_from_group: Creates a complete output entry from a grouped DataFrame by enriching it with metadata
     _process_single_data_file: Processes a single differential expression data file and transforms it into output entries
@@ -60,7 +60,7 @@ REQUIRED_INPUT = {
 }
 
 
-def validate_and_sort_age_entries(
+def _validate_and_sort_age_entries(
     age_entries: Dict[str, Dict[str, float]],
     ensembl_gene_id: str,
     model: str,
@@ -269,7 +269,7 @@ def _create_output_entry_from_group(
         group, ensembl_gene_id, model, tissue, sex
     )
 
-    sorted_ages = validate_and_sort_age_entries(
+    sorted_ages = _validate_and_sort_age_entries(
         age_entries, ensembl_gene_id, model, tissue, sex
     )
 

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -104,6 +104,188 @@ def validate_and_sort_age_entries(
     return sorted_ages
 
 
+def _create_age_entries_from_group(
+    group: pd.DataFrame,
+    ensembl_gene_id: str,
+    model: str,
+    tissue: str,
+    sex: str,
+) -> Dict[str, Dict[str, float]]:
+    """
+    Creates age-based entries from a grouped DataFrame.
+
+    Args:
+        group: DataFrame group containing age, log2foldchange, and padj columns
+        ensembl_gene_id: Gene identifier for error reporting
+        model: Model name for error reporting
+        tissue: Tissue type for error reporting
+        sex: Sex category for error reporting
+
+    Returns:
+        Dictionary mapping age strings to log2_fc and adj_p_val values
+    """
+    age_entries = {}
+    for row in group.itertuples(index=False):
+        age = str(row.age)
+        # Check for negative p-values only if padj is not NA
+        if not pd.isna(row.padj) and float(row.padj) < 0.0:
+            raise ValueError(
+                f"Negative adjusted p-value found in data for gene '{ensembl_gene_id}', "
+                f"model '{model}', tissue '{tissue}', sex '{sex}'. "
+                f"Expected positive adjusted p-value but found: '{row.padj}'"
+            )
+        age_entries[age] = {
+            "log2_fc": normalize_zero(float(row.log2foldchange)),
+            "adj_p_val": 0.0 if pd.isna(row.padj) else float(row.padj),
+        }
+    return age_entries
+
+
+def _create_output_entry_from_group(
+    group_key: tuple,
+    group: pd.DataFrame,
+    gene_metadata_dict: Dict[str, str],
+    label_map_dict: Dict[tuple, str],
+    model_group_dict: Dict[str, str],
+    biodomain_dict: Dict[str, List[str]],
+    model_info_dict: Dict[str, str],
+) -> Dict[str, Any]:
+    """
+    Creates an output entry from a grouped DataFrame.
+
+    Args:
+        group_key: Tuple containing (ensembl_gene_id, model, tissue, sex, case, control)
+        group: DataFrame group containing age-based differential expression data
+        gene_metadata_dict: Dictionary mapping ensembl_gene_id to gene_symbol
+        label_map_dict: Dictionary mapping (model, genotype) to display_label
+        model_group_dict: Dictionary mapping model to model_group
+        biodomain_dict: Dictionary mapping ensembl_id to list of biodomains
+        model_info_dict: Dictionary mapping model to model_type
+
+    Returns:
+        Dictionary containing the output entry for this group
+    """
+    ensembl_gene_id, model, tissue, sex, case, control = group_key
+
+    # Get gene metadata using dictionary lookup
+    gene_symbol = gene_metadata_dict.get(ensembl_gene_id, "")
+
+    # Use dictionary lookups instead of .loc[] operations
+    name = label_map_dict.get((model, case), model)
+    matched_control = label_map_dict.get((model, control), model)
+    model_group = model_group_dict.get(model)
+
+    # Get biodomains using dictionary lookup
+    biodomains = biodomain_dict.get(ensembl_gene_id, [])
+
+    # Get model type using dictionary lookup
+    model_type = model_info_dict.get(model, "")
+
+    # Create age-based entries
+    age_entries = _create_age_entries_from_group(
+        group, ensembl_gene_id, model, tissue, sex
+    )
+
+    # Validate and sort age entries
+    sorted_ages = validate_and_sort_age_entries(
+        age_entries, ensembl_gene_id, model, tissue, sex
+    )
+
+    # If tissue is "Right Cerebral Hemisphere", change tissue to "Hemibrain"
+    # Only expected for JAX models
+    tissue = "Hemibrain" if tissue == "Right Cerebral Hemisphere" else tissue
+
+    # Create the output entry
+    return {
+        "ensembl_gene_id": ensembl_gene_id,
+        "gene_symbol": gene_symbol,
+        "biodomains": biodomains,
+        "name": name,
+        "matched_control": matched_control,
+        "model_group": model_group if model_group != "" else None,
+        "model_type": model_type,
+        "tissue": tissue,
+        "sex": sex,
+        **sorted_ages,
+    }
+
+
+def _process_single_data_file(
+    file_name: str,
+    data_file: pd.DataFrame,
+    data_file_required_columns: List[str],
+    gene_metadata_dict: Dict[str, str],
+    label_map_dict: Dict[tuple, str],
+    model_group_dict: Dict[str, str],
+    biodomain_dict: Dict[str, List[str]],
+    model_info_dict: Dict[str, str],
+    file_index: int,
+    total_files: int,
+) -> List[Dict[str, Any]]:
+    """
+    Processes a single data file and returns output entries.
+
+    Args:
+        file_name: Name of the data file being processed
+        data_file: DataFrame containing the data file contents
+        data_file_required_columns: List of required column names
+        gene_metadata_dict: Dictionary mapping ensembl_gene_id to gene_symbol
+        label_map_dict: Dictionary mapping (model, genotype) to display_label
+        model_group_dict: Dictionary mapping model to model_group
+        biodomain_dict: Dictionary mapping ensembl_id to list of biodomains
+        model_info_dict: Dictionary mapping model to model_type
+        file_index: Current file index (0-based)
+        total_files: Total number of files to process
+
+    Returns:
+        List of output entry dictionaries
+    """
+    logger.info(
+        f"Processing {file_name} ({file_index+1}/{total_files}): {len(data_file)} rows, "
+        f"{len(data_file.columns)} columns, "
+        f"{data_file.memory_usage(deep=True).sum() / 1024**2:.2f} MB"
+    )
+
+    # Check if data file is empty (before column validation)
+    if len(data_file) == 0:
+        raise ValueError(f"Data file {file_name} is empty")
+
+    check_required_datasets_and_columns(
+        {file_name: data_file}, {file_name: data_file_required_columns}
+    )
+
+    # Filter out rows with human gene ensembl IDs (ENSG*), keep only mouse (ENSMUSG*)
+    data_file = data_file[data_file["ensembl_gene_id"].str.startswith("ENSMUSG")]
+
+    # Round numeric columns to 5 decimal places for consistency
+    data_file = data_file.round(decimals=5)
+
+    # Group by gene, model, tissue, and sex to create one entry per group
+    # Using groupby rather than pandas merge operations as a performance optimization
+    grouped = data_file.groupby(
+        ["ensembl_gene_id", "model", "tissue", "sex", "case", "control"]
+    )
+
+    output_entries = []
+    for group_key, group in grouped:
+        output_entry = _create_output_entry_from_group(
+            group_key,
+            group,
+            gene_metadata_dict,
+            label_map_dict,
+            model_group_dict,
+            biodomain_dict,
+            model_info_dict,
+        )
+        output_entries.append(output_entry)
+
+    # Clean up memory by deleting the processed file
+    del data_file
+    gc.collect()
+
+    return output_entries
+
+
 def transform_rna_de_aggregate(
     datasets: Dict[str, pd.DataFrame],
     required_input: Dict[str, List[str]] = REQUIRED_INPUT,
@@ -184,91 +366,19 @@ def transform_rna_de_aggregate(
     for i, file_name in enumerate(file_list):
         # Download and process one file at a time
         data_file = datasets[file_name]
-        logger.info(
-            f"Processing {file_name} ({i+1}/{total_files}): {len(data_file)} rows, "
-            f"{len(data_file.columns)} columns, "
-            f"{data_file.memory_usage(deep=True).sum() / 1024**2:.2f} MB"
+        file_output = _process_single_data_file(
+            file_name,
+            data_file,
+            data_file_required_columns,
+            gene_metadata_dict,
+            label_map_dict,
+            model_group_dict,
+            biodomain_dict,
+            model_info_dict,
+            i,
+            total_files,
         )
-
-        check_required_datasets_and_columns(
-            {file_name: data_file}, {file_name: data_file_required_columns}
-        )
-
-        # Check if data file is empty
-        if len(data_file) == 0:
-            raise ValueError(f"Data file {file_name} is empty")
-
-        # Filter out rows with human gene ensembl IDs (ENSG*), keep only mouse (ENSMUSG*)
-        data_file = data_file[data_file["ensembl_gene_id"].str.startswith("ENSMUSG")]
-
-        # Round numeric columns to 5 decimal places for consistency
-        data_file = data_file.round(decimals=5)
-
-        # Group by gene, model, tissue, and sex to create one entry per group
-        # Using groupby rather than pandas merge operations as a performance optimization
-        grouped = data_file.groupby(
-            ["ensembl_gene_id", "model", "tissue", "sex", "case", "control"]
-        )
-
-        for (ensembl_gene_id, model, tissue, sex, case, control), group in grouped:
-            # Get gene metadata using dictionary lookup
-            gene_symbol = gene_metadata_dict.get(ensembl_gene_id, "")
-
-            # Use dictionary lookups instead of .loc[] operations
-            name = label_map_dict.get((model, case), model)
-            matched_control = label_map_dict.get((model, control), model)
-            model_group = model_group_dict.get(model)
-
-            # Get biodomains using dictionary lookup
-            biodomains = biodomain_dict.get(ensembl_gene_id, [])
-
-            # Get model type using dictionary lookup
-            model_type = model_info_dict.get(model, "")
-
-            # Create age-based entries
-            # Using itertuples() instead of iterrows() for better performance
-            age_entries = {}
-            for row in group.itertuples(index=False):
-                age = str(row.age)
-                if float(row.padj) < 0.0:
-                    raise ValueError(
-                        f"Negative adjusted p-value found in data for gene '{ensembl_gene_id}', "
-                        f"model '{model}', tissue '{tissue}', sex '{sex}'. "
-                        f"Expected positive adjusted p-value but found: '{row.padj}'"
-                    )
-                age_entries[age] = {
-                    "log2_fc": normalize_zero(float(row.log2foldchange)),
-                    "adj_p_val": 0.0 if pd.isna(row.padj) else float(row.padj),
-                }
-
-            # Validate and sort age entries
-            sorted_ages = validate_and_sort_age_entries(
-                age_entries, ensembl_gene_id, model, tissue, sex
-            )
-
-            # If tissue is "Right Cerebral Hemisphere", change tissue to "Hemibrain"
-            # Only expected for JAX models
-            tissue = "Hemibrain" if tissue == "Right Cerebral Hemisphere" else tissue
-
-            # Create the output entry
-            output.append(
-                {
-                    "ensembl_gene_id": ensembl_gene_id,
-                    "gene_symbol": gene_symbol,
-                    "biodomains": biodomains,
-                    "name": name,
-                    "matched_control": matched_control,
-                    "model_group": model_group if model_group != "" else None,
-                    "model_type": model_type,
-                    "tissue": tissue,
-                    "sex": sex,
-                    **sorted_ages,
-                }
-            )
-
-        # Clean up memory by deleting the processed file
-        del data_file
-        gc.collect()
+        output.extend(file_output)
 
     logger.info(f"Transform rna_de_aggregate total output entries: {len(output)}")
     return output

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -29,7 +29,7 @@ from typing import Dict, List, Any
 import logging
 import gc
 
-from agoradatatools.etl.utils import check_required_datasets_and_columns
+from agoradatatools.etl.utils import check_required_datasets_and_columns, normalize_zero
 
 logger = logging.getLogger(__name__)
 
@@ -226,15 +226,19 @@ def transform_rna_de_aggregate(
             model_type = model_info_dict.get(model, "")
 
             # Create age-based entries
-            # Using itertuples() instead of iterrows() for better performance (10-100x faster)
+            # Using itertuples() instead of iterrows() for better performance
             age_entries = {}
             for row in group.itertuples(index=False):
                 age = str(row.age)
-                # Adding 0.0 to avoid -0.0 values
-                # Adding zero to negative zero produces positive zero according to IEEE 754 floating-point arithmetic rules
+                if float(row.padj) < 0.0:
+                    raise ValueError(
+                        f"Negative adjusted p-value found in data for gene '{ensembl_gene_id}', "
+                        f"model '{model}', tissue '{tissue}', sex '{sex}'. "
+                        f"Expected positive adjusted p-value but found: '{row.padj}'"
+                    )
                 age_entries[age] = {
-                    "log2_fc": float(row.log2foldchange) + 0.0,
-                    "adj_p_val": 0.0 if pd.isna(row.padj) else float(row.padj) + 0.0,
+                    "log2_fc": normalize_zero(float(row.log2foldchange)),
+                    "adj_p_val": 0.0 if pd.isna(row.padj) else float(row.padj),
                 }
 
             # Validate and sort age entries

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -112,17 +112,44 @@ def _create_age_entries_from_group(
     sex: str,
 ) -> Dict[str, Dict[str, float]]:
     """
-    Creates age-based entries from a grouped DataFrame.
+    Creates age-based entries from a grouped DataFrame containing differential expression data.
+
+    This function processes a DataFrame group that has been grouped by gene, model, tissue, and sex.
+    It extracts age-specific differential expression measurements (log2 fold change and adjusted
+    p-values) for each age timepoint in the group. The function performs data normalization and
+    validation, including:
+    - Normalizing zero values in log2 fold change to ensure consistent representation
+    - Converting missing (NA) adjusted p-values to 0.0
+    - Validating that adjusted p-values are non-negative when present
+
+    The resulting dictionary structure allows for easy lookup of differential expression metrics
+    by age timepoint, which is used downstream to create structured output entries.
 
     Args:
-        group: DataFrame group containing age, log2foldchange, and padj columns
-        ensembl_gene_id: Gene identifier for error reporting
-        model: Model name for error reporting
-        tissue: Tissue type for error reporting
-        sex: Sex category for error reporting
+        group: DataFrame group containing age, log2foldchange, and padj columns. Each row
+            represents a single age timepoint measurement for the grouped combination of
+            gene, model, tissue, and sex.
+        ensembl_gene_id: Gene identifier (e.g., 'ENSMUSG00000000001') used for error reporting
+            when validation fails.
+        model: Model name used for error reporting when validation fails.
+        tissue: Tissue type used for error reporting when validation fails.
+        sex: Sex category used for error reporting when validation fails.
 
     Returns:
-        Dictionary mapping age strings to log2_fc and adj_p_val values
+        Dictionary mapping age strings (e.g., '3 months', '6 months') to nested dictionaries
+        containing:
+            - 'log2_fc': float, normalized log2 fold change value (zero values normalized)
+            - 'adj_p_val': float, adjusted p-value (NA values converted to 0.0)
+
+        Example:
+            {
+                '3 months': {'log2_fc': 1.234, 'adj_p_val': 0.001},
+                '6 months': {'log2_fc': 2.456, 'adj_p_val': 0.0}
+            }
+
+    Raises:
+        ValueError: If any adjusted p-value (padj) is negative when not NA. This indicates
+            invalid data that should be caught during processing.
     """
     age_entries = {}
     for row in group.itertuples(index=False):
@@ -151,19 +178,74 @@ def _create_output_entry_from_group(
     model_info_dict: Dict[str, str],
 ) -> Dict[str, Any]:
     """
-    Creates an output entry from a grouped DataFrame.
+    Creates a complete output entry from a grouped DataFrame by enriching it with metadata.
+
+    This function orchestrates the creation of a structured output entry for a single group
+    of differential expression data. It takes a DataFrame group that has been grouped by
+    gene, model, tissue, and sex, and enriches it with:
+    - Gene metadata (symbol, biodomains)
+    - Model information (display labels, model group, model type)
+    - Age-based differential expression measurements (log2 fold change and adjusted p-values)
+
+    The function performs several key operations:
+    1. Extracts metadata from lookup dictionaries for efficient data enrichment
+    2. Creates age-based entries from the grouped DataFrame using helper functions
+    3. Validates and sorts age entries by numeric age value
+    4. Applies special tissue name transformation (JAX models: "Right Cerebral Hemisphere" -> "Hemibrain")
+    5. Constructs a comprehensive output dictionary combining all metadata and age-based data
+
+    The resulting entry represents a complete record for one gene-model-tissue-sex combination
+    with all associated age timepoint measurements, ready for inclusion in the final output.
 
     Args:
         group_key: Tuple containing (ensembl_gene_id, model, tissue, sex, case, control)
-        group: DataFrame group containing age-based differential expression data
-        gene_metadata_dict: Dictionary mapping ensembl_gene_id to gene_symbol
-        label_map_dict: Dictionary mapping (model, genotype) to display_label
-        model_group_dict: Dictionary mapping model to model_group
-        biodomain_dict: Dictionary mapping ensembl_id to list of biodomains
-        model_info_dict: Dictionary mapping model to model_type
+            that uniquely identifies this group. The case and control values represent the
+            genotype labels for the experimental and control conditions.
+        group: DataFrame group containing age-based differential expression data. Each row
+            represents a single age timepoint with columns: age, log2foldchange, padj.
+        gene_metadata_dict: Dictionary mapping Ensembl gene IDs to gene symbols. Used to
+            enrich entries with human-readable gene names.
+        label_map_dict: Dictionary mapping (model, genotype) tuples to display labels.
+            Used to create human-readable names for case and control conditions.
+        model_group_dict: Dictionary mapping model names to model groups. Used to categorize
+            models into groups (e.g., "5XFAD", "APP/PS1").
+        biodomain_dict: Dictionary mapping Ensembl gene IDs to lists of biodomain names.
+            Used to annotate genes with their associated biological domains.
+        model_info_dict: Dictionary mapping model names to model types. Used to classify
+            models (e.g., "knockout", "transgenic").
 
     Returns:
-        Dictionary containing the output entry for this group
+        Dictionary containing a complete output entry with the following structure:
+            - 'ensembl_gene_id': str, Ensembl gene identifier
+            - 'gene_symbol': str, Human-readable gene symbol (empty string if not found)
+            - 'biodomains': List[str], List of biodomain names associated with the gene
+            - 'name': str, Display label for the case genotype
+            - 'matched_control': str, Display label for the control genotype
+            - 'model_group': str or None, Model group name (None if empty)
+            - 'model_type': str, Model type classification (empty string if not found)
+            - 'tissue': str, Tissue name (transformed for JAX models if applicable)
+            - 'sex': str, Sex category
+            - Age-based entries: Dictionary keys are age strings (e.g., '3 months', '6 months')
+              with values containing 'log2_fc' and 'adj_p_val' for each age timepoint
+
+        Example:
+            {
+                'ensembl_gene_id': 'ENSMUSG00000000001',
+                'gene_symbol': 'Gapdh',
+                'biodomains': ['Synaptic', 'Metabolic'],
+                'name': '5XFAD',
+                'matched_control': 'Wild-type',
+                'model_group': '5XFAD',
+                'model_type': 'transgenic',
+                'tissue': 'Hemibrain',
+                'sex': 'M',
+                '3 months': {'log2_fc': 1.234, 'adj_p_val': 0.001},
+                '6 months': {'log2_fc': 2.456, 'adj_p_val': 0.0001}
+            }
+
+    Note:
+        Age entries are validated and sorted numerically before being included in the output.
+        Missing values in lookup dictionaries result in empty strings or empty lists, not errors.
     """
     ensembl_gene_id, model, tissue, sex, case, control = group_key
 
@@ -223,22 +305,65 @@ def _process_single_data_file(
     total_files: int,
 ) -> List[Dict[str, Any]]:
     """
-    Processes a single data file and returns output entries.
+    Processes a single differential expression data file and transforms it into output entries.
+
+    This function handles the complete processing pipeline for a single RNA differential
+    expression data file. It performs data validation, filtering, grouping, and enrichment
+    to create structured output entries. The function is designed to process files one at
+    a time to minimize memory usage when handling large datasets.
+
+    The processing pipeline includes:
+    1. Logging file processing information (row count, column count, memory usage)
+    2. Validating that the data file is not empty
+    3. Validating that all required columns are present
+    4. Filtering to keep only mouse genes (ENSMUSG*), excluding human genes (ENSG*)
+    5. Rounding numeric columns to 5 decimal places for consistency
+    6. Grouping data by gene, model, tissue, sex, case, and control
+    7. Creating enriched output entries for each group using metadata dictionaries
+    8. Cleaning up memory by deleting the processed DataFrame and running garbage collection
+
+    Each output entry represents a unique combination of gene, model, tissue, and sex,
+    with age-based differential expression measurements and enriched metadata.
 
     Args:
-        file_name: Name of the data file being processed
-        data_file: DataFrame containing the data file contents
-        data_file_required_columns: List of required column names
-        gene_metadata_dict: Dictionary mapping ensembl_gene_id to gene_symbol
-        label_map_dict: Dictionary mapping (model, genotype) to display_label
-        model_group_dict: Dictionary mapping model to model_group
-        biodomain_dict: Dictionary mapping ensembl_id to list of biodomains
-        model_info_dict: Dictionary mapping model to model_type
-        file_index: Current file index (0-based)
-        total_files: Total number of files to process
+        file_name: Name of the data file being processed. Used for logging and error
+            reporting purposes.
+        data_file: DataFrame containing the differential expression data. Expected columns
+            include: ensembl_gene_id, log2foldchange, padj, model, case, control, age,
+            sex, tissue.
+        data_file_required_columns: List of required column names that must be present
+            in the data_file. Used for validation before processing.
+        gene_metadata_dict: Dictionary mapping Ensembl gene IDs to gene symbols. Used
+            to enrich output entries with human-readable gene names.
+        label_map_dict: Dictionary mapping (model, genotype) tuples to display labels.
+            Used to create human-readable names for case and control conditions.
+        model_group_dict: Dictionary mapping model names to model groups. Used to
+            categorize models into groups (e.g., "5XFAD", "APP/PS1").
+        biodomain_dict: Dictionary mapping Ensembl gene IDs to lists of biodomain names.
+            Used to annotate genes with their associated biological domains.
+        model_info_dict: Dictionary mapping model names to model types. Used to classify
+            models (e.g., "knockout", "transgenic").
+        file_index: Current file index (0-based) for progress tracking. Used in logging
+            to indicate which file is being processed (e.g., "Processing file 3/10").
+        total_files: Total number of files to process. Used in logging to show progress
+            (e.g., "Processing file 3/10").
 
     Returns:
-        List of output entry dictionaries
+        List of output entry dictionaries. Each dictionary represents a unique combination
+        of gene, model, tissue, and sex, enriched with metadata and containing age-based
+        differential expression measurements. The structure matches the output format from
+        `_create_output_entry_from_group`.
+
+    Raises:
+        ValueError: If the data file is empty or if required columns are missing.
+            The error message includes the file name for debugging purposes.
+
+    Note:
+        This function performs memory cleanup by explicitly deleting the processed DataFrame
+        and calling garbage collection. This is important when processing multiple large
+        files sequentially to prevent memory exhaustion. The function filters out human
+        genes to ensure only mouse (Mus musculus) data is processed, as indicated by
+        Ensembl IDs starting with "ENSMUSG".
     """
     logger.info(
         f"Processing {file_name} ({file_index+1}/{total_files}): {len(data_file)} rows, "
@@ -291,8 +416,81 @@ def transform_rna_de_aggregate(
     required_input: Dict[str, List[str]] = REQUIRED_INPUT,
 ) -> List[Dict[str, Any]]:
     """
-    Transforms the rna_de_aggregate source files into a structured format for Model AD.
-    Groups by gene, model, tissue, and sex, with age-based entries containing log2_fc and adj_p_val.
+    Main transformation function that orchestrates the processing of RNA differential expression data.
+
+    This function serves as the entry point for transforming RNA differential expression (RNA-DE)
+    aggregate data files into a structured format suitable for Model AD. It coordinates the entire
+    transformation pipeline, from data validation through enrichment to final output generation.
+
+    The transformation workflow:
+    1. Validates that all required input datasets and columns are present
+    2. Pre-computes lookup dictionaries from metadata for efficient data enrichment:
+       - Gene symbols from Ensembl IDs
+       - Display labels for genotypes
+       - Model groups and types
+       - Biodomain annotations
+    3. Validates data consistency (e.g., ensures each model has a consistent model_group)
+    4. Processes one or more differential expression data files sequentially:
+       - Filters to mouse genes only (ENSMUSG*)
+       - Groups data by gene, model, tissue, sex, case, and control
+       - Enriches each group with metadata
+       - Creates age-based entries with log2 fold change and adjusted p-values
+    5. Combines all processed entries into a single output list
+
+    The output format groups differential expression measurements by unique combinations of
+    gene, model, tissue, and sex, with each entry containing age-based measurements as
+    nested dictionaries.
+
+    Args:
+        datasets: Dictionary mapping dataset names to DataFrames. Must include:
+            - 'rnaseq_genotype_label_map': Maps models and genotypes to display labels
+            - 'mouse_gene_metadata': Gene symbols and aliases for Ensembl IDs
+            - 'model_info': Model types and metadata
+            - 'biodom_genes_mm': Biodomain annotations for mouse genes
+            - One or more data files: CSV DataFrames containing differential expression
+              results with columns: ensembl_gene_id, log2foldchange, padj, model, case,
+              control, age, sex, tissue
+        required_input: Dictionary mapping required dataset names to lists of required
+            column names. Defaults to REQUIRED_INPUT constant. Used to validate that all
+            necessary metadata datasets are present with correct structure.
+
+    Returns:
+        List of dictionaries, where each dictionary represents a unique combination of
+        gene, model, tissue, and sex. Each entry contains:
+            - Gene identifiers: ensembl_gene_id, gene_symbol
+            - Model information: name, matched_control, model_group, model_type
+            - Sample information: tissue, sex
+            - Biodomain annotations: biodomains (list)
+            - Age-based measurements: Dictionary keys are age strings (e.g., '3 months')
+              with values containing 'log2_fc' and 'adj_p_val' for each age timepoint
+
+        Example entry structure:
+            {
+                'ensembl_gene_id': 'ENSMUSG00000000001',
+                'gene_symbol': 'Gapdh',
+                'biodomains': ['Synaptic', 'Metabolic'],
+                'name': '5XFAD',
+                'matched_control': 'Wild-type',
+                'model_group': '5XFAD',
+                'model_type': 'transgenic',
+                'tissue': 'Hemibrain',
+                'sex': 'M',
+                '3 months': {'log2_fc': 1.234, 'adj_p_val': 0.001},
+                '6 months': {'log2_fc': 2.456, 'adj_p_val': 0.0001}
+            }
+
+    Raises:
+        ValueError: If required datasets or columns are missing, if any model has
+            inconsistent model_group values, or if any data file is empty or invalid.
+            Error messages include specific details about what validation failed.
+
+    Note:
+        This function processes data files sequentially (one at a time) rather than
+        loading all files into memory simultaneously. This design minimizes memory
+        usage when processing large numbers of files. Each file is processed, its
+        entries are added to the output list, and then the file is deleted from
+        memory before processing the next file. The function also filters out human
+        genes (ENSG*) to ensure only mouse (Mus musculus) data is included in the output.
     """
     check_required_datasets_and_columns(datasets, required_input)
 

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -230,6 +230,8 @@ def transform_rna_de_aggregate(
             age_entries = {}
             for row in group.itertuples(index=False):
                 age = str(row.age)
+                # Adding 0.0 to avoid -0.0 values
+                # Adding zero to negative zero produces positive zero according to IEEE 754 floating-point arithmetic rules
                 age_entries[age] = {
                     "log2_fc": float(row.log2foldchange) + 0.0,
                     "adj_p_val": 0.0 if pd.isna(row.padj) else float(row.padj) + 0.0,

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -409,4 +409,5 @@ def normalize_zero(value: float) -> float:
         normalize_zero(1.0)
         1.0
     """
-    return 0.0 if value == 0.0 else value
+    # Using a tolerance of 1e-15 to account for floating point precision issues
+    return 0.0 if abs(value) < 1e-15 else value

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -391,3 +391,22 @@ def input_validation_model_info(df: pd.DataFrame) -> None:
             raise ValueError(
                 f"Model {model} has inconsistent model_type values: {unique_model_types}"
             )
+
+
+def normalize_zero(value: float) -> float:
+    """
+    Convert -0.0 to 0.0 while preserving other values.
+
+    Args:
+        value (float): The value to normalize
+
+    Returns:
+        float: The normalized value
+
+    Example:
+        normalize_zero(-0.0)
+        0.0
+        normalize_zero(1.0)
+        1.0
+    """
+    return 0.0 if value == 0.0 else value

--- a/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
+++ b/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
@@ -16,6 +16,7 @@ This directory contains human-readable synthetic datasets designed to test the `
 - **`synthetic_rounding_precision_data.csv`**: Tests numeric rounding to 5 decimal places
 - **`synthetic_multiple_biodomains_data.csv`**: Tests genes with multiple biodomain assignments
 - **`synthetic_null_model_group_data.csv`**: Tests empty model_group conversion to null
+- **`synthetic_nan_negative_zero_data.csv`**: Tests NaN and negative-zero adjusted p-value coercion
 - **`synthetic_empty_data.csv`**: Empty data file for error testing
 - **`synthetic_missing_columns_data.csv`**: Missing required columns for error testing
 
@@ -103,7 +104,16 @@ Expected: model_group=null (not empty string)
 Tests: Empty string to null conversion for model_group field
 ```
 
-### Scenario 10: Inconsistent Model Group (`synthetic_rnaseq_genotype_label_map_inconsistent.csv`)
+### Scenario 10: NaN and Negative Zero Adj P-Values (`synthetic_nan_negative_zero_data.csv`)
+```
+Gene: ENSMUSG00000000003 (Gene_C)
+Model: Model_A
+Ages: 12 months (padj=NaN), 18 months (padj≈-0.0)
+Expected: Both adj_p_val values exported as +0.0 (NaN coerced, negative zero normalized)
+Tests: NaN coercion and IEEE-754 negative zero handling for adjusted p-values
+```
+
+### Scenario 11: Inconsistent Model Group (`synthetic_rnaseq_genotype_label_map_inconsistent.csv`)
 ```
 Model: Model_A with inconsistent model_group values
   - Tg genotype → GroupX
@@ -181,6 +191,7 @@ tests/test_assets/rna_de_aggregate/
 │   │   ├── synthetic_rounding_precision_data.csv
 │   │   ├── synthetic_multiple_biodomains_data.csv
 │   │   ├── synthetic_null_model_group_data.csv
+│   │   ├── synthetic_nan_negative_zero_data.csv
 │   │   ├── synthetic_empty_data.csv
 │   │   └── synthetic_missing_columns_data.csv
 │   └── Metadata Files:

--- a/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
+++ b/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
@@ -16,7 +16,7 @@ This directory contains human-readable synthetic datasets designed to test the `
 - **`synthetic_rounding_precision_data.csv`**: Tests numeric rounding to 5 decimal places
 - **`synthetic_multiple_biodomains_data.csv`**: Tests genes with multiple biodomain assignments
 - **`synthetic_null_model_group_data.csv`**: Tests empty model_group conversion to null
-- **`synthetic_nan_negative_zero_data.csv`**: Tests NaN and negative-zero adjusted p-value coercion
+- **`synthetic_nan_negative_zero_data.csv`**: Tests NaN adjusted p-value coercion to 0.0
 - **`synthetic_empty_data.csv`**: Empty data file for error testing
 - **`synthetic_missing_columns_data.csv`**: Missing required columns for error testing
 
@@ -104,16 +104,28 @@ Expected: model_group=null (not empty string)
 Tests: Empty string to null conversion for model_group field
 ```
 
-### Scenario 10: NaN and Negative Zero Adj P-Values (`synthetic_nan_negative_zero_data.csv`)
+### Scenario 10: NaN Adj P-Values (`synthetic_nan_negative_zero_data.csv`)
 ```
 Gene: ENSMUSG00000000003 (Gene_C)
 Model: Model_A
-Ages: 12 months (padj=NaN), 18 months (padj≈-0.0)
-Expected: Both adj_p_val values exported as +0.0 (NaN coerced, negative zero normalized)
-Tests: NaN coercion and IEEE-754 negative zero handling for adjusted p-values
+Ages: 12 months (padj=NaN, log2foldchange=0.12345), 18 months (padj=0.0, log2foldchange=-0.000001)
+Expected: 
+  - 12 months: adj_p_val=0.0 (NaN coerced), log2_fc=0.12345
+  - 18 months: adj_p_val=0.0 (positive zero verified), log2_fc=-0.000001
+Tests: NaN padj coercion to 0.0 and verification that zero padj values are positive
+Note: This dataset is used by two tests: test_nan_adj_p_values_are_coerced_to_zero (tests 12 months)
+      and test_negative_zero_log2foldchange_are_coerced_to_zero (tests 18 months, verifies adj_p_val is positive zero)
 ```
 
-### Scenario 11: Inconsistent Model Group (`synthetic_rnaseq_genotype_label_map_inconsistent.csv`)
+### Scenario 11: Negative Adjusted P-Values (Error Testing)
+```
+Test: test_negative_adj_p_values_raise_error
+Input: DataFrame with padj=-0.1 (created programmatically in test)
+Expected: ValueError raised with informative message identifying the negative padj value
+Tests: Validation that negative adjusted p-values are rejected with clear error message
+```
+
+### Scenario 12: Inconsistent Model Group (`synthetic_rnaseq_genotype_label_map_inconsistent.csv`)
 ```
 Model: Model_A with inconsistent model_group values
   - Tg genotype → GroupX
@@ -176,6 +188,9 @@ When testing, verify:
 11. **Missing metadata**: Gene not in metadata → gene_symbol="" and biodomains=[]
 12. **Null model_group**: Empty model_group converted to null in output
 13. **Model group consistency**: Each model must have consistent model_group values across all genotypes (raises ValueError if inconsistent)
+14. **Negative padj validation**: Negative adjusted p-values raise ValueError with informative error message
+15. **Log2foldchange normalization**: Negative zero (-0.0) log2foldchange values are normalized to positive zero (0.0) via normalize_zero function
+16. **NaN padj coercion**: NaN adjusted p-values are coerced to 0.0 in output
 
 ## File Structure
 ```

--- a/tests/test_assets/rna_de_aggregate/input/synthetic_nan_negative_zero_data.csv
+++ b/tests/test_assets/rna_de_aggregate/input/synthetic_nan_negative_zero_data.csv
@@ -1,4 +1,4 @@
 ensembl_gene_id,log2foldchange,padj,model,case,control,age,sex,tissue
 ENSMUSG00000000003,0.12345,NaN,Model_A,Tg,Wt,12 months,Female,Right Cerebral Hemisphere
-ENSMUSG00000000003,-0.12345,-0.000001,Model_A,Tg,Wt,18 months,Female,Right Cerebral Hemisphere
+ENSMUSG00000000003,-0.000001,0.0,Model_A,Tg,Wt,18 months,Female,Right Cerebral Hemisphere
 

--- a/tests/test_assets/rna_de_aggregate/input/synthetic_nan_negative_zero_data.csv
+++ b/tests/test_assets/rna_de_aggregate/input/synthetic_nan_negative_zero_data.csv
@@ -1,0 +1,4 @@
+ensembl_gene_id,log2foldchange,padj,model,case,control,age,sex,tissue
+ENSMUSG00000000003,0.12345,NaN,Model_A,Tg,Wt,12 months,Female,Right Cerebral Hemisphere
+ENSMUSG00000000003,-0.12345,-0.000001,Model_A,Tg,Wt,18 months,Female,Right Cerebral Hemisphere
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -863,10 +863,10 @@ class TestNormalizeZero:
 
     def test_negative_values_preserved(self) -> None:
         """Test that negative values (other than -0.0) are preserved."""
-        assert utils.normalize_zero(-1.0) == -1.0
-        assert utils.normalize_zero(-42.5) == -42.5
-        assert utils.normalize_zero(-0.001) == -0.001
-        assert utils.normalize_zero(-1e10) == -1e10
+        assert utils.normalize_zero(-1.0) == pytest.approx(-1.0)
+        assert utils.normalize_zero(-42.5) == pytest.approx(-42.5)
+        assert utils.normalize_zero(-0.001) == pytest.approx(-0.001)
+        assert utils.normalize_zero(-1e10) == pytest.approx(-1e10)
 
     def test_very_small_positive_value_preserved(self) -> None:
         """Test that very small positive values are preserved."""

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -830,3 +830,57 @@ class TestInputValidationModelInfo:
         )
         # Should not raise any exception
         utils.input_validation_model_info(df)
+
+
+class TestNormalizeZero:
+    """Test class for the normalize_zero function."""
+
+    def test_negative_zero_becomes_positive_zero(self) -> None:
+        """Test that -0.0 is converted to 0.0."""
+        import math
+
+        result = utils.normalize_zero(-0.0)
+        assert result == 0.0
+        # Verify it's positive zero using copysign
+        assert math.copysign(1.0, result) > 0
+
+    def test_positive_zero_stays_positive_zero(self) -> None:
+        """Test that 0.0 remains 0.0."""
+        import math
+
+        result = utils.normalize_zero(0.0)
+        assert result == 0.0
+        assert math.copysign(1.0, result) > 0
+
+    def test_positive_values_preserved(self) -> None:
+        """Test that positive values are preserved."""
+        assert utils.normalize_zero(1.0) == 1.0
+        assert utils.normalize_zero(42.5) == 42.5
+        assert utils.normalize_zero(0.001) == 0.001
+        assert utils.normalize_zero(1e10) == 1e10
+
+    def test_negative_values_preserved(self) -> None:
+        """Test that negative values (other than -0.0) are preserved."""
+        assert utils.normalize_zero(-1.0) == -1.0
+        assert utils.normalize_zero(-42.5) == -42.5
+        assert utils.normalize_zero(-0.001) == -0.001
+        assert utils.normalize_zero(-1e10) == -1e10
+
+    def test_very_small_positive_value_preserved(self) -> None:
+        """Test that very small positive values are preserved."""
+        small_value = 1e-15
+        assert utils.normalize_zero(small_value) == small_value
+
+    def test_very_small_negative_value_preserved(self) -> None:
+        """Test that very small negative values are preserved."""
+        small_value = -1e-15
+        assert utils.normalize_zero(small_value) == small_value
+
+    def test_negative_zero_via_copysign(self) -> None:
+        """Test that negative zero created via copysign is normalized."""
+        import math
+
+        negative_zero = math.copysign(0.0, -1.0)
+        result = utils.normalize_zero(negative_zero)
+        assert result == 0.0
+        assert math.copysign(1.0, result) > 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -840,7 +840,8 @@ class TestNormalizeZero:
         import math
 
         result = utils.normalize_zero(-0.0)
-        assert result == 0.0
+        # Verify result is non-negative (positive zero, not negative zero)
+        assert result >= 0
         # Verify it's positive zero using copysign
         assert math.copysign(1.0, result) > 0
 
@@ -849,15 +850,16 @@ class TestNormalizeZero:
         import math
 
         result = utils.normalize_zero(0.0)
-        assert result == 0.0
+        # Verify result is non-negative (positive zero, not negative zero)
+        assert result >= 0
         assert math.copysign(1.0, result) > 0
 
     def test_positive_values_preserved(self) -> None:
         """Test that positive values are preserved."""
-        assert utils.normalize_zero(1.0) == 1.0
-        assert utils.normalize_zero(42.5) == 42.5
-        assert utils.normalize_zero(0.001) == 0.001
-        assert utils.normalize_zero(1e10) == 1e10
+        assert utils.normalize_zero(1.0) == pytest.approx(1.0)
+        assert utils.normalize_zero(42.5) == pytest.approx(42.5)
+        assert utils.normalize_zero(0.001) == pytest.approx(0.001)
+        assert utils.normalize_zero(1e10) == pytest.approx(1e10)
 
     def test_negative_values_preserved(self) -> None:
         """Test that negative values (other than -0.0) are preserved."""
@@ -869,12 +871,12 @@ class TestNormalizeZero:
     def test_very_small_positive_value_preserved(self) -> None:
         """Test that very small positive values are preserved."""
         small_value = 1e-15
-        assert utils.normalize_zero(small_value) == small_value
+        assert utils.normalize_zero(small_value) == pytest.approx(small_value)
 
     def test_very_small_negative_value_preserved(self) -> None:
         """Test that very small negative values are preserved."""
         small_value = -1e-15
-        assert utils.normalize_zero(small_value) == small_value
+        assert utils.normalize_zero(small_value) == pytest.approx(small_value)
 
     def test_negative_zero_via_copysign(self) -> None:
         """Test that negative zero created via copysign is normalized."""
@@ -882,5 +884,6 @@ class TestNormalizeZero:
 
         negative_zero = math.copysign(0.0, -1.0)
         result = utils.normalize_zero(negative_zero)
-        assert result == 0.0
+        # Verify result is non-negative (positive zero, not negative zero)
+        assert result >= 0
         assert math.copysign(1.0, result) > 0

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -529,154 +529,43 @@ class TestTransformRnaDeAggregate:
     def test_nan_adj_p_values_are_coerced_to_zero(self) -> None:
         """NaN adjusted p-values in source data should be exported as 0."""
 
-        datasets: Dict[str, pd.DataFrame] = {
-            "rnaseq_genotype_label_map": pd.DataFrame(
-                [
-                    {
-                        "model": "ModelA",
-                        "model_group": "Group1",
-                        "display_label": "ModelA Case",
-                        "genotype": "Case",
-                    },
-                    {
-                        "model": "ModelA",
-                        "model_group": "Group1",
-                        "display_label": "ModelA Control",
-                        "genotype": "Control",
-                    },
-                ]
-            ),
-            "mouse_gene_metadata": pd.DataFrame(
-                [
-                    {
-                        "ensembl_gene_id": "ENSMUSG00000012345",
-                        "gene_symbol": "GeneA",
-                        "alias": "",
-                    }
-                ]
-            ),
-            "model_info": pd.DataFrame(
-                [
-                    {
-                        "model": "ModelA",
-                        "matched_controls": "Control",
-                        "model_type": "TypeA",
-                    }
-                ]
-            ),
-            "biodom_genes_mm": pd.DataFrame(
-                [
-                    {
-                        "biodomain": "DomainA",
-                        "abbr": "DA",
-                        "label": "Domain A",
-                        "color": "#ffffff",
-                        "go_id": "GO:0000000",
-                        "goterm_name": "Example Term",
-                        "n_symbol": "NS",
-                        "symbol": "SYMB",
-                        "ensembl_id": "ENSMUSG00000012345",
-                    }
-                ]
-            ),
-            "nan_test_data": pd.DataFrame(
-                [
-                    {
-                        "ensembl_gene_id": "ENSMUSG00000012345",
-                        "log2foldchange": 0.12345,
-                        "padj": float("nan"),
-                        "model": "ModelA",
-                        "case": "Case",
-                        "control": "Control",
-                        "age": "12 months",
-                        "sex": "Females & Males",
-                        "tissue": "Right Cerebral Hemisphere",
-                    }
-                ]
-            ),
-        }
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_nan_negative_zero_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+                "synthetic_model_info.csv",
+                "synthetic_biodom_genes_mm.csv",
+            ]
+        )
 
         output_data = transform_rna_de_aggregate(datasets=datasets)
 
         assert len(output_data) == 1
-        twelve_month_entry = output_data[0]["12 months"]
+        result_entry = output_data[0]
+        twelve_month_entry = result_entry["12 months"]
         assert math.isclose(twelve_month_entry["adj_p_val"], 0.0, abs_tol=1e-12)
 
     def test_negative_zero_adj_p_values_are_coerced_to_zero(self) -> None:
         """-0.0 adjusted p-values in source data should be exported as 0."""
 
-        datasets: Dict[str, pd.DataFrame] = {
-            "rnaseq_genotype_label_map": pd.DataFrame(
-                [
-                    {
-                        "model": "ModelA",
-                        "model_group": "Group1",
-                        "display_label": "ModelA Case",
-                        "genotype": "Case",
-                    },
-                    {
-                        "model": "ModelA",
-                        "model_group": "Group1",
-                        "display_label": "ModelA Control",
-                        "genotype": "Control",
-                    },
-                ]
-            ),
-            "mouse_gene_metadata": pd.DataFrame(
-                [
-                    {
-                        "ensembl_gene_id": "ENSMUSG00000012345",
-                        "gene_symbol": "GeneA",
-                        "alias": "",
-                    }
-                ]
-            ),
-            "model_info": pd.DataFrame(
-                [
-                    {
-                        "model": "ModelA",
-                        "matched_controls": "Control",
-                        "model_type": "TypeA",
-                    }
-                ]
-            ),
-            "biodom_genes_mm": pd.DataFrame(
-                [
-                    {
-                        "biodomain": "DomainA",
-                        "abbr": "DA",
-                        "label": "Domain A",
-                        "color": "#ffffff",
-                        "go_id": "GO:0000000",
-                        "goterm_name": "Example Term",
-                        "n_symbol": "NS",
-                        "symbol": "SYMB",
-                        "ensembl_id": "ENSMUSG00000012345",
-                    }
-                ]
-            ),
-            "negative_zero_test_data": pd.DataFrame(
-                [
-                    {
-                        "ensembl_gene_id": "ENSMUSG00000012345",
-                        "log2foldchange": -0.00001,
-                        "padj": -0.000001,
-                        "model": "ModelA",
-                        "case": "Case",
-                        "control": "Control",
-                        "age": "12 months",
-                        "sex": "Females & Males",
-                        "tissue": "Right Cerebral Hemisphere",
-                    }
-                ]
-            ),
-        }
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_nan_negative_zero_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+                "synthetic_model_info.csv",
+                "synthetic_biodom_genes_mm.csv",
+            ]
+        )
 
         output_data = transform_rna_de_aggregate(datasets=datasets)
 
         assert len(output_data) == 1
-        twelve_month_entry = output_data[0]["12 months"]
-        assert math.copysign(1.0, twelve_month_entry["adj_p_val"]) > 0
+        result_entry = output_data[0]
+        eighteen_month_entry = result_entry["18 months"]
+        assert math.isclose(eighteen_month_entry["adj_p_val"], 0.0, abs_tol=1e-12)
+        assert math.copysign(1.0, eighteen_month_entry["adj_p_val"]) > 0
 
     def test_synthetic_age_sorting(self) -> None:
         """Test age sorting with synthetic data.

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -546,8 +546,8 @@ class TestTransformRnaDeAggregate:
         twelve_month_entry = result_entry["12 months"]
         assert math.isclose(twelve_month_entry["adj_p_val"], 0.0, abs_tol=1e-12)
 
-    def test_negative_zero_adj_p_values_are_coerced_to_zero(self) -> None:
-        """-0.0 adjusted p-values in source data should be exported as 0."""
+    def test_negative_zero_log2foldchange_are_coerced_to_zero(self) -> None:
+        """-0.0 log in source data should be exported as 0."""
 
         datasets = self._load_synthetic_test_data(
             [
@@ -566,6 +566,47 @@ class TestTransformRnaDeAggregate:
         eighteen_month_entry = result_entry["18 months"]
         assert math.isclose(eighteen_month_entry["adj_p_val"], 0.0, abs_tol=1e-12)
         assert math.copysign(1.0, eighteen_month_entry["adj_p_val"]) > 0
+
+    def test_negative_adj_p_values_raise_error(self) -> None:
+        """Negative adjusted p-values in source data should raise ValueError."""
+
+        # Load required metadata datasets
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+                "synthetic_model_info.csv",
+                "synthetic_biodom_genes_mm.csv",
+            ]
+        )
+
+        # Create a dataframe with a negative p-value directly
+        negative_padj_data = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001"],
+                "log2foldchange": [1.00000],
+                "padj": [-0.10000],
+                "model": ["Model_A"],
+                "case": ["Tg"],
+                "control": ["Wt"],
+                "age": ["3 months"],
+                "sex": ["Female"],
+                "tissue": ["Brain"],
+            }
+        )
+
+        datasets["negative_padj_data"] = negative_padj_data
+
+        with pytest.raises(ValueError) as exc_info:
+            transform_rna_de_aggregate(datasets=datasets)
+
+        error_message = str(exc_info.value)
+        assert "Negative adjusted p-value found in data" in error_message
+        assert "ENSMUSG00000000001" in error_message
+        assert "Model_A" in error_message
+        assert "Brain" in error_message
+        assert "Female" in error_message
+        assert "-0.10000" in error_message or "-0.1" in error_message
 
     def test_synthetic_age_sorting(self) -> None:
         """Test age sorting with synthetic data.

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -591,18 +591,7 @@ class TestTransformRnaDeAggregate:
                         "age": "12 months",
                         "sex": "Females & Males",
                         "tissue": "Right Cerebral Hemisphere",
-                    },
-                    {
-                        "ensembl_gene_id": "ENSMUSG00000012345",
-                        "log2foldchange": -0.00001,
-                        "padj": -0.000001,
-                        "model": "ModelA",
-                        "case": "Case",
-                        "control": "Control",
-                        "age": "4 months",
-                        "sex": "Females & Males",
-                        "tissue": "Right Cerebral Hemisphere",
-                    },
+                    }
                 ]
             ),
         }
@@ -610,13 +599,84 @@ class TestTransformRnaDeAggregate:
         output_data = transform_rna_de_aggregate(datasets=datasets)
 
         assert len(output_data) == 1
-        entry = output_data[0]
-        twelve_month_entry = entry["12 months"]
+        twelve_month_entry = output_data[0]["12 months"]
         assert math.isclose(twelve_month_entry["adj_p_val"], 0.0, abs_tol=1e-12)
 
-        four_month_entry = entry["4 months"]
-        assert math.copysign(1.0, four_month_entry["adj_p_val"]) > 0
-        assert entry["tissue"] == "Hemibrain"
+    def test_negative_zero_adj_p_values_are_coerced_to_zero(self) -> None:
+        """-0.0 adjusted p-values in source data should be exported as 0."""
+
+        datasets: Dict[str, pd.DataFrame] = {
+            "rnaseq_genotype_label_map": pd.DataFrame(
+                [
+                    {
+                        "model": "ModelA",
+                        "model_group": "Group1",
+                        "display_label": "ModelA Case",
+                        "genotype": "Case",
+                    },
+                    {
+                        "model": "ModelA",
+                        "model_group": "Group1",
+                        "display_label": "ModelA Control",
+                        "genotype": "Control",
+                    },
+                ]
+            ),
+            "mouse_gene_metadata": pd.DataFrame(
+                [
+                    {
+                        "ensembl_gene_id": "ENSMUSG00000012345",
+                        "gene_symbol": "GeneA",
+                        "alias": "",
+                    }
+                ]
+            ),
+            "model_info": pd.DataFrame(
+                [
+                    {
+                        "model": "ModelA",
+                        "matched_controls": "Control",
+                        "model_type": "TypeA",
+                    }
+                ]
+            ),
+            "biodom_genes_mm": pd.DataFrame(
+                [
+                    {
+                        "biodomain": "DomainA",
+                        "abbr": "DA",
+                        "label": "Domain A",
+                        "color": "#ffffff",
+                        "go_id": "GO:0000000",
+                        "goterm_name": "Example Term",
+                        "n_symbol": "NS",
+                        "symbol": "SYMB",
+                        "ensembl_id": "ENSMUSG00000012345",
+                    }
+                ]
+            ),
+            "negative_zero_test_data": pd.DataFrame(
+                [
+                    {
+                        "ensembl_gene_id": "ENSMUSG00000012345",
+                        "log2foldchange": -0.00001,
+                        "padj": -0.000001,
+                        "model": "ModelA",
+                        "case": "Case",
+                        "control": "Control",
+                        "age": "12 months",
+                        "sex": "Females & Males",
+                        "tissue": "Right Cerebral Hemisphere",
+                    }
+                ]
+            ),
+        }
+
+        output_data = transform_rna_de_aggregate(datasets=datasets)
+
+        assert len(output_data) == 1
+        twelve_month_entry = output_data[0]["12 months"]
+        assert math.copysign(1.0, twelve_month_entry["adj_p_val"]) > 0
 
     def test_synthetic_age_sorting(self) -> None:
         """Test age sorting with synthetic data.

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -360,31 +360,14 @@ class TestCreateAgeEntriesFromGroup:
         assert result["12 months"] == {"log2_fc": 1.5, "adj_p_val": 0.001}
 
     def test_create_age_entries_with_nan_padj(self) -> None:
-        """Test that NaN adjusted p-values are converted to 0.0."""
-        group = pd.DataFrame(
-            {
-                "age": ["6 months"],
-                "log2foldchange": [1.5],
-                "padj": [pd.NA],
-            }
-        )
+        """Test that NaN adjusted p-values are converted to 0.0.
 
-        result = _create_age_entries_from_group(
-            group=group,
-            ensembl_gene_id="ENSMUSG00000000003",
-            model="TestModel",
-            tissue="Cortex",
-            sex="Male",
-        )
-
-        assert math.isclose(result["6 months"]["adj_p_val"], 0.0, abs_tol=1e-12)
-        assert result["6 months"]["log2_fc"] == pytest.approx(1.5)
-
-    def test_create_age_entries_with_nan_padj_does_not_check_negative(self) -> None:
-        """Test that NA padj values don't trigger negative p-value validation check.
-
-        This verifies that the NA check happens before float conversion,
-        preventing TypeError when pd.NA is passed to float().
+        This verifies that:
+        - NA padj values are converted to 0.0
+        - NA values don't trigger negative p-value validation check
+        - The NA check happens before float conversion, preventing TypeError
+          when pd.NA is passed to float()
+        - log2_fc values are still processed correctly when padj is NA
         """
         group = pd.DataFrame(
             {
@@ -405,6 +388,7 @@ class TestCreateAgeEntriesFromGroup:
 
         # NA should be converted to 0.0 without errors
         assert math.isclose(result["6 months"]["adj_p_val"], 0.0, abs_tol=1e-12)
+        assert result["6 months"]["log2_fc"] == pytest.approx(1.5)
 
     def test_create_age_entries_mixed_na_and_valid_padj(self) -> None:
         """Test that groups with both NA and valid padj values are handled correctly.

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -35,6 +35,7 @@ Test Data Structure:
 
 import os
 import json
+import math
 from typing import Dict, List
 import pandas as pd
 import pytest
@@ -590,7 +591,18 @@ class TestTransformRnaDeAggregate:
                         "age": "12 months",
                         "sex": "Females & Males",
                         "tissue": "Right Cerebral Hemisphere",
-                    }
+                    },
+                    {
+                        "ensembl_gene_id": "ENSMUSG00000012345",
+                        "log2foldchange": -0.00001,
+                        "padj": -0.000001,
+                        "model": "ModelA",
+                        "case": "Case",
+                        "control": "Control",
+                        "age": "4 months",
+                        "sex": "Females & Males",
+                        "tissue": "Right Cerebral Hemisphere",
+                    },
                 ]
             ),
         }
@@ -599,8 +611,11 @@ class TestTransformRnaDeAggregate:
 
         assert len(output_data) == 1
         entry = output_data[0]
-        age_entry = entry["12 months"]
-        assert age_entry["adj_p_val"] == pytest.approx(0.0, abs=1e-12)
+        twelve_month_entry = entry["12 months"]
+        assert math.isclose(twelve_month_entry["adj_p_val"], 0.0, abs_tol=1e-12)
+
+        four_month_entry = entry["4 months"]
+        assert math.copysign(1.0, four_month_entry["adj_p_val"]) > 0
         assert entry["tissue"] == "Hemibrain"
 
     def test_synthetic_age_sorting(self) -> None:

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -525,6 +525,84 @@ class TestTransformRnaDeAggregate:
         for entry in output_data:
             assert entry["ensembl_gene_id"].startswith("ENSMUSG")
 
+    def test_nan_adj_p_values_are_coerced_to_zero(self) -> None:
+        """NaN adjusted p-values in source data should be exported as 0."""
+
+        datasets: Dict[str, pd.DataFrame] = {
+            "rnaseq_genotype_label_map": pd.DataFrame(
+                [
+                    {
+                        "model": "ModelA",
+                        "model_group": "Group1",
+                        "display_label": "ModelA Case",
+                        "genotype": "Case",
+                    },
+                    {
+                        "model": "ModelA",
+                        "model_group": "Group1",
+                        "display_label": "ModelA Control",
+                        "genotype": "Control",
+                    },
+                ]
+            ),
+            "mouse_gene_metadata": pd.DataFrame(
+                [
+                    {
+                        "ensembl_gene_id": "ENSMUSG00000012345",
+                        "gene_symbol": "GeneA",
+                        "alias": "",
+                    }
+                ]
+            ),
+            "model_info": pd.DataFrame(
+                [
+                    {
+                        "model": "ModelA",
+                        "matched_controls": "Control",
+                        "model_type": "TypeA",
+                    }
+                ]
+            ),
+            "biodom_genes_mm": pd.DataFrame(
+                [
+                    {
+                        "biodomain": "DomainA",
+                        "abbr": "DA",
+                        "label": "Domain A",
+                        "color": "#ffffff",
+                        "go_id": "GO:0000000",
+                        "goterm_name": "Example Term",
+                        "n_symbol": "NS",
+                        "symbol": "SYMB",
+                        "ensembl_id": "ENSMUSG00000012345",
+                    }
+                ]
+            ),
+            "nan_test_data": pd.DataFrame(
+                [
+                    {
+                        "ensembl_gene_id": "ENSMUSG00000012345",
+                        "log2foldchange": 0.12345,
+                        "padj": float("nan"),
+                        "model": "ModelA",
+                        "case": "Case",
+                        "control": "Control",
+                        "age": "12 months",
+                        "sex": "Females & Males",
+                        "tissue": "Right Cerebral Hemisphere",
+                    }
+                ]
+            ),
+        }
+
+        output_data = transform_rna_de_aggregate(datasets=datasets)
+
+        assert len(output_data) == 1
+        entry = output_data[0]
+        age_entry = entry["12 months"]
+        assert age_entry["adj_p_val"] == 0.0
+        assert entry["tissue"] == "Hemibrain"
+
     def test_synthetic_age_sorting(self) -> None:
         """Test age sorting with synthetic data.
 

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -43,6 +43,9 @@ import pytest
 from agoradatatools.etl.transform.rna_de_aggregate import (
     transform_rna_de_aggregate,
     validate_and_sort_age_entries,
+    _create_age_entries_from_group,
+    _create_output_entry_from_group,
+    _process_single_data_file,
 )
 
 
@@ -287,6 +290,687 @@ class TestValidateAndSortAgeEntries:
         )
 
         assert result == {}
+
+
+class TestCreateAgeEntriesFromGroup:
+    """
+    Unit tests for the _create_age_entries_from_group helper function.
+
+    This class contains focused unit tests for age entry creation logic,
+    testing the function in isolation from the full transformation pipeline.
+
+    Test Methods:
+        - test_create_age_entries_single_row: Tests creating age entries from a single row.
+        - test_create_age_entries_multiple_rows: Tests creating age entries from multiple rows.
+        - test_create_age_entries_with_nan_padj: Tests handling of NaN adjusted p-values.
+        - test_create_age_entries_with_negative_zero: Tests handling of negative zero log2foldchange.
+        - test_create_age_entries_negative_padj_raises_error: Tests error handling for negative p-values.
+    """
+
+    def test_create_age_entries_single_row(self) -> None:
+        """Test creating age entries from a single row DataFrame."""
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [1.5],
+                "padj": [0.01],
+            }
+        )
+
+        result = _create_age_entries_from_group(
+            group=group,
+            ensembl_gene_id="ENSMUSG00000000001",
+            model="TestModel",
+            tissue="Cortex",
+            sex="Male",
+        )
+
+        assert result == {"6 months": {"log2_fc": 1.5, "adj_p_val": 0.01}}
+
+    def test_create_age_entries_multiple_rows(self) -> None:
+        """Test creating age entries from multiple rows with different ages."""
+        group = pd.DataFrame(
+            {
+                "age": ["3 months", "6 months", "12 months"],
+                "log2foldchange": [0.5, 1.0, 1.5],
+                "padj": [0.05, 0.01, 0.001],
+            }
+        )
+
+        result = _create_age_entries_from_group(
+            group=group,
+            ensembl_gene_id="ENSMUSG00000000002",
+            model="TestModel",
+            tissue="Hippocampus",
+            sex="Female",
+        )
+
+        assert len(result) == 3
+        assert "3 months" in result
+        assert "6 months" in result
+        assert "12 months" in result
+        assert result["3 months"] == {"log2_fc": 0.5, "adj_p_val": 0.05}
+        assert result["6 months"] == {"log2_fc": 1.0, "adj_p_val": 0.01}
+        assert result["12 months"] == {"log2_fc": 1.5, "adj_p_val": 0.001}
+
+    def test_create_age_entries_with_nan_padj(self) -> None:
+        """Test that NaN adjusted p-values are converted to 0.0."""
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [1.5],
+                "padj": [pd.NA],
+            }
+        )
+
+        result = _create_age_entries_from_group(
+            group=group,
+            ensembl_gene_id="ENSMUSG00000000003",
+            model="TestModel",
+            tissue="Cortex",
+            sex="Male",
+        )
+
+        assert math.isclose(result["6 months"]["adj_p_val"], 0.0, abs_tol=1e-12)
+        assert result["6 months"]["log2_fc"] == pytest.approx(1.5)
+
+    def test_create_age_entries_with_nan_padj_does_not_check_negative(self) -> None:
+        """Test that NA padj values don't trigger negative p-value validation check.
+
+        This verifies that the NA check happens before float conversion,
+        preventing TypeError when pd.NA is passed to float().
+        """
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [1.5],
+                "padj": [pd.NA],
+            }
+        )
+
+        # Should not raise TypeError or ValueError, should handle NA gracefully
+        result = _create_age_entries_from_group(
+            group=group,
+            ensembl_gene_id="ENSMUSG00000000003",
+            model="TestModel",
+            tissue="Cortex",
+            sex="Male",
+        )
+
+        # NA should be converted to 0.0 without errors
+        assert math.isclose(result["6 months"]["adj_p_val"], 0.0, abs_tol=1e-12)
+
+    def test_create_age_entries_mixed_na_and_valid_padj(self) -> None:
+        """Test that groups with both NA and valid padj values are handled correctly.
+
+        This verifies that NA values are skipped in negative check but valid
+        negative values still raise errors.
+        """
+        # Group with NA and valid positive values
+        group_valid = pd.DataFrame(
+            {
+                "age": ["3 months", "6 months"],
+                "log2foldchange": [0.5, 1.5],
+                "padj": [pd.NA, 0.01],
+            }
+        )
+
+        result = _create_age_entries_from_group(
+            group=group_valid,
+            ensembl_gene_id="ENSMUSG00000000010",
+            model="TestModel",
+            tissue="Cortex",
+            sex="Male",
+        )
+
+        # Both entries should be created without errors
+        assert len(result) == 2
+        assert math.isclose(result["3 months"]["adj_p_val"], 0.0, abs_tol=1e-12)
+        assert result["6 months"]["adj_p_val"] == pytest.approx(0.01)
+
+        # Group with NA and negative value should still raise error for negative
+        group_negative = pd.DataFrame(
+            {
+                "age": ["3 months", "6 months"],
+                "log2foldchange": [0.5, 1.5],
+                "padj": [pd.NA, -0.01],
+            }
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            _create_age_entries_from_group(
+                group=group_negative,
+                ensembl_gene_id="ENSMUSG00000000011",
+                model="TestModel",
+                tissue="Cortex",
+                sex="Male",
+            )
+
+        # Should still catch negative p-value even when NA is present
+        error_message = str(exc_info.value)
+        assert "Negative adjusted p-value found in data" in error_message
+        assert "ENSMUSG00000000011" in error_message
+
+    def test_create_age_entries_with_negative_zero(self) -> None:
+        """Test that negative zero log2foldchange is normalized to positive zero."""
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [-0.0],
+                "padj": [0.01],
+            }
+        )
+
+        result = _create_age_entries_from_group(
+            group=group,
+            ensembl_gene_id="ENSMUSG00000000004",
+            model="TestModel",
+            tissue="Cortex",
+            sex="Male",
+        )
+
+        # normalize_zero should convert -0.0 to 0.0
+        assert math.isclose(result["6 months"]["log2_fc"], 0.0, abs_tol=1e-12)
+        assert math.copysign(1.0, result["6 months"]["log2_fc"]) > 0
+
+    def test_create_age_entries_negative_padj_raises_error(self) -> None:
+        """Test that negative adjusted p-values raise ValueError with informative message."""
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [1.5],
+                "padj": [-0.01],
+            }
+        )
+
+        with pytest.raises(ValueError) as exc_info:
+            _create_age_entries_from_group(
+                group=group,
+                ensembl_gene_id="ENSMUSG00000000005",
+                model="TestModel",
+                tissue="Cortex",
+                sex="Female",
+            )
+
+        error_message = str(exc_info.value)
+        assert "Negative adjusted p-value found in data" in error_message
+        assert "ENSMUSG00000000005" in error_message
+        assert "TestModel" in error_message
+        assert "Cortex" in error_message
+        assert "Female" in error_message
+
+
+class TestCreateOutputEntryFromGroup:
+    """
+    Unit tests for the _create_output_entry_from_group helper function.
+
+    This class contains focused unit tests for output entry creation logic,
+    testing the function in isolation from the full transformation pipeline.
+
+    Test Methods:
+        - test_create_output_entry_basic: Tests basic output entry creation.
+        - test_create_output_entry_missing_metadata: Tests handling of missing metadata.
+        - test_create_output_entry_jax_tissue_mapping: Tests JAX tissue name mapping.
+        - test_create_output_entry_empty_model_group: Tests empty model_group conversion to None.
+        - test_create_output_entry_multiple_biodomains: Tests multiple biodomain assignments.
+    """
+
+    def test_create_output_entry_basic(self) -> None:
+        """Test basic output entry creation with all metadata present."""
+        group_key = ("ENSMUSG00000000001", "Model_A", "Cortex", "Male", "Tg", "Wt")
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [1.5],
+                "padj": [0.01],
+            }
+        )
+
+        gene_metadata_dict = {"ENSMUSG00000000001": "Gene1"}
+        label_map_dict = {
+            ("Model_A", "Tg"): "Transgenic",
+            ("Model_A", "Wt"): "Wildtype",
+        }
+        model_group_dict = {"Model_A": "Group1"}
+        biodomain_dict = {"ENSMUSG00000000001": ["Synaptic"]}
+        model_info_dict = {"Model_A": "knockout"}
+
+        result = _create_output_entry_from_group(
+            group_key=group_key,
+            group=group,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            biodomain_dict=biodomain_dict,
+            model_info_dict=model_info_dict,
+        )
+
+        assert result["ensembl_gene_id"] == "ENSMUSG00000000001"
+        assert result["gene_symbol"] == "Gene1"
+        assert result["biodomains"] == ["Synaptic"]
+        assert result["name"] == "Transgenic"
+        assert result["matched_control"] == "Wildtype"
+        assert result["model_group"] == "Group1"
+        assert result["model_type"] == "knockout"
+        assert result["tissue"] == "Cortex"
+        assert result["sex"] == "Male"
+        assert "6 months" in result
+        assert result["6 months"]["log2_fc"] == pytest.approx(1.5)
+        assert result["6 months"]["adj_p_val"] == pytest.approx(0.01)
+
+    def test_create_output_entry_missing_metadata(self) -> None:
+        """Test output entry creation with missing metadata (defaults to empty strings/lists)."""
+        group_key = (
+            "ENSMUSG00000000002",
+            "Model_B",
+            "Hippocampus",
+            "Female",
+            "Tg",
+            "Wt",
+        )
+        group = pd.DataFrame(
+            {
+                "age": ["3 months"],
+                "log2foldchange": [0.5],
+                "padj": [0.05],
+            }
+        )
+
+        # Empty dictionaries simulate missing metadata
+        gene_metadata_dict = {}
+        label_map_dict = {}
+        model_group_dict = {}
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        result = _create_output_entry_from_group(
+            group_key=group_key,
+            group=group,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            biodomain_dict=biodomain_dict,
+            model_info_dict=model_info_dict,
+        )
+
+        assert result["ensembl_gene_id"] == "ENSMUSG00000000002"
+        assert result["gene_symbol"] == ""  # Default for missing
+        assert result["biodomains"] == []  # Default for missing
+        assert result["name"] == "Model_B"  # Falls back to model name
+        assert result["matched_control"] == "Model_B"  # Falls back to model name
+        assert result["model_group"] is None  # Empty string converted to None
+        assert result["model_type"] == ""  # Default for missing
+        assert result["tissue"] == "Hippocampus"
+        assert result["sex"] == "Female"
+
+    def test_create_output_entry_jax_tissue_mapping(self) -> None:
+        """Test that JAX tissue name 'Right Cerebral Hemisphere' is mapped to 'Hemibrain'."""
+        group_key = (
+            "ENSMUSG00000000003",
+            "Model_C",
+            "Right Cerebral Hemisphere",
+            "Male",
+            "Tg",
+            "Wt",
+        )
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [1.0],
+                "padj": [0.01],
+            }
+        )
+
+        gene_metadata_dict = {"ENSMUSG00000000003": "Gene3"}
+        label_map_dict = {}
+        model_group_dict = {}
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        result = _create_output_entry_from_group(
+            group_key=group_key,
+            group=group,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            biodomain_dict=biodomain_dict,
+            model_info_dict=model_info_dict,
+        )
+
+        assert result["tissue"] == "Hemibrain"  # Should be mapped
+
+    def test_create_output_entry_empty_model_group(self) -> None:
+        """Test that empty string model_group is converted to None."""
+        group_key = ("ENSMUSG00000000004", "Model_D", "Cortex", "Female", "Tg", "Wt")
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [1.5],
+                "padj": [0.01],
+            }
+        )
+
+        gene_metadata_dict = {}
+        label_map_dict = {}
+        model_group_dict = {"Model_D": ""}  # Empty string
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        result = _create_output_entry_from_group(
+            group_key=group_key,
+            group=group,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            biodomain_dict=biodomain_dict,
+            model_info_dict=model_info_dict,
+        )
+
+        assert result["model_group"] is None  # Empty string should become None
+
+    def test_create_output_entry_multiple_biodomains(self) -> None:
+        """Test output entry with multiple biodomain assignments."""
+        group_key = ("ENSMUSG00000000005", "Model_E", "Cortex", "Male", "Tg", "Wt")
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [1.5],
+                "padj": [0.01],
+            }
+        )
+
+        gene_metadata_dict = {}
+        label_map_dict = {}
+        model_group_dict = {}
+        biodomain_dict = {"ENSMUSG00000000005": ["Synaptic", "Metabolic"]}
+        model_info_dict = {}
+
+        result = _create_output_entry_from_group(
+            group_key=group_key,
+            group=group,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            biodomain_dict=biodomain_dict,
+            model_info_dict=model_info_dict,
+        )
+
+        assert len(result["biodomains"]) == 2
+        assert set(result["biodomains"]) == {"Synaptic", "Metabolic"}
+
+
+class TestProcessSingleDataFile:
+    """
+    Unit tests for the _process_single_data_file helper function.
+
+    This class contains focused unit tests for single file processing logic,
+    testing the function in isolation from the full transformation pipeline.
+
+    Test Methods:
+        - test_process_single_data_file_basic: Tests basic file processing.
+        - test_process_single_data_file_empty_raises_error: Tests error handling for empty files.
+        - test_process_single_data_file_filters_human_genes: Tests filtering of human genes.
+        - test_process_single_data_file_rounding: Tests numeric rounding to 5 decimal places.
+        - test_process_single_data_file_multiple_groups: Tests processing multiple groups.
+    """
+
+    def test_process_single_data_file_basic(self) -> None:
+        """Test basic processing of a single data file."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001"],
+                "log2foldchange": [1.5],
+                "padj": [0.01],
+                "model": ["Model_A"],
+                "case": ["Tg"],
+                "control": ["Wt"],
+                "age": ["6 months"],
+                "sex": ["Male"],
+                "tissue": ["Cortex"],
+            }
+        )
+
+        gene_metadata_dict = {"ENSMUSG00000000001": "Gene1"}
+        label_map_dict = {
+            ("Model_A", "Tg"): "Transgenic",
+            ("Model_A", "Wt"): "Wildtype",
+        }
+        model_group_dict = {"Model_A": "Group1"}
+        biodomain_dict = {"ENSMUSG00000000001": ["Synaptic"]}
+        model_info_dict = {"Model_A": "knockout"}
+
+        data_file_required_columns = [
+            "ensembl_gene_id",
+            "log2foldchange",
+            "padj",
+            "model",
+            "case",
+            "control",
+            "age",
+            "sex",
+            "tissue",
+        ]
+
+        result = _process_single_data_file(
+            file_name="test_file.csv",
+            data_file=data_file,
+            data_file_required_columns=data_file_required_columns,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            biodomain_dict=biodomain_dict,
+            model_info_dict=model_info_dict,
+            file_index=0,
+            total_files=1,
+        )
+
+        assert len(result) == 1
+        assert result[0]["ensembl_gene_id"] == "ENSMUSG00000000001"
+        assert result[0]["gene_symbol"] == "Gene1"
+
+    def test_process_single_data_file_empty_raises_error(self) -> None:
+        """Test that processing an empty file raises ValueError with correct message.
+
+        This verifies that the empty file check happens before column validation,
+        ensuring the error message is about the file being empty, not about missing columns.
+        """
+        data_file = pd.DataFrame()
+
+        gene_metadata_dict = {}
+        label_map_dict = {}
+        model_group_dict = {}
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        data_file_required_columns = [
+            "ensembl_gene_id",
+            "log2foldchange",
+            "padj",
+            "model",
+            "case",
+            "control",
+            "age",
+            "sex",
+            "tissue",
+        ]
+
+        with pytest.raises(ValueError) as exc_info:
+            _process_single_data_file(
+                file_name="empty_file.csv",
+                data_file=data_file,
+                data_file_required_columns=data_file_required_columns,
+                gene_metadata_dict=gene_metadata_dict,
+                label_map_dict=label_map_dict,
+                model_group_dict=model_group_dict,
+                biodomain_dict=biodomain_dict,
+                model_info_dict=model_info_dict,
+                file_index=0,
+                total_files=1,
+            )
+
+        # Verify the error message is about empty file, not missing columns
+        error_message = str(exc_info.value)
+        assert "Data file empty_file.csv is empty" in error_message
+        assert "Missing required columns" not in error_message
+
+    def test_process_single_data_file_filters_human_genes(self) -> None:
+        """Test that human genes (ENSG*) are filtered out, only mouse genes (ENSMUSG*) are kept."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": [
+                    "ENSMUSG00000000001",
+                    "ENSG00000000001",
+                    "ENSMUSG00000000002",
+                ],
+                "log2foldchange": [1.5, 2.0, 0.5],
+                "padj": [0.01, 0.02, 0.03],
+                "model": ["Model_A", "Model_A", "Model_A"],
+                "case": ["Tg", "Tg", "Tg"],
+                "control": ["Wt", "Wt", "Wt"],
+                "age": ["6 months", "6 months", "6 months"],
+                "sex": ["Male", "Male", "Male"],
+                "tissue": ["Cortex", "Cortex", "Cortex"],
+            }
+        )
+
+        gene_metadata_dict = {}
+        label_map_dict = {}
+        model_group_dict = {}
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        data_file_required_columns = [
+            "ensembl_gene_id",
+            "log2foldchange",
+            "padj",
+            "model",
+            "case",
+            "control",
+            "age",
+            "sex",
+            "tissue",
+        ]
+
+        result = _process_single_data_file(
+            file_name="mixed_genes.csv",
+            data_file=data_file,
+            data_file_required_columns=data_file_required_columns,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            biodomain_dict=biodomain_dict,
+            model_info_dict=model_info_dict,
+            file_index=0,
+            total_files=1,
+        )
+
+        # Should only have 2 entries (mouse genes only)
+        assert len(result) == 2
+        assert all(entry["ensembl_gene_id"].startswith("ENSMUSG") for entry in result)
+        assert not any(entry["ensembl_gene_id"].startswith("ENSG") for entry in result)
+
+    def test_process_single_data_file_rounding(self) -> None:
+        """Test that numeric values are rounded to 5 decimal places."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001"],
+                "log2foldchange": [1.123456789],
+                "padj": [0.0123456789],
+                "model": ["Model_A"],
+                "case": ["Tg"],
+                "control": ["Wt"],
+                "age": ["6 months"],
+                "sex": ["Male"],
+                "tissue": ["Cortex"],
+            }
+        )
+
+        gene_metadata_dict = {}
+        label_map_dict = {}
+        model_group_dict = {}
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        data_file_required_columns = [
+            "ensembl_gene_id",
+            "log2foldchange",
+            "padj",
+            "model",
+            "case",
+            "control",
+            "age",
+            "sex",
+            "tissue",
+        ]
+
+        result = _process_single_data_file(
+            file_name="rounding_test.csv",
+            data_file=data_file,
+            data_file_required_columns=data_file_required_columns,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            biodomain_dict=biodomain_dict,
+            model_info_dict=model_info_dict,
+            file_index=0,
+            total_files=1,
+        )
+
+        # Values should be rounded to 5 decimal places
+        assert result[0]["6 months"]["log2_fc"] == pytest.approx(1.12346, abs=1e-6)
+        assert result[0]["6 months"]["adj_p_val"] == pytest.approx(0.01235, abs=1e-6)
+
+    def test_process_single_data_file_multiple_groups(self) -> None:
+        """Test processing a file with multiple groups (different genes/models/tissues)."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
+                "log2foldchange": [1.5, 0.5],
+                "padj": [0.01, 0.05],
+                "model": ["Model_A", "Model_B"],
+                "case": ["Tg", "Tg"],
+                "control": ["Wt", "Wt"],
+                "age": ["6 months", "3 months"],
+                "sex": ["Male", "Female"],
+                "tissue": ["Cortex", "Hippocampus"],
+            }
+        )
+
+        gene_metadata_dict = {}
+        label_map_dict = {}
+        model_group_dict = {}
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        data_file_required_columns = [
+            "ensembl_gene_id",
+            "log2foldchange",
+            "padj",
+            "model",
+            "case",
+            "control",
+            "age",
+            "sex",
+            "tissue",
+        ]
+
+        result = _process_single_data_file(
+            file_name="multiple_groups.csv",
+            data_file=data_file,
+            data_file_required_columns=data_file_required_columns,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            biodomain_dict=biodomain_dict,
+            model_info_dict=model_info_dict,
+            file_index=0,
+            total_files=1,
+        )
+
+        # Should have 2 separate output entries
+        assert len(result) == 2
+        assert result[0]["ensembl_gene_id"] == "ENSMUSG00000000001"
+        assert result[1]["ensembl_gene_id"] == "ENSMUSG00000000002"
 
 
 class TestTransformRnaDeAggregate:
@@ -547,7 +1231,7 @@ class TestTransformRnaDeAggregate:
         assert math.isclose(twelve_month_entry["adj_p_val"], 0.0, abs_tol=1e-12)
 
     def test_negative_zero_log2foldchange_are_coerced_to_zero(self) -> None:
-        """-0.0 log in source data should be exported as 0."""
+        """-0.0 log2 fold change in source data should be exported as 0."""
 
         datasets = self._load_synthetic_test_data(
             [

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -2,11 +2,14 @@
 Test suite for RNA differential expression aggregate transformation.
 
 This module contains comprehensive tests for the `transform_rna_de_aggregate` function
-and the `validate_and_sort_age_entries` helper function, which aggregate mouse model
-RNA-seq differential expression data into a structured format for the Agora platform.
+and its helper functions, which aggregate mouse model RNA-seq differential expression
+data into a structured format for the Agora platform.
 
 Test Classes:
-    - TestValidateAndSortAgeEntries: Unit tests for the age validation and sorting helper function
+    - TestValidateAndSortAgeEntries: Unit tests for the _validate_and_sort_age_entries helper function
+    - TestCreateAgeEntriesFromGroup: Unit tests for the _create_age_entries_from_group helper function
+    - TestCreateOutputEntryFromGroup: Unit tests for the _create_output_entry_from_group helper function
+    - TestProcessSingleDataFile: Unit tests for the _process_single_data_file helper function
     - TestTransformRnaDeAggregate: Integration tests for the full transformation pipeline
 
 The tests use synthetic datasets stored in `tests/test_assets/rna_de_aggregate/` to verify:
@@ -16,6 +19,9 @@ The tests use synthetic datasets stored in `tests/test_assets/rna_de_aggregate/`
 - Human gene filtering (only mouse genes with ENSMUSG* IDs should be processed)
 - Age sorting (numeric ordering of age entries)
 - Age validation (empty strings, whitespace, invalid formats)
+- NaN handling (NaN adjusted p-values are coerced to 0.0)
+- Negative zero handling (negative zero log2foldchange values are normalized to positive zero)
+- Negative p-value validation (negative adjusted p-values raise ValueError)
 - Edge cases (single row data, missing metadata, empty biodomains)
 - Error handling (missing datasets, empty files, missing columns, invalid age formats, inconsistent model_group values)
 - Data precision (rounding to 5 decimal places)
@@ -42,7 +48,7 @@ import pytest
 
 from agoradatatools.etl.transform.rna_de_aggregate import (
     transform_rna_de_aggregate,
-    validate_and_sort_age_entries,
+    _validate_and_sort_age_entries,
     _create_age_entries_from_group,
     _create_output_entry_from_group,
     _process_single_data_file,
@@ -51,7 +57,7 @@ from agoradatatools.etl.transform.rna_de_aggregate import (
 
 class TestValidateAndSortAgeEntries:
     """
-    Unit tests for the validate_and_sort_age_entries helper function.
+    Unit tests for the _validate_and_sort_age_entries helper function.
 
     This class contains focused unit tests for age validation and sorting logic,
     testing the function in isolation from the full transformation pipeline.
@@ -75,7 +81,7 @@ class TestValidateAndSortAgeEntries:
         """Test that a single valid age entry is handled correctly."""
         age_entries = {"6 months": {"log2_fc": 0.5, "adj_p_val": 0.01}}
 
-        result = validate_and_sort_age_entries(
+        result = _validate_and_sort_age_entries(
             age_entries=age_entries,
             ensembl_gene_id="ENSMUSG00000000001",
             model="TestModel",
@@ -93,7 +99,7 @@ class TestValidateAndSortAgeEntries:
             "12 months": {"log2_fc": 0.8, "adj_p_val": 0.005},
         }
 
-        result = validate_and_sort_age_entries(
+        result = _validate_and_sort_age_entries(
             age_entries=age_entries,
             ensembl_gene_id="ENSMUSG00000000001",
             model="TestModel",
@@ -112,7 +118,7 @@ class TestValidateAndSortAgeEntries:
             "6 months": {"log2_fc": 0.5, "adj_p_val": 0.01},
         }
 
-        result = validate_and_sort_age_entries(
+        result = _validate_and_sort_age_entries(
             age_entries=age_entries,
             ensembl_gene_id="ENSMUSG00000000001",
             model="TestModel",
@@ -135,7 +141,7 @@ class TestValidateAndSortAgeEntries:
         }
 
         # This should work because split()[0] handles multiple spaces
-        result = validate_and_sort_age_entries(
+        result = _validate_and_sort_age_entries(
             age_entries=age_entries,
             ensembl_gene_id="ENSMUSG00000000001",
             model="TestModel",
@@ -150,7 +156,7 @@ class TestValidateAndSortAgeEntries:
         age_entries = {"": {"log2_fc": 0.5, "adj_p_val": 0.01}}
 
         with pytest.raises(ValueError) as exc_info:
-            validate_and_sort_age_entries(
+            _validate_and_sort_age_entries(
                 age_entries=age_entries,
                 ensembl_gene_id="ENSMUSG00000000001",
                 model="TestModel",
@@ -170,7 +176,7 @@ class TestValidateAndSortAgeEntries:
         age_entries = {"   ": {"log2_fc": 0.5, "adj_p_val": 0.01}}
 
         with pytest.raises(ValueError) as exc_info:
-            validate_and_sort_age_entries(
+            _validate_and_sort_age_entries(
                 age_entries=age_entries,
                 ensembl_gene_id="ENSMUSG00000000002",
                 model="Model_X",
@@ -190,7 +196,7 @@ class TestValidateAndSortAgeEntries:
         age_entries = {"6months": {"log2_fc": 0.5, "adj_p_val": 0.01}}
 
         with pytest.raises(ValueError) as exc_info:
-            validate_and_sort_age_entries(
+            _validate_and_sort_age_entries(
                 age_entries=age_entries,
                 ensembl_gene_id="ENSMUSG00000000004",
                 model="Model_Z",
@@ -210,7 +216,7 @@ class TestValidateAndSortAgeEntries:
         age_entries = {"unknown months": {"log2_fc": 0.5, "adj_p_val": 0.01}}
 
         with pytest.raises(ValueError) as exc_info:
-            validate_and_sort_age_entries(
+            _validate_and_sort_age_entries(
                 age_entries=age_entries,
                 ensembl_gene_id="ENSMUSG00000000005",
                 model="Model_A",
@@ -230,7 +236,7 @@ class TestValidateAndSortAgeEntries:
 
         # This actually won't raise an error because int("-6") works
         # But it will sort correctly
-        result = validate_and_sort_age_entries(
+        result = _validate_and_sort_age_entries(
             age_entries=age_entries,
             ensembl_gene_id="ENSMUSG00000000006",
             model="Model_B",
@@ -246,7 +252,7 @@ class TestValidateAndSortAgeEntries:
 
         # This will raise because int("6.5") fails
         with pytest.raises(ValueError) as exc_info:
-            validate_and_sort_age_entries(
+            _validate_and_sort_age_entries(
                 age_entries=age_entries,
                 ensembl_gene_id="ENSMUSG00000000007",
                 model="Model_C",
@@ -266,7 +272,7 @@ class TestValidateAndSortAgeEntries:
             "12 days": {"log2_fc": 0.3, "adj_p_val": 0.02},
         }
 
-        result = validate_and_sort_age_entries(
+        result = _validate_and_sort_age_entries(
             age_entries=age_entries,
             ensembl_gene_id="ENSMUSG00000000008",
             model="Model_D",
@@ -281,7 +287,7 @@ class TestValidateAndSortAgeEntries:
         """Test that empty age_entries dictionary is handled gracefully."""
         age_entries = {}
 
-        result = validate_and_sort_age_entries(
+        result = _validate_and_sort_age_entries(
             age_entries=age_entries,
             ensembl_gene_id="ENSMUSG00000000009",
             model="Model_E",

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -600,7 +600,7 @@ class TestTransformRnaDeAggregate:
         assert len(output_data) == 1
         entry = output_data[0]
         age_entry = entry["12 months"]
-        assert age_entry["adj_p_val"] == 0.0
+        assert age_entry["adj_p_val"] == pytest.approx(0.0, abs=1e-12)
         assert entry["tissue"] == "Hemibrain"
 
     def test_synthetic_age_sorting(self) -> None:


### PR DESCRIPTION
## Problem
- `transform_rna_de_aggregate` propagated `NaN` adjusted p-values from the upstream differential-expression CSVs, producing invalid JSON in `rna_de_aggregate.json`.
- `transform_rna_de_aggregate` created `-0.0` values when rounding very small negative numbers.

## Solution
- Coerce `padj` values to `0.0` when they are `NaN` while building age entries, leaving the rest of the transform untouched.
- Coerce `-0.0` values to `0.0` by adding `0.0` to all `log2_fc` and `adj_p_val` values. This works because adding zero to negative zero produces positive zero according to IEEE 754 floating-point arithmetic rules. I used this method because it is simple and does not require any conditionals.

## Testing
- Added a test that feeds a dataset containing a `NaN` `padj`, verifying the output is `0.0` and that the JAX tissue remapping still occurs.
- Added a test that feeds a dataset containing a very small negative number `padj`, verifying the output is `0.0` and that the JAX tissue remapping still occurs.

## Important Note
I know it looks like there are a lot of new changes, but in reality its just the converting NaN to 0.0 and converting -0.0 to 0.0. I had to move code out of the main transform function and into separate helper functions because it exceeded SonarCloud's cognitive complexity. I added very detailed function docstrings to help us all keep track of what each function is doing. I also added tests for the new helper functions.