### PR TITLE
MG-602: Add strict validation for genotype label mappings in RNA DE aggregate transform

### DIFF
--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -257,13 +257,28 @@ def _create_output_entry_from_group(
 
     Note:
         Age entries are validated and sorted numerically before being included in the output.
-        Missing values in lookup dictionaries result in empty strings or empty lists, not errors.
+        Missing values in gene_metadata_dict, biodomain_dict, and model_info_dict result
+        in empty strings or empty lists, not errors. However, missing entries in label_map_dict
+        for the case or control genotypes will raise a ValueError.
     """
     ensembl_gene_id, model, tissue, sex, case, control = group_key
 
     gene_symbol = gene_metadata_dict.get(ensembl_gene_id, "")
-    name = label_map_dict.get((model, case), case)
-    matched_control = label_map_dict.get((model, control), control)
+
+    # Lookup name and matched_control - raise error if not found
+    case_key = (model, case)
+    control_key = (model, control)
+    for k in [case_key, control_key]:
+        if k not in label_map_dict:
+            raise ValueError(
+                f"Label mapping not found for genotype. "
+                f"Model: '{model}', Genotype: '{k[1]}', "
+                f"Gene: {ensembl_gene_id}, Tissue: {tissue}, Sex: {sex}. "
+                f"Please ensure the rnaseq_genotype_label_map dataset contains "
+                f"an entry for model '{model}' and genotype '{k[1]}'."
+            )
+    name = label_map_dict[case_key]
+    matched_control = label_map_dict[control_key]
     model_group = model_group_dict.get(model)
     biodomains = biodomain_dict.get(ensembl_gene_id, [])
     model_type = model_info_dict.get(model, "")

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -12,7 +12,7 @@ The transformation:
 - Validates and sorts age entries by numeric value
 - Normalizes zero values in log2 fold change for consistent representation
 - Enriches data with gene symbols, biodomains, and model metadata
-- Maps genotypes to display labels for better readability
+- Maps genotypes to display labels with strict validation (raises ValueError if mappings are missing)
 - Applies special tissue name transformation for JAX models ("Right Cerebral Hemisphere" -> "Hemibrain")
 - Rounds numeric columns to 5 decimal places for consistency
 - Processes multiple data files sequentially to minimize memory usage
@@ -25,7 +25,8 @@ Key Functions:
     _process_single_data_file: Processes a single differential expression data file and transforms it into output entries
 
 Required Inputs:
-    - rnaseq_genotype_label_map: Maps models and genotypes to display labels
+    - rnaseq_genotype_label_map: Maps (model, genotype) tuples to display labels. All genotypes
+      used in data files must have corresponding entries or a ValueError will be raised.
     - mouse_gene_metadata: Gene symbols and aliases for Ensembl IDs
     - model_info: Model types and matched controls
     - biodom_genes_mm: Biodomain annotations for mouse genes
@@ -255,6 +256,11 @@ def _create_output_entry_from_group(
                 '6 months': {'log2_fc': 2.456, 'adj_p_val': 0.0001}
             }
 
+    Raises:
+        ValueError: If the case or control genotype is not found in label_map_dict.
+            The error includes details about the model, genotype, gene, tissue, and sex
+            to help identify which mapping is missing.
+
     Note:
         Age entries are validated and sorted numerically before being included in the output.
         Missing values in gene_metadata_dict, biodomain_dict, and model_info_dict result
@@ -374,8 +380,9 @@ def _process_single_data_file(
         `_create_output_entry_from_group`.
 
     Raises:
-        ValueError: If the data file is empty or if required columns are missing.
-            The error message includes the file name for debugging purposes.
+        ValueError: If the data file is empty, if required columns are missing, or if any
+            case or control genotype is not found in label_map_dict during group processing.
+            The error message includes the file name and specific details for debugging purposes.
 
     Note:
         This function performs memory cleanup by explicitly deleting the processed DataFrame
@@ -502,7 +509,9 @@ def transform_rna_de_aggregate(
 
     Raises:
         ValueError: If required datasets or columns are missing, if any model has
-            inconsistent model_group values, or if any data file is empty or invalid.
+            inconsistent model_group values, if any data file is empty or invalid,
+            or if any case or control genotype used in the data files is not found
+            in the rnaseq_genotype_label_map dataset.
             Error messages include specific details about what validation failed.
 
     Note:

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -549,7 +549,11 @@ class TestCreateOutputEntryFromGroup:
         assert result["6 months"]["adj_p_val"] == pytest.approx(0.01)
 
     def test_create_output_entry_missing_metadata(self) -> None:
-        """Test output entry creation with missing metadata (defaults to genotype strings for name/matched_control)."""
+        """Test output entry creation with missing metadata (empty strings/lists for gene_metadata, biodomain, model_info).
+
+        Note: label_map_dict must contain entries for the genotypes used, as the function
+        now raises an error if they are missing.
+        """
         group_key = (
             "ENSMUSG00000000002",
             "Model_B",
@@ -567,8 +571,12 @@ class TestCreateOutputEntryFromGroup:
         )
 
         # Empty dictionaries simulate missing metadata
+        # label_map_dict must have entries for genotypes to avoid errors
         gene_metadata_dict = {}
-        label_map_dict = {}
+        label_map_dict = {
+            ("Model_B", "Tg"): "Transgenic_B",
+            ("Model_B", "Wt"): "Wildtype_B",
+        }
         model_group_dict = {}
         biodomain_dict = {}
         model_info_dict = {}
@@ -586,8 +594,8 @@ class TestCreateOutputEntryFromGroup:
         assert result["ensembl_gene_id"] == "ENSMUSG00000000002"
         assert result["gene_symbol"] == ""  # Default for missing
         assert result["biodomains"] == []  # Default for missing
-        assert result["name"] == "Tg"  # Falls back to case genotype
-        assert result["matched_control"] == "Wt"  # Falls back to control genotype
+        assert result["name"] == "Transgenic_B"  # From label_map_dict
+        assert result["matched_control"] == "Wildtype_B"  # From label_map_dict
         assert result["model_group"] is None  # Empty string converted to None
         assert result["model_type"] == ""  # Default for missing
         assert result["tissue"] == "Hippocampus"
@@ -612,7 +620,10 @@ class TestCreateOutputEntryFromGroup:
         )
 
         gene_metadata_dict = {"ENSMUSG00000000003": "Gene3"}
-        label_map_dict = {}
+        label_map_dict = {
+            ("Model_C", "Tg"): "Transgenic_C",
+            ("Model_C", "Wt"): "Wildtype_C",
+        }
         model_group_dict = {}
         biodomain_dict = {}
         model_info_dict = {}
@@ -641,7 +652,10 @@ class TestCreateOutputEntryFromGroup:
         )
 
         gene_metadata_dict = {}
-        label_map_dict = {}
+        label_map_dict = {
+            ("Model_D", "Tg"): "Transgenic_D",
+            ("Model_D", "Wt"): "Wildtype_D",
+        }
         model_group_dict = {"Model_D": ""}  # Empty string
         biodomain_dict = {}
         model_info_dict = {}
@@ -670,7 +684,10 @@ class TestCreateOutputEntryFromGroup:
         )
 
         gene_metadata_dict = {}
-        label_map_dict = {}
+        label_map_dict = {
+            ("Model_E", "Tg"): "Transgenic_E",
+            ("Model_E", "Wt"): "Wildtype_E",
+        }
         model_group_dict = {}
         biodomain_dict = {"ENSMUSG00000000005": ["Synaptic", "Metabolic"]}
         model_info_dict = {}
@@ -687,6 +704,128 @@ class TestCreateOutputEntryFromGroup:
 
         assert len(result["biodomains"]) == 2
         assert set(result["biodomains"]) == {"Synaptic", "Metabolic"}
+
+    def test_create_output_entry_missing_case_label_raises_error(self) -> None:
+        """Test that missing case genotype in label_map_dict raises ValueError."""
+        group_key = ("ENSMUSG00000000006", "Model_F", "Cortex", "Male", "Tg", "Wt")
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "log2foldchange": [1.5],
+                "padj": [0.01],
+            }
+        )
+
+        gene_metadata_dict = {}
+        # label_map_dict is missing entry for ("Model_F", "Tg")
+        label_map_dict = {
+            ("Model_F", "Wt"): "Wildtype",
+        }
+        model_group_dict = {}
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        with pytest.raises(ValueError) as exc_info:
+            _create_output_entry_from_group(
+                group_key=group_key,
+                group=group,
+                gene_metadata_dict=gene_metadata_dict,
+                label_map_dict=label_map_dict,
+                model_group_dict=model_group_dict,
+                biodomain_dict=biodomain_dict,
+                model_info_dict=model_info_dict,
+            )
+
+        error_message = str(exc_info.value)
+        assert "Label mapping not found for genotype" in error_message
+        assert "Model_F" in error_message
+        assert "Tg" in error_message
+        assert "ENSMUSG00000000006" in error_message
+        assert "Cortex" in error_message
+        assert "Male" in error_message
+
+    def test_create_output_entry_missing_control_label_raises_error(self) -> None:
+        """Test that missing control genotype in label_map_dict raises ValueError."""
+        group_key = (
+            "ENSMUSG00000000007",
+            "Model_G",
+            "Hippocampus",
+            "Female",
+            "Tg",
+            "Wt",
+        )
+        group = pd.DataFrame(
+            {
+                "age": ["3 months"],
+                "log2foldchange": [2.0],
+                "padj": [0.001],
+            }
+        )
+
+        gene_metadata_dict = {}
+        # label_map_dict is missing entry for ("Model_G", "Wt")
+        label_map_dict = {
+            ("Model_G", "Tg"): "Transgenic",
+        }
+        model_group_dict = {}
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        with pytest.raises(ValueError) as exc_info:
+            _create_output_entry_from_group(
+                group_key=group_key,
+                group=group,
+                gene_metadata_dict=gene_metadata_dict,
+                label_map_dict=label_map_dict,
+                model_group_dict=model_group_dict,
+                biodomain_dict=biodomain_dict,
+                model_info_dict=model_info_dict,
+            )
+
+        error_message = str(exc_info.value)
+        assert "Label mapping not found for genotype" in error_message
+        assert "Model_G" in error_message
+        assert "Wt" in error_message
+        assert "ENSMUSG00000000007" in error_message
+        assert "Hippocampus" in error_message
+        assert "Female" in error_message
+
+    def test_create_output_entry_missing_both_labels_raises_case_error_first(
+        self,
+    ) -> None:
+        """Test that when both case and control are missing, case error is raised first."""
+        group_key = ("ENSMUSG00000000008", "Model_H", "Cortex", "Male", "Tg", "Wt")
+        group = pd.DataFrame(
+            {
+                "age": ["12 months"],
+                "log2foldchange": [0.5],
+                "padj": [0.05],
+            }
+        )
+
+        gene_metadata_dict = {}
+        # label_map_dict is completely empty
+        label_map_dict = {}
+        model_group_dict = {}
+        biodomain_dict = {}
+        model_info_dict = {}
+
+        with pytest.raises(ValueError) as exc_info:
+            _create_output_entry_from_group(
+                group_key=group_key,
+                group=group,
+                gene_metadata_dict=gene_metadata_dict,
+                label_map_dict=label_map_dict,
+                model_group_dict=model_group_dict,
+                biodomain_dict=biodomain_dict,
+                model_info_dict=model_info_dict,
+            )
+
+        # Should raise error for case first, since case is checked before control
+        error_message = str(exc_info.value)
+        assert "Label mapping not found for genotype" in error_message
+        assert "Model_H" in error_message
+        assert "Tg" in error_message
 
 
 class TestProcessSingleDataFile:
@@ -767,7 +906,7 @@ class TestProcessSingleDataFile:
         data_file = pd.DataFrame()
 
         gene_metadata_dict = {}
-        label_map_dict = {}
+        label_map_dict = {}  # Empty is OK since no data will be processed
         model_group_dict = {}
         biodomain_dict = {}
         model_info_dict = {}
@@ -824,7 +963,10 @@ class TestProcessSingleDataFile:
         )
 
         gene_metadata_dict = {}
-        label_map_dict = {}
+        label_map_dict = {
+            ("Model_A", "Tg"): "Transgenic",
+            ("Model_A", "Wt"): "Wildtype",
+        }
         model_group_dict = {}
         biodomain_dict = {}
         model_info_dict = {}
@@ -876,7 +1018,10 @@ class TestProcessSingleDataFile:
         )
 
         gene_metadata_dict = {}
-        label_map_dict = {}
+        label_map_dict = {
+            ("Model_A", "Tg"): "Transgenic",
+            ("Model_A", "Wt"): "Wildtype",
+        }
         model_group_dict = {}
         biodomain_dict = {}
         model_info_dict = {}
@@ -927,7 +1072,12 @@ class TestProcessSingleDataFile:
         )
 
         gene_metadata_dict = {}
-        label_map_dict = {}
+        label_map_dict = {
+            ("Model_A", "Tg"): "Transgenic_A",
+            ("Model_A", "Wt"): "Wildtype_A",
+            ("Model_B", "Tg"): "Transgenic_B",
+            ("Model_B", "Wt"): "Wildtype_B",
+        }
         model_group_dict = {}
         biodomain_dict = {}
         model_info_dict = {}


### PR DESCRIPTION
### Problem

The `rna_de_aggregate` transform was silently falling back to using model names when genotype labels were missing from the `rnaseq_genotype_label_map` dataset. This could lead to:

1. **Data quality issues**: Incorrect or incomplete display labels in the output without any indication of a problem
2. **Silent failures**: Missing entries in the label map would not be detected until the data was examined downstream
3. **Difficult debugging**: When data issues occurred, it was unclear whether they originated from missing label mappings or other sources

For example, if a model/genotype combination like `('5xFAD (UCI)', '5XFAD_carrier')` was missing from the label map, the code would silently use `'5xFAD (UCI)'` as the display label instead of raising an error.

### Solution

Modified the `_create_output_entry_from_group` function in `rna_de_aggregate.py` to enforce strict validation of genotype label mappings:

1. **Replaced `.get()` with explicit key lookups**: Changed from using `.get(key, default)` to direct dictionary access that raises a `KeyError` if the key is missing
2. **Added explicit validation loop**: Before looking up values, iterate through case and control keys to check if they exist in `label_map_dict`
3. **Provide detailed error messages**: When a mapping is missing, raise a `ValueError` with comprehensive context including:
   - The model and genotype that are missing
   - The gene, tissue, and sex where the issue was encountered
   - Instructions to ensure the `rnaseq_genotype_label_map` dataset contains the necessary entry

4. **Updated documentation**: Enhanced docstrings and comments to clarify:
   - That the `label_map_dict` maps genotype identifiers (e.g., `'5XFAD_carrier'`) to display labels (e.g., `'5xFAD (UCI)'`)
   - That missing entries in `label_map_dict` will raise errors, unlike other metadata dictionaries which use defaults

### Testing

#### Unit tests added
3 new test cases in `test_rna_de_aggregate.py`:
- `test_create_output_entry_missing_case_label_raises_error`: Verifies that a missing case genotype raises `ValueError` with appropriate context
- `test_create_output_entry_missing_control_label_raises_error`: Verifies that a missing control genotype raises `ValueError` with appropriate context  
- `test_create_output_entry_missing_both_labels_raises_case_error_first`: Verifies that when both case and control are missing, the error is raised on the first check (case)

#### Unit tests updated
4 existing test cases modified to provide valid label map entries:
- `test_create_output_entry_missing_metadata`
- `test_create_output_entry_null_model_group`
- `test_create_output_entry_empty_model_group`
- `test_create_output_entry_multiple_biodomains`