### PR TITLE
MG-602: rnaseq_de_aggregate contains unexpected duplicate objects

### DIFF
--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -209,13 +209,16 @@ def _create_output_entry_from_group(
     Args:
         group_key: Tuple containing (ensembl_gene_id, model, tissue, sex, case, control)
             that uniquely identifies this group. The case and control values represent the
-            genotype labels for the experimental and control conditions.
+            genotype identifiers (e.g., '5XFAD_carrier', '5XFAD_noncarrier') from the input
+            data files, which are mapped to display labels via the label_map_dict.
         group: DataFrame group containing age-based differential expression data. Each row
             represents a single age timepoint with columns: age, log2foldchange, padj.
         gene_metadata_dict: Dictionary mapping Ensembl gene IDs to gene symbols. Used to
             enrich entries with human-readable gene names.
         label_map_dict: Dictionary mapping (model, genotype) tuples to display labels.
-            Used to create human-readable names for case and control conditions.
+            Used to map genotype identifiers to human-readable display names for case and
+            control conditions. For example, ('5xFAD (UCI)', '5XFAD_carrier') -> '5xFAD (UCI)',
+            or ('5xFAD (UCI)', '5XFAD_noncarrier') -> 'C57BL/6J'.
         model_group_dict: Dictionary mapping model names to model groups. Used to categorize
             models into groups (e.g., "5XFAD", "APP/PS1").
         biodomain_dict: Dictionary mapping Ensembl gene IDs to lists of biodomain names.
@@ -335,7 +338,9 @@ def _process_single_data_file(
         gene_metadata_dict: Dictionary mapping Ensembl gene IDs to gene symbols. Used
             to enrich output entries with human-readable gene names.
         label_map_dict: Dictionary mapping (model, genotype) tuples to display labels.
-            Used to create human-readable names for case and control conditions.
+            Used to map genotype identifiers to human-readable display names for case and
+            control conditions. For example, ('5xFAD (UCI)', '5XFAD_carrier') -> '5xFAD (UCI)',
+            or ('5xFAD (UCI)', '5XFAD_noncarrier') -> 'C57BL/6J'.
         model_group_dict: Dictionary mapping model names to model groups. Used to
             categorize models into groups (e.g., "5XFAD", "APP/PS1").
         biodomain_dict: Dictionary mapping Ensembl gene IDs to lists of biodomain names.
@@ -425,7 +430,7 @@ def transform_rna_de_aggregate(
     1. Validates that all required input datasets and columns are present
     2. Pre-computes lookup dictionaries from metadata for efficient data enrichment:
        - Gene symbols from Ensembl IDs
-       - Display labels for genotypes
+       - Display labels for genotype identifiers (case/control) by model
        - Model groups and types
        - Biodomain annotations
     3. Validates data consistency (e.g., ensures each model has a consistent model_group)
@@ -442,7 +447,9 @@ def transform_rna_de_aggregate(
 
     Args:
         datasets: Dictionary mapping dataset names to DataFrames. Must include:
-            - 'rnaseq_genotype_label_map': Maps models and genotypes to display labels
+            - 'rnaseq_genotype_label_map': Maps (model, genotype) combinations to display labels
+              and organizes models into model_groups. Each row specifies how a genotype identifier
+              should be displayed for a given model.
             - 'mouse_gene_metadata': Gene symbols and aliases for Ensembl IDs
             - 'model_info': Model types and metadata
             - 'biodom_genes_mm': Biodomain annotations for mouse genes

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -259,8 +259,8 @@ def _create_output_entry_from_group(
     ensembl_gene_id, model, tissue, sex, case, control = group_key
 
     gene_symbol = gene_metadata_dict.get(ensembl_gene_id, "")
-    name = label_map_dict.get((model, case), model)
-    matched_control = label_map_dict.get((model, control), model)
+    name = label_map_dict.get((model, case), case)
+    matched_control = label_map_dict.get((model, control), control)
     model_group = model_group_dict.get(model)
     biodomains = biodomain_dict.get(ensembl_gene_id, [])
     model_type = model_info_dict.get(model, "")

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -549,7 +549,7 @@ class TestCreateOutputEntryFromGroup:
         assert result["6 months"]["adj_p_val"] == pytest.approx(0.01)
 
     def test_create_output_entry_missing_metadata(self) -> None:
-        """Test output entry creation with missing metadata (defaults to empty strings/lists)."""
+        """Test output entry creation with missing metadata (defaults to genotype strings for name/matched_control)."""
         group_key = (
             "ENSMUSG00000000002",
             "Model_B",
@@ -586,8 +586,8 @@ class TestCreateOutputEntryFromGroup:
         assert result["ensembl_gene_id"] == "ENSMUSG00000000002"
         assert result["gene_symbol"] == ""  # Default for missing
         assert result["biodomains"] == []  # Default for missing
-        assert result["name"] == "Model_B"  # Falls back to model name
-        assert result["matched_control"] == "Model_B"  # Falls back to model name
+        assert result["name"] == "Tg"  # Falls back to case genotype
+        assert result["matched_control"] == "Wt"  # Falls back to control genotype
         assert result["model_group"] is None  # Empty string converted to None
         assert result["model_type"] == ""  # Default for missing
         assert result["tissue"] == "Hippocampus"


### PR DESCRIPTION
# MG-602: rnaseq_de_aggregate contains unexpected duplicate objects
The `rna_de_aggregate` output contained unexpected duplicate objects with the same `gene` + `model` + `tissue` + `sex_cohort` combination, but different `log2_fc` and `adj_p_val` values. This caused data inconsistencies and made it impossible for downstream consumers to uniquely identify differential expression results.

## Root Cause
The issue occurred when genotype-to-display-label mappings were missing from the `rnaseq_genotype_label_map`. In these cases, the transform was defaulting to use the `model` name for **both** the case (`name`) and control (`matched_control`) labels.

## Solution

Changed the fallback logic to use the actual genotype identifiers from the input data instead of the model name:
```
name = label_map_dict.get((model, case), case)          # defaults to "Model_X_carrier"
matched_control = label_map_dict.get((model, control), control)  # defaults to "Model_X_noncarrier"
```

## Changes Made

1. **Fixed Fallback Logic** (`src/agoradatatools/etl/transform/rna_de_aggregate.py`)
   - Modified `_create_output_entry_from_group` to default to `case`/`control` genotype identifiers instead of `model` name
   - This ensures unique output entries even when display label mappings are incomplete

2. **Enhanced Documentation**
   - Added concrete examples of genotype-to-display-label mappings
   - Clarified that `case` and `control` are genotype identifiers in input data
   - Updated docstrings to explain the mapping process and fallback behavior

3. **Updated Tests** (`tests/transform/test_rna_de_aggregate.py`)
   - Modified `test_create_output_entry_missing_metadata` to validate new fallback behavior
   - Test now expects genotype identifiers (`'Tg'`, `'Wt'`) instead of model name