### PR TITLE
MG-607: Update rna_de_aggregate transform to generate link objects for name field

### DIFF
--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -231,7 +231,7 @@ def _create_output_entry_from_group(
             - 'ensembl_gene_id': str, Ensembl gene identifier
             - 'gene_symbol': str, Human-readable gene symbol (empty string if not found)
             - 'biodomains': List[str], List of biodomain names associated with the gene
-            - 'name': dict, Object with 'link_url' key containing the model link path
+            - 'name': dict, Object with 'link_url' and 'link_text' keys containing the model link path and display text
             - 'matched_control': str, Display label for the control genotype
             - 'model_group': str or None, Model group name (None if empty)
             - 'model_type': str, Model type classification (empty string if not found)
@@ -245,7 +245,7 @@ def _create_output_entry_from_group(
                 'ensembl_gene_id': 'ENSMUSG00000000001',
                 'gene_symbol': 'Gapdh',
                 'biodomains': ['Synaptic', 'Metabolic'],
-                'name': {'link_url': 'models/5XFAD'},
+                'name': {'link_url': 'models/5XFAD', 'link_text': '5XFAD'},
                 'matched_control': 'Wild-type',
                 'model_group': '5XFAD',
                 'model_type': 'transgenic',
@@ -284,7 +284,7 @@ def _create_output_entry_from_group(
         "ensembl_gene_id": ensembl_gene_id,
         "gene_symbol": gene_symbol,
         "biodomains": biodomains,
-        "name": {"link_url": f"models/{name}"},
+        "name": {"link_url": f"models/{name}", "link_text": name},
         "matched_control": matched_control,
         "model_group": model_group if model_group != "" else None,
         "model_type": model_type,
@@ -464,7 +464,7 @@ def transform_rna_de_aggregate(
         List of dictionaries, where each dictionary represents a unique combination of
         gene, model, tissue, and sex. Each entry contains:
             - Gene identifiers: ensembl_gene_id, gene_symbol
-            - Model information: name (object with link_url), matched_control, model_group, model_type
+            - Model information: name (object with link_url and link_text), matched_control, model_group, model_type
             - Sample information: tissue, sex
             - Biodomain annotations: biodomains (list)
             - Age-based measurements: Dictionary keys are age strings (e.g., '3 months')
@@ -475,7 +475,7 @@ def transform_rna_de_aggregate(
                 'ensembl_gene_id': 'ENSMUSG00000000001',
                 'gene_symbol': 'Gapdh',
                 'biodomains': ['Synaptic', 'Metabolic'],
-                'name': {'link_url': 'models/5XFAD'},
+                'name': {'link_url': 'models/5XFAD', 'link_text': '5XFAD'},
                 'matched_control': 'Wild-type',
                 'model_group': '5XFAD',
                 'model_type': 'transgenic',

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -231,7 +231,7 @@ def _create_output_entry_from_group(
             - 'ensembl_gene_id': str, Ensembl gene identifier
             - 'gene_symbol': str, Human-readable gene symbol (empty string if not found)
             - 'biodomains': List[str], List of biodomain names associated with the gene
-            - 'name': str, Display label for the case genotype
+            - 'name': dict, Object with 'link_url' key containing the model link path
             - 'matched_control': str, Display label for the control genotype
             - 'model_group': str or None, Model group name (None if empty)
             - 'model_type': str, Model type classification (empty string if not found)
@@ -245,7 +245,7 @@ def _create_output_entry_from_group(
                 'ensembl_gene_id': 'ENSMUSG00000000001',
                 'gene_symbol': 'Gapdh',
                 'biodomains': ['Synaptic', 'Metabolic'],
-                'name': '5XFAD',
+                'name': {'link_url': 'models/5XFAD'},
                 'matched_control': 'Wild-type',
                 'model_group': '5XFAD',
                 'model_type': 'transgenic',
@@ -284,7 +284,7 @@ def _create_output_entry_from_group(
         "ensembl_gene_id": ensembl_gene_id,
         "gene_symbol": gene_symbol,
         "biodomains": biodomains,
-        "name": name,
+        "name": {"link_url": f"models/{name}"},
         "matched_control": matched_control,
         "model_group": model_group if model_group != "" else None,
         "model_type": model_type,
@@ -464,7 +464,7 @@ def transform_rna_de_aggregate(
         List of dictionaries, where each dictionary represents a unique combination of
         gene, model, tissue, and sex. Each entry contains:
             - Gene identifiers: ensembl_gene_id, gene_symbol
-            - Model information: name, matched_control, model_group, model_type
+            - Model information: name (object with link_url), matched_control, model_group, model_type
             - Sample information: tissue, sex
             - Biodomain annotations: biodomains (list)
             - Age-based measurements: Dictionary keys are age strings (e.g., '3 months')
@@ -475,7 +475,7 @@ def transform_rna_de_aggregate(
                 'ensembl_gene_id': 'ENSMUSG00000000001',
                 'gene_symbol': 'Gapdh',
                 'biodomains': ['Synaptic', 'Metabolic'],
-                'name': '5XFAD',
+                'name': {'link_url': 'models/5XFAD'},
                 'matched_control': 'Wild-type',
                 'model_group': '5XFAD',
                 'model_type': 'transgenic',

--- a/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
+++ b/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
@@ -156,8 +156,8 @@ The `case` and `control` columns in the input data represent the comparison bein
 - **Control**: The control condition (e.g., wild-type "Wt")
 
 The `rnaseq_genotype_label_map.csv` file maps these genotypes to human-readable display labels:
-- `case` → `name` (e.g., "Model_A (Tg)")
-- `control` → `matched_control` (e.g., "Model_A (Wt)")
+- `case` → `name` (object with `link_url` field, e.g., `{"link_url": "models/Model_A (Tg)"}`)
+- `control` → `matched_control` (string, e.g., "Model_A (Wt)")
 
 ### Example Grouping
 Given input data:
@@ -172,6 +172,51 @@ This creates **2 output entries**:
 1. Gene + Model_A + Female + Brain + Tg/Wt → contains ages 3 months, 6 months
 2. Gene + Model_A + Male + Brain + Tg/Wt → contains age 3 months
 
+## Output Structure
+
+Each output entry in the transform result has the following structure:
+
+```json
+{
+  "ensembl_gene_id": "ENSMUSG00000000001",
+  "gene_symbol": "Gene_A",
+  "biodomains": ["Synaptic"],
+  "name": {
+    "link_url": "models/Model_A (Tg)"
+  },
+  "matched_control": "Model_A (Wt)",
+  "model_group": "AD",
+  "model_type": "Transgenic",
+  "tissue": "Brain",
+  "sex_cohort": "Female",
+  "3 months": {
+    "log2_fc": 1.0,
+    "adj_p_val": 0.01
+  },
+  "6 months": {
+    "log2_fc": 2.0,
+    "adj_p_val": 0.02
+  }
+}
+```
+
+### Output Fields
+
+- **ensembl_gene_id** (string): Mouse gene identifier (ENSMUSG*)
+- **gene_symbol** (string): Human-readable gene symbol (empty string if not found in metadata)
+- **biodomains** (array): List of biodomain names associated with the gene
+- **name** (object): Display label for the case genotype with navigation link
+  - **link_url** (string): Relative URL path to the model page (format: `models/<display_label>`)
+- **matched_control** (string): Display label for the control genotype
+- **model_group** (string or null): Model group name (null if empty)
+- **model_type** (string): Model type classification (e.g., "Transgenic", "knockout")
+- **tissue** (string): Tissue name (JAX models have "Right Cerebral Hemisphere" mapped to "Hemibrain")
+- **sex_cohort** (string): Sex category ("Male" or "Female")
+- **<age>** (object): Age-based entries (keys are age strings like "3 months", "6 months", etc.)
+  - **log2_fc** (number): Log2 fold change value (rounded to 5 decimal places)
+  - **adj_p_val** (number): Adjusted p-value (rounded to 5 decimal places, NaN values coerced to 0.0)
+
+
 ## Validation Points
 
 When testing, verify:
@@ -182,15 +227,16 @@ When testing, verify:
 5. **Label mapping**: Correct display labels from genotype map
 6. **Model metadata**: Correct model type and matched controls
 7. **Grouping logic**: One output entry per unique gene+model+tissue+sex+case+control combination
-8. **Case/control mapping**: Correct name and matched_control values from genotype labels
-9. **Numeric rounding**: log2_fc and adj_p_val rounded to exactly 5 decimal places
-10. **Multiple biodomains**: Genes can have multiple biodomain assignments in a list
-11. **Missing metadata**: Gene not in metadata → gene_symbol="" and biodomains=[]
-12. **Null model_group**: Empty model_group converted to null in output
-13. **Model group consistency**: Each model must have consistent model_group values across all genotypes (raises ValueError if inconsistent)
-14. **Negative padj validation**: Negative adjusted p-values raise ValueError with informative error message
-15. **Log2foldchange normalization**: Negative zero (-0.0) log2foldchange values are normalized to positive zero (0.0) via normalize_zero function
-16. **NaN padj coercion**: NaN adjusted p-values are coerced to 0.0 in output
+8. **Case/control mapping**: Correct name (with link_url) and matched_control values from genotype labels
+9. **Name field structure**: `name` is an object with `link_url` field formatted as `models/<display_label>`
+10. **Numeric rounding**: log2_fc and adj_p_val rounded to exactly 5 decimal places
+11. **Multiple biodomains**: Genes can have multiple biodomain assignments in a list
+12. **Missing metadata**: Gene not in metadata → gene_symbol="" and biodomains=[]
+13. **Null model_group**: Empty model_group converted to null in output
+14. **Model group consistency**: Each model must have consistent model_group values across all genotypes (raises ValueError if inconsistent)
+15. **Negative padj validation**: Negative adjusted p-values raise ValueError with informative error message
+16. **Log2foldchange normalization**: Negative zero (-0.0) log2foldchange values are normalized to positive zero (0.0) via normalize_zero function
+17. **NaN padj coercion**: NaN adjusted p-values are coerced to 0.0 in output
 
 ## File Structure
 ```

--- a/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
+++ b/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
@@ -156,7 +156,7 @@ The `case` and `control` columns in the input data represent the comparison bein
 - **Control**: The control condition (e.g., wild-type "Wt")
 
 The `rnaseq_genotype_label_map.csv` file maps these genotypes to human-readable display labels:
-- `case` → `name` (object with `link_url` field, e.g., `{"link_url": "models/Model_A (Tg)"}`)
+- `case` → `name` (object with `link_url` and `link_text` fields, e.g., `{"link_url": "models/Model_A (Tg)", "link_text": "Model_A (Tg)"}`)
 - `control` → `matched_control` (string, e.g., "Model_A (Wt)")
 
 ### Example Grouping
@@ -182,7 +182,8 @@ Each output entry in the transform result has the following structure:
   "gene_symbol": "Gene_A",
   "biodomains": ["Synaptic"],
   "name": {
-    "link_url": "models/Model_A (Tg)"
+    "link_url": "models/Model_A (Tg)",
+    "link_text": "Model_A (Tg)"
   },
   "matched_control": "Model_A (Wt)",
   "model_group": "AD",
@@ -207,6 +208,7 @@ Each output entry in the transform result has the following structure:
 - **biodomains** (array): List of biodomain names associated with the gene
 - **name** (object): Display label for the case genotype with navigation link
   - **link_url** (string): Relative URL path to the model page (format: `models/<display_label>`)
+  - **link_text** (string): Display text for the link (typically the model name/label)
 - **matched_control** (string): Display label for the control genotype
 - **model_group** (string or null): Model group name (null if empty)
 - **model_type** (string): Model type classification (e.g., "Transgenic", "knockout")
@@ -227,8 +229,8 @@ When testing, verify:
 5. **Label mapping**: Correct display labels from genotype map
 6. **Model metadata**: Correct model type and matched controls
 7. **Grouping logic**: One output entry per unique gene+model+tissue+sex+case+control combination
-8. **Case/control mapping**: Correct name (with link_url) and matched_control values from genotype labels
-9. **Name field structure**: `name` is an object with `link_url` field formatted as `models/<display_label>`
+8. **Case/control mapping**: Correct name (with link_url and link_text) and matched_control values from genotype labels
+9. **Name field structure**: `name` is an object with `link_url` and `link_text` fields formatted as `models/<display_label>`
 10. **Numeric rounding**: log2_fc and adj_p_val rounded to exactly 5 decimal places
 11. **Multiple biodomains**: Genes can have multiple biodomain assignments in a list
 12. **Missing metadata**: Gene not in metadata → gene_symbol="" and biodomains=[]

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_age_sorting_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_age_sorting_output.json
@@ -3,7 +3,9 @@
     "ensembl_gene_id": "ENSMUSG00000000007",
     "gene_symbol": "Gene_G",
     "biodomains": [],
-    "name": "Model_E (Tg)",
+    "name": {
+      "link_url": "models/Model_E (Tg)"
+    },
     "matched_control": "Model_E (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_age_sorting_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_age_sorting_output.json
@@ -4,7 +4,8 @@
     "gene_symbol": "Gene_G",
     "biodomains": [],
     "name": {
-      "link_url": "models/Model_E (Tg)"
+      "link_url": "models/Model_E (Tg)",
+      "link_text": "Model_E (Tg)"
     },
     "matched_control": "Model_E (Wt)",
     "model_group": "AD",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_basic_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_basic_output.json
@@ -3,7 +3,9 @@
     "ensembl_gene_id": "ENSMUSG00000000001",
     "gene_symbol": "Gene_A",
     "biodomains": ["Synaptic"],
-    "name": "Model_A (Tg)",
+    "name": {
+      "link_url": "models/Model_A (Tg)"
+    },
     "matched_control": "Model_A (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",
@@ -22,7 +24,9 @@
     "ensembl_gene_id": "ENSMUSG00000000002",
     "gene_symbol": "Gene_B",
     "biodomains": ["Synaptic"],
-    "name": "Model_A (Tg)",
+    "name": {
+      "link_url": "models/Model_A (Tg)"
+    },
     "matched_control": "Model_A (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_basic_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_basic_output.json
@@ -4,7 +4,8 @@
     "gene_symbol": "Gene_A",
     "biodomains": ["Synaptic"],
     "name": {
-      "link_url": "models/Model_A (Tg)"
+      "link_url": "models/Model_A (Tg)",
+      "link_text": "Model_A (Tg)"
     },
     "matched_control": "Model_A (Wt)",
     "model_group": "AD",
@@ -25,7 +26,8 @@
     "gene_symbol": "Gene_B",
     "biodomains": ["Synaptic"],
     "name": {
-      "link_url": "models/Model_A (Tg)"
+      "link_url": "models/Model_A (Tg)",
+      "link_text": "Model_A (Tg)"
     },
     "matched_control": "Model_A (Wt)",
     "model_group": "AD",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_jax_tissue_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_jax_tissue_output.json
@@ -4,7 +4,8 @@
     "gene_symbol": "Gene_D",
     "biodomains": ["Metabolic"],
     "name": {
-      "link_url": "models/JAX_Model (Tg)"
+      "link_url": "models/JAX_Model (Tg)",
+      "link_text": "JAX_Model (Tg)"
     },
     "matched_control": "JAX_Model (Wt)",
     "model_group": "AD",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_jax_tissue_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_jax_tissue_output.json
@@ -3,7 +3,9 @@
     "ensembl_gene_id": "ENSMUSG00000000004",
     "gene_symbol": "Gene_D",
     "biodomains": ["Metabolic"],
-    "name": "JAX_Model (Tg)",
+    "name": {
+      "link_url": "models/JAX_Model (Tg)"
+    },
     "matched_control": "JAX_Model (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_mixed_genes_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_mixed_genes_output.json
@@ -3,7 +3,9 @@
     "ensembl_gene_id": "ENSMUSG00000000005",
     "gene_symbol": "Gene_E",
     "biodomains": [],
-    "name": "Model_D (Tg)",
+    "name": {
+      "link_url": "models/Model_D (Tg)"
+    },
     "matched_control": "Model_D (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",
@@ -18,7 +20,9 @@
     "ensembl_gene_id": "ENSMUSG00000000006",
     "gene_symbol": "Gene_F",
     "biodomains": [],
-    "name": "Model_D (Tg)",
+    "name": {
+      "link_url": "models/Model_D (Tg)"
+    },
     "matched_control": "Model_D (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_mixed_genes_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_mixed_genes_output.json
@@ -4,7 +4,8 @@
     "gene_symbol": "Gene_E",
     "biodomains": [],
     "name": {
-      "link_url": "models/Model_D (Tg)"
+      "link_url": "models/Model_D (Tg)",
+      "link_text": "Model_D (Tg)"
     },
     "matched_control": "Model_D (Wt)",
     "model_group": "AD",
@@ -21,7 +22,8 @@
     "gene_symbol": "Gene_F",
     "biodomains": [],
     "name": {
-      "link_url": "models/Model_D (Tg)"
+      "link_url": "models/Model_D (Tg)",
+      "link_text": "Model_D (Tg)"
     },
     "matched_control": "Model_D (Wt)",
     "model_group": "AD",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_multi_model_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_multi_model_output.json
@@ -3,7 +3,9 @@
     "ensembl_gene_id": "ENSMUSG00000000001",
     "gene_symbol": "Gene_A",
     "biodomains": ["Synaptic"],
-    "name": "Model_B (Tg)",
+    "name": {
+      "link_url": "models/Model_B (Tg)"
+    },
     "matched_control": "Model_B (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",
@@ -22,7 +24,9 @@
     "ensembl_gene_id": "ENSMUSG00000000003",
     "gene_symbol": "Gene_C",
     "biodomains": ["Neuronal"],
-    "name": "Model_C (Tg)",
+    "name": {
+      "link_url": "models/Model_C (Tg)"
+    },
     "matched_control": "Model_C (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_multi_model_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_multi_model_output.json
@@ -4,7 +4,8 @@
     "gene_symbol": "Gene_A",
     "biodomains": ["Synaptic"],
     "name": {
-      "link_url": "models/Model_B (Tg)"
+      "link_url": "models/Model_B (Tg)",
+      "link_text": "Model_B (Tg)"
     },
     "matched_control": "Model_B (Wt)",
     "model_group": "AD",
@@ -25,7 +26,8 @@
     "gene_symbol": "Gene_C",
     "biodomains": ["Neuronal"],
     "name": {
-      "link_url": "models/Model_C (Tg)"
+      "link_url": "models/Model_C (Tg)",
+      "link_text": "Model_C (Tg)"
     },
     "matched_control": "Model_C (Wt)",
     "model_group": "AD",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_multiple_biodomains_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_multiple_biodomains_output.json
@@ -4,7 +4,8 @@
     "gene_symbol": "Gene_MultiDomain",
     "biodomains": ["Synaptic", "Metabolic"],
     "name": {
-      "link_url": "models/Model_A (Tg)"
+      "link_url": "models/Model_A (Tg)",
+      "link_text": "Model_A (Tg)"
     },
     "matched_control": "Model_A (Wt)",
     "model_group": "AD",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_multiple_biodomains_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_multiple_biodomains_output.json
@@ -3,7 +3,9 @@
     "ensembl_gene_id": "ENSMUSG00000000005",
     "gene_symbol": "Gene_MultiDomain",
     "biodomains": ["Synaptic", "Metabolic"],
-    "name": "Model_A (Tg)",
+    "name": {
+      "link_url": "models/Model_A (Tg)"
+    },
     "matched_control": "Model_A (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_null_model_group_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_null_model_group_output.json
@@ -3,7 +3,9 @@
     "ensembl_gene_id": "ENSMUSG00000000001",
     "gene_symbol": "Gene_A",
     "biodomains": ["Synaptic"],
-    "name": "Model_NoGroup (Tg)",
+    "name": {
+      "link_url": "models/Model_NoGroup (Tg)"
+    },
     "matched_control": "Model_NoGroup (Wt)",
     "model_group": null,
     "model_type": "Transgenic",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_null_model_group_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_null_model_group_output.json
@@ -4,7 +4,8 @@
     "gene_symbol": "Gene_A",
     "biodomains": ["Synaptic"],
     "name": {
-      "link_url": "models/Model_NoGroup (Tg)"
+      "link_url": "models/Model_NoGroup (Tg)",
+      "link_text": "Model_NoGroup (Tg)"
     },
     "matched_control": "Model_NoGroup (Wt)",
     "model_group": null,

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_rounding_precision_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_rounding_precision_output.json
@@ -3,7 +3,9 @@
     "ensembl_gene_id": "ENSMUSG00000000001",
     "gene_symbol": "Gene_A",
     "biodomains": ["Synaptic"],
-    "name": "Model_A (Tg)",
+    "name": {
+      "link_url": "models/Model_A (Tg)"
+    },
     "matched_control": "Model_A (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_rounding_precision_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_rounding_precision_output.json
@@ -4,7 +4,8 @@
     "gene_symbol": "Gene_A",
     "biodomains": ["Synaptic"],
     "name": {
-      "link_url": "models/Model_A (Tg)"
+      "link_url": "models/Model_A (Tg)",
+      "link_text": "Model_A (Tg)"
     },
     "matched_control": "Model_A (Wt)",
     "model_group": "AD",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_single_row_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_single_row_output.json
@@ -3,7 +3,9 @@
     "ensembl_gene_id": "ENSMUSG00000000008",
     "gene_symbol": "",
     "biodomains": [],
-    "name": "Model_F (Tg)",
+    "name": {
+      "link_url": "models/Model_F (Tg)"
+    },
     "matched_control": "Model_F (Wt)",
     "model_group": "AD",
     "model_type": "Transgenic",

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_single_row_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_single_row_output.json
@@ -4,7 +4,8 @@
     "gene_symbol": "",
     "biodomains": [],
     "name": {
-      "link_url": "models/Model_F (Tg)"
+      "link_url": "models/Model_F (Tg)",
+      "link_text": "Model_F (Tg)"
     },
     "matched_control": "Model_F (Wt)",
     "model_group": "AD",

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -1122,10 +1122,10 @@ class TestTransformRnaDeAggregate:
 
         # Sort output data by ensembl_gene_id and name for deterministic comparison
         output_data_sorted = sorted(
-            output_data, key=lambda x: (x["ensembl_gene_id"], x["name"]["link_url"])
+            output_data, key=lambda x: (x["ensembl_gene_id"], x["name"]["link_text"])
         )
         expected_data_sorted = sorted(
-            expected_data, key=lambda x: (x["ensembl_gene_id"], x["name"]["link_url"])
+            expected_data, key=lambda x: (x["ensembl_gene_id"], x["name"]["link_text"])
         )
 
         # Compare output with expected

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -538,7 +538,7 @@ class TestCreateOutputEntryFromGroup:
         assert result["ensembl_gene_id"] == "ENSMUSG00000000001"
         assert result["gene_symbol"] == "Gene1"
         assert result["biodomains"] == ["Synaptic"]
-        assert result["name"] == "Transgenic"
+        assert result["name"] == {"link_url": "models/Transgenic"}
         assert result["matched_control"] == "Wildtype"
         assert result["model_group"] == "Group1"
         assert result["model_type"] == "knockout"
@@ -586,7 +586,9 @@ class TestCreateOutputEntryFromGroup:
         assert result["ensembl_gene_id"] == "ENSMUSG00000000002"
         assert result["gene_symbol"] == ""  # Default for missing
         assert result["biodomains"] == []  # Default for missing
-        assert result["name"] == "Tg"  # Falls back to case genotype
+        assert result["name"] == {
+            "link_url": "models/Tg"
+        }  # Falls back to case genotype
         assert result["matched_control"] == "Wt"  # Falls back to control genotype
         assert result["model_group"] is None  # Empty string converted to None
         assert result["model_type"] == ""  # Default for missing
@@ -1116,10 +1118,10 @@ class TestTransformRnaDeAggregate:
 
         # Sort output data by ensembl_gene_id and name for deterministic comparison
         output_data_sorted = sorted(
-            output_data, key=lambda x: (x["ensembl_gene_id"], x["name"])
+            output_data, key=lambda x: (x["ensembl_gene_id"], x["name"]["link_url"])
         )
         expected_data_sorted = sorted(
-            expected_data, key=lambda x: (x["ensembl_gene_id"], x["name"])
+            expected_data, key=lambda x: (x["ensembl_gene_id"], x["name"]["link_url"])
         )
 
         # Compare output with expected

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -538,7 +538,10 @@ class TestCreateOutputEntryFromGroup:
         assert result["ensembl_gene_id"] == "ENSMUSG00000000001"
         assert result["gene_symbol"] == "Gene1"
         assert result["biodomains"] == ["Synaptic"]
-        assert result["name"] == {"link_url": "models/Transgenic"}
+        assert result["name"] == {
+            "link_url": "models/Transgenic",
+            "link_text": "Transgenic",
+        }
         assert result["matched_control"] == "Wildtype"
         assert result["model_group"] == "Group1"
         assert result["model_type"] == "knockout"
@@ -587,7 +590,8 @@ class TestCreateOutputEntryFromGroup:
         assert result["gene_symbol"] == ""  # Default for missing
         assert result["biodomains"] == []  # Default for missing
         assert result["name"] == {
-            "link_url": "models/Tg"
+            "link_url": "models/Tg",
+            "link_text": "Tg",
         }  # Falls back to case genotype
         assert result["matched_control"] == "Wt"  # Falls back to control genotype
         assert result["model_group"] is None  # Empty string converted to None


### PR DESCRIPTION
## Problem

The `rna_de_aggregate` transform currently outputs the `name` field as a simple string value (e.g., `"LOAD1.Clasp2L163P"`). To support frontend navigation features, we need the `name` field to include a URL path to enable linking to the corresponding model detail page.

**Current Structure:**
```
{
  "name": "LOAD1.Clasp2L163P",
  ...
}
```

**Desired Structure:**
```
{
  "name": {
    "link_url": "models/LOAD1.Clasp2L163P"
    "link_text": "LOAD1.Clasp2L163P"
  },
  ...
}
```

## Solution

Updated the `rna_de_aggregate` transform to convert the `name` field from a string to an object containing `link_url` and `link_text` properties.

**Transform Logic**
   - Modified `_create_output_entry_from_group()` to output `name` as: `{"link_url": f"models/{name}", "link_text":"{name}"}`
   - Updated all docstrings and inline documentation to reflect the new structure
   - Added examples showing the new format in function documentation

## Testing

**Test Assets** (`tests/test_assets/rna_de_aggregate/`)
   - Updated all 9 synthetic output JSON files with the new `name` field structure
   - Enhanced `README_synthetic_datasets.md` with:
     - New "Output Structure" section with complete field documentation
     - Updated "Case/Control Mapping" section to reflect object structure
     - Added validation point for the new name field structure

**Test Code** (`tests/transform/test_rna_de_aggregate.py`)
   - Updated test assertions to validate the new object structure: `assert result["name"] == {"link_url": "models/Transgenic", "link_text": "Transgenic"}`
   - Fixed sorting logic to use `x["name"]["link_text"]` for deterministic comparisons in tests