### PR TITLE
MG-594: Rename rna_de_aggregate.sex to sex_cohort

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -202,7 +202,7 @@ ge_matched_control_column <- list("Control", "text", "matched_control", NA, "Sor
 
 # Hidden static columns
 ge_tissue_column <- list(NA, "text", "tissue", NA, NA, NA, NA, TRUE, TRUE)
-ge_sex_column <- list(NA, "text", "sex", NA, NA, NA, NA, TRUE, TRUE)
+ge_sex_cohort_column <- list(NA, "text", "sex_cohort", NA, NA, NA, NA, TRUE, TRUE)
 ge_biodomains_column <- list(NA, "text", "biodomains", NA, NA, NA, NA, TRUE, TRUE)
 ge_model_group_column <- list(NA, "text", "model_group", NA, NA, NA, NA, FALSE, TRUE)
 ge_model_type_column <- list(NA, "text", "model_type", NA, NA, NA, NA, TRUE, TRUE)
@@ -243,7 +243,7 @@ build_ge_objects <- function() {
   primary <- do.call(build_column, ge_primary_column)
   ensembl_gene_id  <- do.call(build_column, ge_ensembl_gene_id_column)
   tissue <- do.call(build_column, ge_tissue_column)
-  sex <- do.call(build_column, ge_sex_column)
+  sex_cohort <- do.call(build_column, ge_sex_cohort_column)
   model <- do.call(build_column, ge_model_column)
   matched_control <- do.call(build_column, ge_matched_control_column)
   biodomains <- do.call(build_column, ge_biodomains_column)
@@ -264,7 +264,7 @@ build_ge_objects <- function() {
     })
 
     # The column ordering is mirrored when a CSV is generated
-    columns <- c(list(primary, ensembl_gene_id, tissue, sex, model, matched_control), dynamic_columns, c(list(biodomains, model_type, model_group)))
+    columns <- c(list(primary, ensembl_gene_id, tissue, sex_cohort, model, matched_control), dynamic_columns, c(list(biodomains, model_type, model_group)))
     filters <- build_filters(ge_filters, ge_filter_values)
 
     list(

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -286,7 +286,7 @@ def _create_output_entry_from_group(
         "model_group": model_group if model_group != "" else None,
         "model_type": model_type,
         "tissue": tissue,
-        "sex": sex,
+        "sex_cohort": sex,
         **sorted_ages,
     }
 

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_age_sorting_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_age_sorting_output.json
@@ -8,7 +8,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Brain",
-    "sex": "Female",
+    "sex_cohort": "Female",
     "3 months": {
       "log2_fc": 2.0,
       "adj_p_val": 0.2

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_basic_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_basic_output.json
@@ -8,7 +8,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Brain",
-    "sex": "Female",
+    "sex_cohort": "Female",
     "3 months": {
       "log2_fc": 1.0,
       "adj_p_val": 0.01
@@ -27,7 +27,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Brain",
-    "sex": "Female",
+    "sex_cohort": "Female",
     "3 months": {
       "log2_fc": -1.5,
       "adj_p_val": 0.03

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_jax_tissue_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_jax_tissue_output.json
@@ -8,7 +8,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Hemibrain",
-    "sex": "Male",
+    "sex_cohort": "Male",
     "3 months": {
       "log2_fc": 3.0,
       "adj_p_val": 0.3

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_mixed_genes_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_mixed_genes_output.json
@@ -8,7 +8,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Brain",
-    "sex": "Female",
+    "sex_cohort": "Female",
     "3 months": {
       "log2_fc": 1.5,
       "adj_p_val": 0.15
@@ -23,7 +23,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Brain",
-    "sex": "Male",
+    "sex_cohort": "Male",
     "6 months": {
       "log2_fc": -1.0,
       "adj_p_val": 0.1

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_multi_model_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_multi_model_output.json
@@ -8,7 +8,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Hippocampus",
-    "sex": "Male",
+    "sex_cohort": "Male",
     "3 months": {
       "log2_fc": 1.1,
       "adj_p_val": 0.011
@@ -27,7 +27,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Cortex",
-    "sex": "Female",
+    "sex_cohort": "Female",
     "3 months": {
       "log2_fc": 0.5,
       "adj_p_val": 0.05

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_multiple_biodomains_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_multiple_biodomains_output.json
@@ -8,7 +8,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Brain",
-    "sex": "Female",
+    "sex_cohort": "Female",
     "3 months": {
       "log2_fc": 1.5,
       "adj_p_val": 0.01

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_null_model_group_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_null_model_group_output.json
@@ -8,7 +8,7 @@
     "model_group": null,
     "model_type": "Transgenic",
     "tissue": "Brain",
-    "sex": "Female",
+    "sex_cohort": "Female",
     "3 months": {
       "log2_fc": 1.0,
       "adj_p_val": 0.01

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_rounding_precision_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_rounding_precision_output.json
@@ -8,7 +8,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Brain",
-    "sex": "Female",
+    "sex_cohort": "Female",
     "3 months": {
       "log2_fc": 1.12346,
       "adj_p_val": 0.01235

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_single_row_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_single_row_output.json
@@ -8,7 +8,7 @@
     "model_group": "AD",
     "model_type": "Transgenic",
     "tissue": "Striatum",
-    "sex": "Male",
+    "sex_cohort": "Male",
     "9 months": {
       "log2_fc": 5.0,
       "adj_p_val": 0.5

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -543,7 +543,7 @@ class TestCreateOutputEntryFromGroup:
         assert result["model_group"] == "Group1"
         assert result["model_type"] == "knockout"
         assert result["tissue"] == "Cortex"
-        assert result["sex"] == "Male"
+        assert result["sex_cohort"] == "Male"
         assert "6 months" in result
         assert result["6 months"]["log2_fc"] == pytest.approx(1.5)
         assert result["6 months"]["adj_p_val"] == pytest.approx(0.01)
@@ -591,7 +591,7 @@ class TestCreateOutputEntryFromGroup:
         assert result["model_group"] is None  # Empty string converted to None
         assert result["model_type"] == ""  # Default for missing
         assert result["tissue"] == "Hippocampus"
-        assert result["sex"] == "Female"
+        assert result["sex_cohort"] == "Female"
 
     def test_create_output_entry_jax_tissue_mapping(self) -> None:
         """Test that JAX tissue name 'Right Cerebral Hemisphere' is mapped to 'Hemibrain'."""


### PR DESCRIPTION
## Problem

The rna_de_aggregate dataset's `sex` field has three valid values (Female, Male, Female & Male), while other data collections have a `sex` field that has only two valid values (Female, Male). 

This introduces additional cognitive load for the developers when managing code that needs to function across multiple data collections.

## Solution

Rename the field to `sex_cohort` to more accurately reflect the nature of the field for an aggregated population of mice.

Also, fix the tests.