### PR TITLE
AG-1902: Update source file versions to pick up ensembl 115 and TREAT-AD nominations

### DIFF
--- a/configs/agora_preprod.yaml
+++ b/configs/agora_preprod.yaml
@@ -147,7 +147,7 @@ datasets:
         - <<: *agora_proteomics_srm_files
         - <<: *rna_diff_expr_data_files
         - name: target_list
-          id: syn12540368.54
+          id: syn12540368.62
           format: csv
         - name: median_expression
           id: syn27211878.2
@@ -157,7 +157,7 @@ datasets:
           id: syn51942280.6
           format: csv
         - name: ensg_to_uniprot_mapping
-          id: syn54113663.5
+          id: syn54113663.6
           format: tsv
         - name: pharos_classes
           id: syn64123611.2

--- a/configs/agora_prod.yaml
+++ b/configs/agora_prod.yaml
@@ -147,7 +147,7 @@ datasets:
         - <<: *agora_proteomics_srm_files
         - <<: *rna_diff_expr_data_files
         - name: target_list
-          id: syn12540368.54
+          id: syn12540368.62
           format: csv
         - name: median_expression
           id: syn27211878.2
@@ -157,7 +157,7 @@ datasets:
           id: syn51942280.6
           format: csv
         - name: ensg_to_uniprot_mapping
-          id: syn54113663.5
+          id: syn54113663.6
           format: tsv
         - name: pharos_classes
           id: syn64123611.2


### PR DESCRIPTION
This PR updates the Agora configs to pick up the following new data:
* ensg_to_uniprot_mapping: protein mappings for ensembl release 115
* target_list: TREAT-AD 2025 nominations, round 2

Note that the new ensembl 115 version of gene_metadata has already been incorporated.

