### PR TITLE
MG-645: Add tooltip values to primary columns 

### DIFF
--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -166,3 +166,42 @@ datasets:
         - syn69058662
       destination: *dest
       custom_transformations: transform_rna_de_aggregate
+
+  - rna_de_individual:
+      files:
+        - name: rnaseq_genotype_label_map
+          id: syn69014401
+          format: csv
+        - name: mouse_gene_metadata
+          id: syn51615422
+          format: json
+        - name: Jax.IU.Pitt_5XFAD_normalized_expression
+          id: syn69693095
+          format: csv
+        - name: UCI_3xTg-AD_normalized_expression
+          id: syn69693094
+          format: csv
+        - name: UCI_ABCA7_normalized_expression
+          id: syn69693096
+          format: csv
+        - name: Jax.IU.Pitt_APOE4.Trem2.R47H_normalized_expression
+          id: syn69693097
+          format: csv
+        - name: UCI_5XFAD_normalized_expression
+          id: syn69693098
+          format: csv
+        - name: UCI_Trem2-R47H_NSS_normalized_expression
+          id: syn69693099
+          format: csv
+      final_format: json
+      provenance:
+        - syn69014401
+        - syn51615422
+        - syn69693095
+        - syn69693094
+        - syn69693096
+        - syn69693097
+        - syn69693098
+        - syn69693099
+      destination: *dest
+      custom_transformations: transform_rna_de_individual

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -196,7 +196,7 @@ ge_menu3 <- c("Sex - Females & Males", "Sex - Females", "Sex - Males")
 # name, type, data_key, tooltip, sort_tooltip, link_url, link_text, is_exported, is_hidden
 #
 # Static columns are the same across all views
-ge_primary_column <- list("Gene", "primary", "gene_symbol", NA, NA, NA, NA, TRUE, FALSE)
+ge_primary_column <- list("Gene", "primary", "gene_symbol", "Mouse Gene", NA, NA, NA, TRUE, FALSE)
 ge_model_column <- list("Model", "link_internal", "name", "Mouse Model", "Sort by Model value", NA, NA, TRUE, FALSE)
 ge_matched_control_column <- list("Control", "text", "matched_control", NA, "Sort by Control value", NA, NA, TRUE, FALSE)
 
@@ -298,7 +298,7 @@ dc_menu2 <- c(
 # name, type, data_key, tooltip, sort_tooltip, link_url, link_text, is_exported, is_hidden
 #
 # All views have the same static column values
-dc_primary_column <- list("Model", "primary", "name", NA, NA, NA, NA, TRUE, FALSE)
+dc_primary_column <- list("Model", "primary", "name", "Mouse Model", NA, NA, NA, TRUE, FALSE)
 dc_age_column <- list("Age", "text", "age", NA, "Sort by Age value", NA, NA, TRUE, FALSE)
 dc_sex_column <- list("Sex", "text", "sex", NA, "Sort by Sex value", NA, NA, TRUE, FALSE)
 
@@ -421,8 +421,8 @@ mo_columns <- data.frame(
   data_key = c("name", "model_type", "matched_controls", "gene_expression",
                  "disease_correlation", "pathology", "biomarkers",
                  "study_data", "jax_strain", "center", "modified_genes", "available_data"),
-  tooltip = rep(NA, times = 12),
-  sort_tooltip = rep(NA, times = 12),
+  tooltip = c("Mouse Model",  rep(NA, times = 12)),
+  sort_tooltip = rep(NA, times = 11),
   link_url = rep(NA, times = 12),
   link_text = c(NA, NA, NA, "Results", "Results", "Results", "Results", "View Data", "View Strain", NA, NA, NA),
   is_exported = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE),

--- a/src/agoradatatools/etl/transform/__init__.py
+++ b/src/agoradatatools/etl/transform/__init__.py
@@ -23,6 +23,7 @@ from agoradatatools.etl.transform.disease_correlation import (
 )
 from agoradatatools.etl.transform.model_overview import transform_model_overview
 from agoradatatools.etl.transform.rna_de_aggregate import transform_rna_de_aggregate
+from agoradatatools.etl.transform.rna_de_individual import transform_rna_de_individual
 
 
 __all__ = [
@@ -41,4 +42,5 @@ __all__ = [
     "transform_disease_correlation",
     "transform_model_overview",
     "transform_rna_de_aggregate",
+    "transform_rna_de_individual",
 ]

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -39,6 +39,18 @@ import logging
 import gc
 
 from agoradatatools.etl.utils import check_required_datasets_and_columns, normalize_zero
+from agoradatatools.etl.transform.rna_shared_utils import (
+    filter_mouse_genes,
+    validate_and_sort_age_entries as validate_and_sort_age_entries_shared,
+    validate_model_group_consistency,
+    create_gene_metadata_dict,
+    create_model_group_dict,
+    create_label_map_dict,
+    log_file_processing_info,
+    validate_data_file_not_empty,
+    normalize_model_group_value,
+    extract_common_metadata,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -87,30 +99,9 @@ def _validate_and_sort_age_entries(
     Raises:
         ValueError: If any age string is empty, whitespace-only, or not in 'N months' format
     """
-    # Validate that no age strings are empty or whitespace-only
-    for age in age_entries.keys():
-        age_stripped = age.strip()
-        if not age_stripped:
-            raise ValueError(
-                f"Empty or whitespace-only age value found in data for gene '{ensembl_gene_id}', "
-                f"model '{model}', tissue '{tissue}', sex '{sex}'. "
-                f"Expected 'N months' format but found: '{age}'"
-            )
-
-    # Sort age entries by numeric value with error handling for format validation
-    try:
-        sorted_ages = dict(
-            sorted(age_entries.items(), key=lambda x: int(x[0].split()[0]))
-        )
-    except (ValueError, IndexError) as e:
-        raise ValueError(
-            f"Invalid age format in data for gene '{ensembl_gene_id}', "
-            f"model '{model}', tissue '{tissue}', sex '{sex}'. "
-            f"Expected 'N months' format but found: {list(age_entries.keys())}. "
-            f"Original error: {e}"
-        ) from e
-
-    return sorted_ages
+    return validate_and_sort_age_entries_shared(
+        age_entries, ensembl_gene_id, model, tissue, sex
+    )
 
 
 def _create_age_entries_from_group(
@@ -261,7 +252,11 @@ def _create_output_entry_from_group(
     """
     ensembl_gene_id, model, tissue, sex, case, control = group_key
 
-    gene_symbol = gene_metadata_dict.get(ensembl_gene_id, "")
+    # Extract common metadata (gene_symbol, tissue mapping)
+    common_metadata = extract_common_metadata(
+        ensembl_gene_id, tissue, gene_metadata_dict
+    )
+
     name = label_map_dict.get((model, case), case)
     matched_control = label_map_dict.get((model, control), control)
     model_group = model_group_dict.get(model)
@@ -276,19 +271,13 @@ def _create_output_entry_from_group(
         age_entries, ensembl_gene_id, model, tissue, sex
     )
 
-    # If tissue is "Right Cerebral Hemisphere", change tissue to "Hemibrain"
-    # Only expected for JAX models
-    tissue = "Hemibrain" if tissue == "Right Cerebral Hemisphere" else tissue
-
     return {
-        "ensembl_gene_id": ensembl_gene_id,
-        "gene_symbol": gene_symbol,
+        **common_metadata,
         "biodomains": biodomains,
         "name": name,
         "matched_control": matched_control,
-        "model_group": model_group if model_group != "" else None,
+        "model_group": normalize_model_group_value(model_group),
         "model_type": model_type,
-        "tissue": tissue,
         "sex_cohort": sex,
         **sorted_ages,
     }
@@ -369,22 +358,17 @@ def _process_single_data_file(
         genes to ensure only mouse (Mus musculus) data is processed, as indicated by
         Ensembl IDs starting with "ENSMUSG".
     """
-    logger.info(
-        f"Processing {file_name} ({file_index+1}/{total_files}): {len(data_file)} rows, "
-        f"{len(data_file.columns)} columns, "
-        f"{data_file.memory_usage(deep=True).sum() / 1024**2:.2f} MB"
-    )
+    log_file_processing_info(file_name, file_index, total_files, data_file)
 
     # Check if data file is empty (before column validation)
-    if len(data_file) == 0:
-        raise ValueError(f"Data file {file_name} is empty")
+    validate_data_file_not_empty(file_name, data_file)
 
     check_required_datasets_and_columns(
         {file_name: data_file}, {file_name: data_file_required_columns}
     )
 
     # Filter out rows with human gene ensembl IDs (ENSG*), keep only mouse (ENSMUSG*)
-    data_file = data_file[data_file["ensembl_gene_id"].str.startswith("ENSMUSG")]
+    data_file = filter_mouse_genes(data_file)
 
     # Round numeric columns to 5 decimal places for consistency
     data_file = data_file.round(decimals=5)
@@ -511,31 +495,16 @@ def transform_rna_de_aggregate(
     )
 
     # Create lookup dictionaries
-    gene_metadata_dict = mouse_gene_metadata_df.set_index("ensembl_gene_id")[
-        "gene_symbol"
-    ].to_dict()
+    gene_metadata_dict = create_gene_metadata_dict(mouse_gene_metadata_df)
     model_info_dict = model_info_df.set_index("model")["model_type"].to_dict()
 
     # Create label map dictionaries for efficient lookups
-    label_map_dict = rnaseq_genotype_label_map_df.set_index(["model", "genotype"])[
-        "display_label"
-    ].to_dict()
+    label_map_dict = create_label_map_dict(rnaseq_genotype_label_map_df)
 
     # Validate that each model has consistent model_group values
-    inconsistent_models = (
-        rnaseq_genotype_label_map_df.groupby("model")["model_group"]
-        .nunique()
-        .pipe(lambda x: x[x > 1].index.tolist())
-    )
-    if inconsistent_models:
-        raise ValueError(
-            f"Each model must have a consistent model_group value in rnaseq_genotype_label_map. "
-            f"Models with inconsistent model_group values: {inconsistent_models}"
-        )
+    validate_model_group_consistency(rnaseq_genotype_label_map_df)
 
-    model_group_dict = (
-        rnaseq_genotype_label_map_df.groupby("model")["model_group"].first().to_dict()
-    )
+    model_group_dict = create_model_group_dict(rnaseq_genotype_label_map_df)
 
     # Create biodomain lookup dictionary
     biodomain_dict = (

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -1,0 +1,360 @@
+"""
+RNA Individual Expression Transform Module
+
+This module transforms individual RNA expression (normalized expression) data for Model AD.
+It combines multiple datasets including gene metadata, genotype labels, and individual expression
+values to create a structured output format grouped by model_group.
+
+The transformation:
+- Filters to mouse genes only (ENSMUSG*), excluding human genes (ENSG*)
+- Groups individual expression data by gene, tissue, and model_group
+- Creates age-based entries containing individual expression values for all genotypes
+- Organizes data by model_group to support both single and multiple control display paradigms
+- Enriches data with gene symbols from gene metadata
+- Maps genotypes to display labels for better readability
+- Applies special tissue name transformation for JAX models ("Right Cerebral Hemisphere" -> "Hemibrain")
+- Rounds numeric columns to 5 decimal places for consistency
+- Processes multiple data files sequentially to minimize memory usage
+
+Key Functions:
+    transform_rna_de_individual: Main transformation function that orchestrates the data processing
+    _create_individual_results_from_group: Creates individual_results structure with age-based grouping
+    _create_output_entry_from_group: Creates a complete output entry from a grouped DataFrame
+    _process_single_data_file: Processes a single individual expression data file
+
+Required Inputs:
+    - rnaseq_genotype_label_map: Maps models and genotypes to display labels and model_groups
+    - mouse_gene_metadata: Gene symbols and aliases for Ensembl IDs
+    - Data files: One or more CSV files containing individual expression results with columns:
+      ensembl_gene_id, expression, model, genotype, age, sex, tissue, individualID
+"""
+
+import pandas as pd
+from typing import Dict, List, Any
+import logging
+import gc
+
+from agoradatatools.etl.utils import check_required_datasets_and_columns
+from agoradatatools.etl.transform.rna_shared_utils import (
+    filter_mouse_genes,
+    validate_model_group_consistency,
+    create_gene_metadata_dict,
+    create_model_group_dict,
+    create_label_map_dict,
+    log_file_processing_info,
+    validate_data_file_not_empty,
+    normalize_model_group_value,
+    extract_common_metadata,
+)
+
+logger = logging.getLogger(__name__)
+
+REQUIRED_INPUT = {
+    "rnaseq_genotype_label_map": ["model", "model_group", "display_label", "genotype"],
+    "mouse_gene_metadata": ["ensembl_gene_id", "gene_symbol", "alias"],
+}
+
+
+def _create_individual_results_from_group(
+    group: pd.DataFrame,
+) -> List[Dict[str, Any]]:
+    """
+    Creates individual_results structure from a grouped DataFrame.
+
+    Groups the data by age and creates entries with all individual data points
+    for each age timepoint.
+
+    Args:
+        group: DataFrame group containing age, genotype, sex, individualID, and expression columns.
+
+    Returns:
+        List of dictionaries, one per age timepoint, each containing:
+            - 'age': str, age timepoint (e.g., '3 months')
+            - 'data': List of dicts with individual data points containing:
+                - 'genotype': str, genotype identifier
+                - 'sex': str, sex identifier
+                - 'individual_id': str, individual identifier
+                - 'value': float, expression value
+    """
+    individual_results = []
+
+    # Group by age to create age-based entries
+    age_groups = group.groupby("age")
+
+    for age, age_group in age_groups:
+        data_points = []
+        for row in age_group.itertuples(index=False):
+            data_points.append(
+                {
+                    "genotype": row.genotype,
+                    "sex": row.sex,
+                    "individual_id": str(row.individualID),
+                    "value": float(row.expression),
+                }
+            )
+
+        individual_results.append(
+            {
+                "age": str(age),
+                "data": data_points,
+            }
+        )
+
+    # Sort by numeric age value
+    try:
+        individual_results = sorted(
+            individual_results, key=lambda x: int(x["age"].split()[0])
+        )
+    except (ValueError, IndexError):
+        # If age format is unexpected, keep original order
+        pass
+
+    return individual_results
+
+
+def _create_output_entry_from_group(
+    group_key: tuple[str, str, str, str],
+    group: pd.DataFrame,
+    gene_metadata_dict: Dict[str, str],
+    matched_control_dict: Dict[str, str],
+) -> Dict[str, Any]:
+    """
+    Creates a complete output entry from a grouped DataFrame.
+
+    Args:
+        group_key: Tuple containing (ensembl_gene_id, tissue, model_group, name)
+        group: DataFrame group containing individual expression data
+        gene_metadata_dict: Dictionary mapping Ensembl gene IDs to gene symbols
+        matched_control_dict: Dictionary mapping models to matched controls
+
+    Returns:
+        Dictionary containing the complete output entry with individual_results
+    """
+    ensembl_gene_id, tissue, model_group, name = group_key
+
+    # Extract common metadata (gene_symbol, tissue mapping)
+    common_metadata = extract_common_metadata(
+        ensembl_gene_id, tissue, gene_metadata_dict
+    )
+
+    matched_control = matched_control_dict.get(name, "")
+
+    # Create individual_results structure
+    individual_results = _create_individual_results_from_group(group)
+
+    return {
+        "ensembl_gene_id": common_metadata["ensembl_gene_id"],
+        "hgnc_symbol": common_metadata["gene_symbol"],
+        "tissue": common_metadata["tissue"],
+        "name": name,
+        "model_group": normalize_model_group_value(model_group),
+        "matched_control": matched_control,
+        "units": "Log2 Counts per Million",
+        "individual_results": individual_results,
+    }
+
+
+def _process_single_data_file(
+    file_name: str,
+    data_file: pd.DataFrame,
+    data_file_required_columns: List[str],
+    gene_metadata_dict: Dict[str, str],
+    label_map_dict: Dict[tuple[str, str], str],
+    model_group_dict: Dict[str, str],
+    matched_control_dict: Dict[str, str],
+    genotypes_by_model_group: Dict[str, List[str]],
+    file_index: int,
+    total_files: int,
+) -> List[Dict[str, Any]]:
+    """
+    Processes a single individual expression data file.
+
+    Args:
+        file_name: Name of the data file being processed
+        data_file: DataFrame containing the individual expression data
+        data_file_required_columns: List of required column names
+        gene_metadata_dict: Dictionary mapping Ensembl gene IDs to gene symbols
+        label_map_dict: Dictionary mapping (model, genotype) tuples to display labels
+        model_group_dict: Dictionary mapping model names to model_groups
+        matched_control_dict: Dictionary mapping models to matched controls
+        genotypes_by_model_group: Dictionary mapping model_groups to lists of genotypes
+        file_index: Current file index for progress tracking
+        total_files: Total number of files to process
+
+    Returns:
+        List of output entry dictionaries
+    """
+    log_file_processing_info(file_name, file_index, total_files, data_file)
+
+    # Check if data file is empty
+    validate_data_file_not_empty(file_name, data_file)
+
+    check_required_datasets_and_columns(
+        {file_name: data_file}, {file_name: data_file_required_columns}
+    )
+
+    # Filter out rows with human gene ensembl IDs (ENSG*), keep only mouse (ENSMUSG*)
+    data_file = filter_mouse_genes(data_file)
+
+    # Round numeric columns to 5 decimal places for consistency
+    data_file = data_file.round(decimals=5)
+
+    # Add model_group and display_label to data_file based on genotype label map
+    # Map genotype to display_label
+    data_file["genotype_display"] = data_file.apply(
+        lambda row: label_map_dict.get(
+            (row["model"], row["genotype"]), row["genotype"]
+        ),
+        axis=1,
+    )
+
+    # Map model to model_group
+    data_file["model_group"] = data_file["model"].map(model_group_dict).fillna("")
+
+    # Determine the "name" field based on grouping logic
+    # If model_group exists and is different from model, use model_group
+    # Otherwise, use the model name
+    data_file["name"] = data_file.apply(
+        lambda row: row["model_group"]
+        if row["model_group"] and row["model_group"] != row["model"]
+        else row["model"],
+        axis=1,
+    )
+
+    # Filter data to only include genotypes that belong to the model_group
+    def filter_by_model_group(row):
+        model_group = row["model_group"] if row["model_group"] else row["model"]
+        allowed_genotypes = genotypes_by_model_group.get(model_group, [])
+        return row["genotype"] in allowed_genotypes
+
+    data_file = data_file[data_file.apply(filter_by_model_group, axis=1)]
+
+    # Group by gene, tissue, model_group, and name to create one entry per group
+    grouped = data_file.groupby(["ensembl_gene_id", "tissue", "model_group", "name"])
+
+    output_entries = []
+    for group_key, group in grouped:
+        output_entry = _create_output_entry_from_group(
+            group_key,
+            group,
+            gene_metadata_dict,
+            matched_control_dict,
+        )
+        output_entries.append(output_entry)
+
+    # Clean up memory
+    del data_file
+    gc.collect()
+
+    return output_entries
+
+
+def transform_rna_de_individual(
+    datasets: Dict[str, pd.DataFrame],
+    required_input: Dict[str, List[str]] = REQUIRED_INPUT,
+) -> List[Dict[str, Any]]:
+    """
+    Main transformation function for RNA individual expression data.
+
+    This function transforms individual RNA expression data files into a structured
+    format grouped by model_group to support display paradigms for models with
+    single or multiple controls.
+
+    Args:
+        datasets: Dictionary mapping dataset names to DataFrames. Must include:
+            - 'rnaseq_genotype_label_map': Maps genotypes to display labels and model_groups
+            - 'mouse_gene_metadata': Gene symbols for Ensembl IDs
+            - One or more data files: CSV DataFrames containing individual expression
+              results with columns: ensembl_gene_id, expression, model, genotype, age,
+              sex, tissue, individualID
+        required_input: Dictionary mapping required dataset names to required columns
+
+    Returns:
+        List of dictionaries, each representing a unique combination of gene, tissue,
+        and model_group/name with individual_results containing all expression data
+        grouped by age.
+    """
+    check_required_datasets_and_columns(datasets, required_input)
+
+    # Pre-compute lookup dictionaries
+    rnaseq_genotype_label_map_df = datasets["rnaseq_genotype_label_map"].fillna("")
+    mouse_gene_metadata_df = datasets["mouse_gene_metadata"].fillna("")
+
+    # Create lookup dictionaries
+    gene_metadata_dict = create_gene_metadata_dict(mouse_gene_metadata_df)
+
+    label_map_dict = create_label_map_dict(rnaseq_genotype_label_map_df)
+
+    # Validate that each model has consistent model_group values
+    validate_model_group_consistency(rnaseq_genotype_label_map_df)
+
+    model_group_dict = create_model_group_dict(rnaseq_genotype_label_map_df)
+
+    # Create a dictionary of genotypes by model_group
+    # This is used to filter data to only include genotypes that belong to the model_group
+    genotypes_by_model_group = {}
+    for _, row in rnaseq_genotype_label_map_df.iterrows():
+        model_group = row["model_group"] if row["model_group"] else row["model"]
+        if model_group not in genotypes_by_model_group:
+            genotypes_by_model_group[model_group] = []
+        if row["genotype"] not in genotypes_by_model_group[model_group]:
+            genotypes_by_model_group[model_group].append(row["genotype"])
+
+    # Create matched_control dictionary
+    # For each model, find the genotype that maps to a control (contains "noncarrier" or is a control strain)
+    matched_control_dict = {}
+    for model in rnaseq_genotype_label_map_df["model"].unique():
+        model_df = rnaseq_genotype_label_map_df[
+            rnaseq_genotype_label_map_df["model"] == model
+        ]
+        # Look for control genotypes (typically contain "noncarrier")
+        control_genotypes = model_df[
+            model_df["genotype"].str.contains("noncarrier", case=False, na=False)
+        ]
+        if not control_genotypes.empty:
+            matched_control = control_genotypes.iloc[0]["display_label"]
+        else:
+            # Fallback: use the first genotype's display label
+            matched_control = (
+                model_df.iloc[0]["display_label"] if not model_df.empty else ""
+            )
+        matched_control_dict[model] = matched_control
+
+    output = []
+
+    # Process files one at a time to reduce memory usage
+    file_list = [k for k in datasets.keys() if k not in required_input]
+    total_files = len(file_list)
+
+    data_file_required_columns = [
+        "ensembl_gene_id",
+        "expression",
+        "model",
+        "genotype",
+        "age",
+        "sex",
+        "tissue",
+        "individualID",
+    ]
+
+    logger.info(f"Transform rna_de_individual total data files: {total_files}")
+    logger.info(f"Data files list: {file_list}")
+
+    for i, file_name in enumerate(file_list):
+        data_file = datasets[file_name]
+        file_output = _process_single_data_file(
+            file_name,
+            data_file,
+            data_file_required_columns,
+            gene_metadata_dict,
+            label_map_dict,
+            model_group_dict,
+            matched_control_dict,
+            genotypes_by_model_group,
+            i,
+            total_files,
+        )
+        output.extend(file_output)
+
+    logger.info(f"Transform rna_de_individual total output entries: {len(output)}")
+    return output

--- a/src/agoradatatools/etl/transform/rna_shared_utils.py
+++ b/src/agoradatatools/etl/transform/rna_shared_utils.py
@@ -1,0 +1,238 @@
+"""
+Shared utility functions for RNA-seq data transformations.
+
+This module contains common functionality used by multiple RNA-seq transforms
+including rna_de_aggregate and rna_de_individual.
+"""
+
+import pandas as pd
+from typing import Dict, Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def filter_mouse_genes(df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Filter DataFrame to keep only mouse genes (ENSMUSG*), excluding human genes (ENSG*).
+
+    Args:
+        df: DataFrame with an 'ensembl_gene_id' column
+
+    Returns:
+        Filtered DataFrame containing only mouse genes
+    """
+    return df[df["ensembl_gene_id"].str.startswith("ENSMUSG")]
+
+
+def map_jax_tissue_name(tissue: str) -> str:
+    """
+    Map JAX-specific tissue names to standard names.
+
+    Currently maps "Right Cerebral Hemisphere" to "Hemibrain".
+
+    Args:
+        tissue: Original tissue name
+
+    Returns:
+        Mapped tissue name
+    """
+    return "Hemibrain" if tissue == "Right Cerebral Hemisphere" else tissue
+
+
+def validate_and_sort_age_entries(
+    age_entries: Dict,
+    ensembl_gene_id: str,
+    model: str,
+    tissue: str,
+    sex: str,
+) -> Dict:
+    """
+    Validates and sorts age entries by their numeric value.
+
+    Age entries are expected to be in the format 'N months' where N is an integer.
+    This function validates that all age strings are properly formatted and not empty,
+    then sorts them numerically.
+
+    Args:
+        age_entries: Dictionary with age strings as keys
+        ensembl_gene_id: Gene identifier for error reporting
+        model: Model name for error reporting
+        tissue: Tissue type for error reporting
+        sex: Sex category for error reporting
+
+    Returns:
+        Dictionary of age entries sorted by numeric age value
+
+    Raises:
+        ValueError: If any age string is empty, whitespace-only, or not in 'N months' format
+    """
+    # Validate that no age strings are empty or whitespace-only
+    for age in age_entries.keys():
+        age_stripped = age.strip()
+        if not age_stripped:
+            raise ValueError(
+                f"Empty or whitespace-only age value found in data for gene '{ensembl_gene_id}', "
+                f"model '{model}', tissue '{tissue}', sex '{sex}'. "
+                f"Expected 'N months' format but found: '{age}'"
+            )
+
+    # Sort age entries by numeric value with error handling for format validation
+    try:
+        sorted_ages = dict(
+            sorted(age_entries.items(), key=lambda x: int(x[0].split()[0]))
+        )
+    except (ValueError, IndexError) as e:
+        raise ValueError(
+            f"Invalid age format in data for gene '{ensembl_gene_id}', "
+            f"model '{model}', tissue '{tissue}', sex '{sex}'. "
+            f"Expected 'N months' format but found: {list(age_entries.keys())}. "
+            f"Original error: {e}"
+        ) from e
+
+    return sorted_ages
+
+
+def validate_model_group_consistency(
+    genotype_label_map_df: pd.DataFrame,
+) -> None:
+    """
+    Validate that each model has consistent model_group values.
+
+    Args:
+        genotype_label_map_df: DataFrame with 'model' and 'model_group' columns
+
+    Raises:
+        ValueError: If any model has inconsistent model_group values
+    """
+    inconsistent_models = (
+        genotype_label_map_df.groupby("model")["model_group"]
+        .nunique()
+        .pipe(lambda x: x[x > 1].index.tolist())
+    )
+    if inconsistent_models:
+        raise ValueError(
+            f"Each model must have a consistent model_group value in rnaseq_genotype_label_map. "
+            f"Models with inconsistent model_group values: {inconsistent_models}"
+        )
+
+
+def create_gene_metadata_dict(mouse_gene_metadata_df: pd.DataFrame) -> Dict[str, str]:
+    """
+    Create a lookup dictionary mapping Ensembl gene IDs to gene symbols.
+
+    Args:
+        mouse_gene_metadata_df: DataFrame with 'ensembl_gene_id' and 'gene_symbol' columns
+
+    Returns:
+        Dictionary mapping ensembl_gene_id to gene_symbol
+    """
+    return mouse_gene_metadata_df.set_index("ensembl_gene_id")["gene_symbol"].to_dict()
+
+
+def create_model_group_dict(genotype_label_map_df: pd.DataFrame) -> Dict[str, str]:
+    """
+    Create a lookup dictionary mapping model names to model_group values.
+
+    Args:
+        genotype_label_map_df: DataFrame with 'model' and 'model_group' columns
+
+    Returns:
+        Dictionary mapping model to model_group
+    """
+    return genotype_label_map_df.groupby("model")["model_group"].first().to_dict()
+
+
+def create_label_map_dict(genotype_label_map_df: pd.DataFrame) -> Dict[tuple, str]:
+    """
+    Create a lookup dictionary mapping (model, genotype) tuples to display labels.
+
+    Args:
+        genotype_label_map_df: DataFrame with 'model', 'genotype', and 'display_label' columns
+
+    Returns:
+        Dictionary mapping (model, genotype) to display_label
+    """
+    return genotype_label_map_df.set_index(["model", "genotype"])[
+        "display_label"
+    ].to_dict()
+
+
+def log_file_processing_info(
+    file_name: str,
+    file_index: int,
+    total_files: int,
+    data_file: pd.DataFrame,
+) -> None:
+    """
+    Log information about a file being processed.
+
+    Args:
+        file_name: Name of the file being processed
+        file_index: Current file index (0-based)
+        total_files: Total number of files to process
+        data_file: DataFrame being processed
+    """
+    logger.info(
+        f"Processing {file_name} ({file_index+1}/{total_files}): {len(data_file)} rows, "
+        f"{len(data_file.columns)} columns, "
+        f"{data_file.memory_usage(deep=True).sum() / 1024**2:.2f} MB"
+    )
+
+
+def validate_data_file_not_empty(file_name: str, data_file: pd.DataFrame) -> None:
+    """
+    Validate that a data file is not empty.
+
+    Args:
+        file_name: Name of the file being validated
+        data_file: DataFrame to validate
+
+    Raises:
+        ValueError: If the data file is empty
+    """
+    if len(data_file) == 0:
+        raise ValueError(f"Data file {file_name} is empty")
+
+
+def normalize_model_group_value(model_group: str) -> str or None:
+    """
+    Normalize model_group value by converting empty strings to None.
+
+    Args:
+        model_group: Model group string value
+
+    Returns:
+        None if model_group is empty string, otherwise returns model_group
+    """
+    return None if model_group == "" else model_group
+
+
+def extract_common_metadata(
+    ensembl_gene_id: str,
+    tissue: str,
+    gene_metadata_dict: Dict[str, str],
+) -> Dict[str, Any]:
+    """
+    Extract common metadata fields used by both RNA transforms.
+
+    This function handles:
+    - Gene symbol lookup
+    - JAX tissue name mapping
+
+    Args:
+        ensembl_gene_id: Ensembl gene identifier
+        tissue: Tissue name
+        gene_metadata_dict: Dictionary mapping ensembl_gene_id to gene_symbol
+
+    Returns:
+        Dictionary with extracted metadata:
+            - 'ensembl_gene_id': str
+            - 'gene_symbol': str (empty if not found)
+            - 'tissue': str (mapped tissue name)
+    """
+    return {
+        "ensembl_gene_id": ensembl_gene_id,
+        "gene_symbol": gene_metadata_dict.get(ensembl_gene_id, ""),
+        "tissue": map_jax_tissue_name(tissue),
+    }

--- a/tests/test_assets/rna_de_individual/input/synthetic_basic_individual_data.csv
+++ b/tests/test_assets/rna_de_individual/input/synthetic_basic_individual_data.csv
@@ -1,0 +1,14 @@
+ensembl_gene_id,individualID,expression,tissue,sex,age,genotype,model
+ENSMUSG00000000001,1001,5.5,Cortex,Male,6 months,5XFAD_carrier,5xFAD (UCI)
+ENSMUSG00000000001,1002,5.2,Cortex,Female,6 months,5XFAD_carrier,5xFAD (UCI)
+ENSMUSG00000000001,1003,4.8,Cortex,Male,6 months,5XFAD_noncarrier,5xFAD (UCI)
+ENSMUSG00000000001,1004,4.9,Cortex,Female,6 months,5XFAD_noncarrier,5xFAD (UCI)
+ENSMUSG00000000001,2001,6.1,Cortex,Male,12 months,5XFAD_carrier,5xFAD (UCI)
+ENSMUSG00000000001,2002,6.0,Cortex,Female,12 months,5XFAD_carrier,5xFAD (UCI)
+ENSMUSG00000000001,2003,5.1,Cortex,Male,12 months,5XFAD_noncarrier,5xFAD (UCI)
+ENSMUSG00000000001,2004,5.0,Cortex,Female,12 months,5XFAD_noncarrier,5xFAD (UCI)
+ENSMUSG00000000002,1005,3.5,Hippocampus,Male,6 months,5XFAD_carrier,5xFAD (UCI)
+ENSMUSG00000000002,1006,3.2,Hippocampus,Female,6 months,5XFAD_carrier,5xFAD (UCI)
+ENSMUSG00000000002,1007,2.8,Hippocampus,Male,6 months,5XFAD_noncarrier,5xFAD (UCI)
+ENSMUSG00000000002,1008,2.9,Hippocampus,Female,6 months,5XFAD_noncarrier,5xFAD (UCI)
+

--- a/tests/test_assets/rna_de_individual/input/synthetic_model_group_data.csv
+++ b/tests/test_assets/rna_de_individual/input/synthetic_model_group_data.csv
@@ -1,0 +1,18 @@
+ensembl_gene_id,individualID,expression,tissue,sex,age,genotype,model
+ENSMUSG00000000003,3001,4.5,Hippocampus,Male,4 months,Abca7-V1599M_homozygous,Abca7*V1599M
+ENSMUSG00000000003,3002,4.2,Hippocampus,Female,4 months,Abca7-V1599M_homozygous,Abca7*V1599M
+ENSMUSG00000000003,3003,5.1,Hippocampus,Male,4 months,5XFAD_carrier; Abca7-V1599M_homozygous,Abca7*V1599M
+ENSMUSG00000000003,3004,5.3,Hippocampus,Female,4 months,5XFAD_carrier; Abca7-V1599M_homozygous,Abca7*V1599M
+ENSMUSG00000000003,3005,4.9,Hippocampus,Male,4 months,5XFAD_carrier,Abca7*V1599M
+ENSMUSG00000000003,3006,5.0,Hippocampus,Female,4 months,5XFAD_carrier,Abca7*V1599M
+ENSMUSG00000000003,3007,3.8,Hippocampus,Male,4 months,5XFAD_noncarrier,Abca7*V1599M
+ENSMUSG00000000003,3008,3.9,Hippocampus,Female,4 months,5XFAD_noncarrier,Abca7*V1599M
+ENSMUSG00000000003,4001,5.5,Hippocampus,Male,12 months,Abca7-V1599M_homozygous,Abca7*V1599M
+ENSMUSG00000000003,4002,5.2,Hippocampus,Female,12 months,Abca7-V1599M_homozygous,Abca7*V1599M
+ENSMUSG00000000003,4003,6.1,Hippocampus,Male,12 months,5XFAD_carrier; Abca7-V1599M_homozygous,Abca7*V1599M
+ENSMUSG00000000003,4004,6.3,Hippocampus,Female,12 months,5XFAD_carrier; Abca7-V1599M_homozygous,Abca7*V1599M
+ENSMUSG00000000003,4005,5.9,Hippocampus,Male,12 months,5XFAD_carrier,Abca7*V1599M
+ENSMUSG00000000003,4006,6.0,Hippocampus,Female,12 months,5XFAD_carrier,Abca7*V1599M
+ENSMUSG00000000003,4007,4.8,Hippocampus,Male,12 months,5XFAD_noncarrier,Abca7*V1599M
+ENSMUSG00000000003,4008,4.9,Hippocampus,Female,12 months,5XFAD_noncarrier,Abca7*V1599M
+

--- a/tests/test_assets/rna_de_individual/input/synthetic_mouse_gene_metadata.csv
+++ b/tests/test_assets/rna_de_individual/input/synthetic_mouse_gene_metadata.csv
@@ -1,0 +1,5 @@
+ensembl_gene_id,gene_symbol,alias
+ENSMUSG00000000001,Gene1,
+ENSMUSG00000000002,Gene2,
+ENSMUSG00000000003,Gene3,
+

--- a/tests/test_assets/rna_de_individual/input/synthetic_rnaseq_genotype_label_map.csv
+++ b/tests/test_assets/rna_de_individual/input/synthetic_rnaseq_genotype_label_map.csv
@@ -1,0 +1,12 @@
+model,model_group,display_label,genotype
+5xFAD (UCI),,5xFAD (UCI),5XFAD_carrier
+5xFAD (UCI),,C57BL/6J,5XFAD_noncarrier
+Abca7*V1599M,Abca7*V1599M,Abca7*V1599M,Abca7-V1599M_homozygous
+Abca7*V1599M,Abca7*V1599M,C57BL/6J,5XFAD_noncarrier
+Abca7*V1599M,Abca7*V1599M,Abca7*V1599M.5xFAD,5XFAD_carrier; Abca7-V1599M_homozygous
+Abca7*V1599M,Abca7*V1599M,5xFAD,5XFAD_carrier
+LOAD1,LOAD1,C57BL/6J,APOE4-KI_noncarrier
+LOAD1,LOAD1,APOE4,APOE4-KI_homozygous
+LOAD1,LOAD1,LOAD1,APOE4-KI_homozygous; Trem2-R47H_homozygous
+LOAD1,LOAD1,Trem2R47H,Trem2-R47H_homozygous
+

--- a/tests/test_assets/rna_de_individual/output/synthetic_basic_output.json
+++ b/tests/test_assets/rna_de_individual/output/synthetic_basic_output.json
@@ -1,0 +1,112 @@
+[
+  {
+    "ensembl_gene_id": "ENSMUSG00000000001",
+    "hgnc_symbol": "Gene1",
+    "tissue": "Cortex",
+    "name": "5xFAD (UCI)",
+    "model_group": null,
+    "matched_control": "C57BL/6J",
+    "units": "Log2 Counts per Million",
+    "individual_results": [
+      {
+        "age": "6 months",
+        "data": [
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Male",
+            "individual_id": "1001",
+            "value": 5.5
+          },
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Female",
+            "individual_id": "1002",
+            "value": 5.2
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Male",
+            "individual_id": "1003",
+            "value": 4.8
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Female",
+            "individual_id": "1004",
+            "value": 4.9
+          }
+        ]
+      },
+      {
+        "age": "12 months",
+        "data": [
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Male",
+            "individual_id": "2001",
+            "value": 6.1
+          },
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Female",
+            "individual_id": "2002",
+            "value": 6.0
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Male",
+            "individual_id": "2003",
+            "value": 5.1
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Female",
+            "individual_id": "2004",
+            "value": 5.0
+          }
+        ]
+      }
+    ]
+  },
+  {
+    "ensembl_gene_id": "ENSMUSG00000000002",
+    "hgnc_symbol": "Gene2",
+    "tissue": "Hippocampus",
+    "name": "5xFAD (UCI)",
+    "model_group": null,
+    "matched_control": "C57BL/6J",
+    "units": "Log2 Counts per Million",
+    "individual_results": [
+      {
+        "age": "6 months",
+        "data": [
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Male",
+            "individual_id": "1005",
+            "value": 3.5
+          },
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Female",
+            "individual_id": "1006",
+            "value": 3.2
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Male",
+            "individual_id": "1007",
+            "value": 2.8
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Female",
+            "individual_id": "1008",
+            "value": 2.9
+          }
+        ]
+      }
+    ]
+  }
+]
+

--- a/tests/test_assets/rna_de_individual/output/synthetic_model_group_output.json
+++ b/tests/test_assets/rna_de_individual/output/synthetic_model_group_output.json
@@ -1,0 +1,120 @@
+[
+  {
+    "ensembl_gene_id": "ENSMUSG00000000003",
+    "hgnc_symbol": "Gene3",
+    "tissue": "Hippocampus",
+    "name": "Abca7*V1599M",
+    "model_group": "Abca7*V1599M",
+    "matched_control": "C57BL/6J",
+    "units": "Log2 Counts per Million",
+    "individual_results": [
+      {
+        "age": "4 months",
+        "data": [
+          {
+            "genotype": "Abca7-V1599M_homozygous",
+            "sex": "Male",
+            "individual_id": "3001",
+            "value": 4.5
+          },
+          {
+            "genotype": "Abca7-V1599M_homozygous",
+            "sex": "Female",
+            "individual_id": "3002",
+            "value": 4.2
+          },
+          {
+            "genotype": "5XFAD_carrier; Abca7-V1599M_homozygous",
+            "sex": "Male",
+            "individual_id": "3003",
+            "value": 5.1
+          },
+          {
+            "genotype": "5XFAD_carrier; Abca7-V1599M_homozygous",
+            "sex": "Female",
+            "individual_id": "3004",
+            "value": 5.3
+          },
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Male",
+            "individual_id": "3005",
+            "value": 4.9
+          },
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Female",
+            "individual_id": "3006",
+            "value": 5.0
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Male",
+            "individual_id": "3007",
+            "value": 3.8
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Female",
+            "individual_id": "3008",
+            "value": 3.9
+          }
+        ]
+      },
+      {
+        "age": "12 months",
+        "data": [
+          {
+            "genotype": "Abca7-V1599M_homozygous",
+            "sex": "Male",
+            "individual_id": "4001",
+            "value": 5.5
+          },
+          {
+            "genotype": "Abca7-V1599M_homozygous",
+            "sex": "Female",
+            "individual_id": "4002",
+            "value": 5.2
+          },
+          {
+            "genotype": "5XFAD_carrier; Abca7-V1599M_homozygous",
+            "sex": "Male",
+            "individual_id": "4003",
+            "value": 6.1
+          },
+          {
+            "genotype": "5XFAD_carrier; Abca7-V1599M_homozygous",
+            "sex": "Female",
+            "individual_id": "4004",
+            "value": 6.3
+          },
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Male",
+            "individual_id": "4005",
+            "value": 5.9
+          },
+          {
+            "genotype": "5XFAD_carrier",
+            "sex": "Female",
+            "individual_id": "4006",
+            "value": 6.0
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Male",
+            "individual_id": "4007",
+            "value": 4.8
+          },
+          {
+            "genotype": "5XFAD_noncarrier",
+            "sex": "Female",
+            "individual_id": "4008",
+            "value": 4.9
+          }
+        ]
+      }
+    ]
+  }
+]
+

--- a/tests/transform/test_rna_de_individual.py
+++ b/tests/transform/test_rna_de_individual.py
@@ -1,0 +1,430 @@
+"""
+Test suite for RNA individual expression transformation.
+
+This module contains comprehensive tests for the `transform_rna_de_individual` function
+and its helper functions, which transform mouse model individual RNA-seq expression
+data into a structured format for the Agora platform.
+
+Test Classes:
+    - TestCreateIndividualResultsFromGroup: Unit tests for _create_individual_results_from_group
+    - TestCreateOutputEntryFromGroup: Unit tests for _create_output_entry_from_group
+    - TestProcessSingleDataFile: Unit tests for _process_single_data_file
+    - TestTransformRnaDeIndividual: Integration tests for the full transformation pipeline
+
+The tests use synthetic datasets stored in `tests/test_assets/rna_de_individual/` to verify:
+- Core transformation logic (data grouping, metadata enrichment)
+- Model_group handling (single control vs multiple control paradigms)
+- JAX tissue name mapping (e.g., 'Right Cerebral Hemisphere' -> 'Hemibrain')
+- Human gene filtering (only mouse genes with ENSMUSG* IDs should be processed)
+- Age sorting (numeric ordering of age entries)
+- Edge cases (single row data, missing metadata, empty files)
+- Error handling (missing datasets, empty files, missing columns)
+"""
+
+import os
+import json
+from typing import Dict, List
+import pandas as pd
+import pytest
+
+from agoradatatools.etl.transform.rna_de_individual import (
+    transform_rna_de_individual,
+    _create_individual_results_from_group,
+    _create_output_entry_from_group,
+    _process_single_data_file,
+)
+
+
+class TestCreateIndividualResultsFromGroup:
+    """
+    Unit tests for the _create_individual_results_from_group helper function.
+    """
+
+    def test_create_individual_results_single_age(self) -> None:
+        """Test creating individual_results from a single age group."""
+        group = pd.DataFrame(
+            {
+                "age": ["6 months", "6 months"],
+                "genotype": ["5XFAD_carrier", "5XFAD_noncarrier"],
+                "sex": ["Male", "Female"],
+                "individualID": ["1001", "1002"],
+                "expression": [5.5, 4.9],
+            }
+        )
+
+        result = _create_individual_results_from_group(group)
+
+        assert len(result) == 1
+        assert result[0]["age"] == "6 months"
+        assert len(result[0]["data"]) == 2
+        assert result[0]["data"][0]["genotype"] == "5XFAD_carrier"
+        assert result[0]["data"][0]["value"] == pytest.approx(5.5)
+        assert result[0]["data"][0]["individual_id"] == "1001"
+
+    def test_create_individual_results_multiple_ages(self) -> None:
+        """Test creating individual_results from multiple age groups."""
+        group = pd.DataFrame(
+            {
+                "age": ["6 months", "6 months", "12 months", "12 months"],
+                "genotype": [
+                    "5XFAD_carrier",
+                    "5XFAD_noncarrier",
+                    "5XFAD_carrier",
+                    "5XFAD_noncarrier",
+                ],
+                "sex": ["Male", "Female", "Male", "Female"],
+                "individualID": ["1001", "1002", "2001", "2002"],
+                "expression": [5.5, 4.9, 6.1, 5.0],
+            }
+        )
+
+        result = _create_individual_results_from_group(group)
+
+        assert len(result) == 2
+        assert result[0]["age"] == "6 months"
+        assert result[1]["age"] == "12 months"
+        assert len(result[0]["data"]) == 2
+        assert len(result[1]["data"]) == 2
+
+    def test_create_individual_results_age_sorting(self) -> None:
+        """Test that ages are sorted numerically."""
+        group = pd.DataFrame(
+            {
+                "age": ["12 months", "6 months", "18 months"],
+                "genotype": ["5XFAD_carrier", "5XFAD_carrier", "5XFAD_carrier"],
+                "sex": ["Male", "Male", "Male"],
+                "individualID": ["2001", "1001", "3001"],
+                "expression": [6.1, 5.5, 7.0],
+            }
+        )
+
+        result = _create_individual_results_from_group(group)
+
+        assert len(result) == 3
+        assert result[0]["age"] == "6 months"
+        assert result[1]["age"] == "12 months"
+        assert result[2]["age"] == "18 months"
+
+
+class TestCreateOutputEntryFromGroup:
+    """
+    Unit tests for the _create_output_entry_from_group helper function.
+    """
+
+    def test_create_output_entry_basic(self) -> None:
+        """Test basic output entry creation."""
+        # group_key contains (ensembl_gene_id, tissue, model_group, name)
+        # When model_group is empty, it should be set to empty string in group_key
+        group_key = ("ENSMUSG00000000001", "Cortex", "", "5xFAD (UCI)")
+        group = pd.DataFrame(
+            {
+                "age": ["6 months", "6 months"],
+                "genotype": ["5XFAD_carrier", "5XFAD_noncarrier"],
+                "sex": ["Male", "Female"],
+                "individualID": ["1001", "1002"],
+                "expression": [5.5, 4.9],
+            }
+        )
+
+        gene_metadata_dict = {"ENSMUSG00000000001": "Gene1"}
+        matched_control_dict = {"5xFAD (UCI)": "C57BL/6J"}
+
+        result = _create_output_entry_from_group(
+            group_key,
+            group,
+            gene_metadata_dict,
+            matched_control_dict,
+        )
+
+        assert result["ensembl_gene_id"] == "ENSMUSG00000000001"
+        assert result["hgnc_symbol"] == "Gene1"
+        assert result["tissue"] == "Cortex"
+        assert result["name"] == "5xFAD (UCI)"
+        assert result["model_group"] is None
+        assert result["matched_control"] == "C57BL/6J"
+        assert result["units"] == "Log2 Counts per Million"
+        assert len(result["individual_results"]) == 1
+
+    def test_create_output_entry_jax_tissue_mapping(self) -> None:
+        """Test that JAX tissue name is mapped correctly."""
+        group_key = (
+            "ENSMUSG00000000001",
+            "Right Cerebral Hemisphere",
+            "Model_A",
+            "Model_A",
+        )
+        group = pd.DataFrame(
+            {
+                "age": ["6 months"],
+                "genotype": ["5XFAD_carrier"],
+                "sex": ["Male"],
+                "individualID": ["1001"],
+                "expression": [5.5],
+            }
+        )
+
+        gene_metadata_dict = {}
+        matched_control_dict = {}
+
+        result = _create_output_entry_from_group(
+            group_key,
+            group,
+            gene_metadata_dict,
+            matched_control_dict,
+        )
+
+        assert result["tissue"] == "Hemibrain"
+
+    def test_create_output_entry_with_model_group(self) -> None:
+        """Test output entry creation with model_group."""
+        group_key = (
+            "ENSMUSG00000000003",
+            "Hippocampus",
+            "Abca7*V1599M",
+            "Abca7*V1599M",
+        )
+        group = pd.DataFrame(
+            {
+                "age": ["4 months"],
+                "genotype": ["Abca7-V1599M_homozygous"],
+                "sex": ["Male"],
+                "individualID": ["3001"],
+                "expression": [4.5],
+            }
+        )
+
+        gene_metadata_dict = {"ENSMUSG00000000003": "Gene3"}
+        matched_control_dict = {"Abca7*V1599M": "C57BL/6J"}
+
+        result = _create_output_entry_from_group(
+            group_key,
+            group,
+            gene_metadata_dict,
+            matched_control_dict,
+        )
+
+        assert result["model_group"] == "Abca7*V1599M"
+
+
+class TestProcessSingleDataFile:
+    """
+    Unit tests for the _process_single_data_file helper function.
+    """
+
+    def test_process_single_data_file_basic(self) -> None:
+        """Test basic processing of a single data file."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000001"],
+                "individualID": ["1001", "1002"],
+                "expression": [5.5, 4.9],
+                "tissue": ["Cortex", "Cortex"],
+                "sex": ["Male", "Female"],
+                "age": ["6 months", "6 months"],
+                "genotype": ["5XFAD_carrier", "5XFAD_noncarrier"],
+                "model": ["5xFAD (UCI)", "5xFAD (UCI)"],
+            }
+        )
+
+        gene_metadata_dict = {"ENSMUSG00000000001": "Gene1"}
+        label_map_dict = {
+            ("5xFAD (UCI)", "5XFAD_carrier"): "5xFAD (UCI)",
+            ("5xFAD (UCI)", "5XFAD_noncarrier"): "C57BL/6J",
+        }
+        model_group_dict = {"5xFAD (UCI)": ""}
+        matched_control_dict = {"5xFAD (UCI)": "C57BL/6J"}
+        genotypes_by_model_group = {
+            "5xFAD (UCI)": ["5XFAD_carrier", "5XFAD_noncarrier"]
+        }
+
+        data_file_required_columns = [
+            "ensembl_gene_id",
+            "expression",
+            "model",
+            "genotype",
+            "age",
+            "sex",
+            "tissue",
+            "individualID",
+        ]
+
+        result = _process_single_data_file(
+            file_name="test_file.csv",
+            data_file=data_file,
+            data_file_required_columns=data_file_required_columns,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            matched_control_dict=matched_control_dict,
+            genotypes_by_model_group=genotypes_by_model_group,
+            file_index=0,
+            total_files=1,
+        )
+
+        assert len(result) == 1
+        assert result[0]["ensembl_gene_id"] == "ENSMUSG00000000001"
+
+    def test_process_single_data_file_filters_human_genes(self) -> None:
+        """Test that human genes are filtered out."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSG00000000001"],
+                "individualID": ["1001", "1002"],
+                "expression": [5.5, 4.9],
+                "tissue": ["Cortex", "Cortex"],
+                "sex": ["Male", "Female"],
+                "age": ["6 months", "6 months"],
+                "genotype": ["5XFAD_carrier", "5XFAD_carrier"],
+                "model": ["5xFAD (UCI)", "5xFAD (UCI)"],
+            }
+        )
+
+        gene_metadata_dict = {}
+        label_map_dict = {}
+        model_group_dict = {"5xFAD (UCI)": ""}
+        matched_control_dict = {}
+        genotypes_by_model_group = {"5xFAD (UCI)": ["5XFAD_carrier"]}
+
+        data_file_required_columns = [
+            "ensembl_gene_id",
+            "expression",
+            "model",
+            "genotype",
+            "age",
+            "sex",
+            "tissue",
+            "individualID",
+        ]
+
+        result = _process_single_data_file(
+            file_name="test_file.csv",
+            data_file=data_file,
+            data_file_required_columns=data_file_required_columns,
+            gene_metadata_dict=gene_metadata_dict,
+            label_map_dict=label_map_dict,
+            model_group_dict=model_group_dict,
+            matched_control_dict=matched_control_dict,
+            genotypes_by_model_group=genotypes_by_model_group,
+            file_index=0,
+            total_files=1,
+        )
+
+        # Only one entry (mouse gene only)
+        assert len(result) == 1
+        assert result[0]["ensembl_gene_id"].startswith("ENSMUSG")
+
+    def test_process_single_data_file_empty_raises_error(self) -> None:
+        """Test that empty file raises ValueError."""
+        data_file = pd.DataFrame()
+
+        with pytest.raises(ValueError, match="Data file .* is empty"):
+            _process_single_data_file(
+                file_name="empty_file.csv",
+                data_file=data_file,
+                data_file_required_columns=["ensembl_gene_id"],
+                gene_metadata_dict={},
+                label_map_dict={},
+                model_group_dict={},
+                matched_control_dict={},
+                genotypes_by_model_group={},
+                file_index=0,
+                total_files=1,
+            )
+
+
+class TestTransformRnaDeIndividual:
+    """
+    Integration tests for RNA individual expression transformation.
+    """
+
+    data_files_path = "tests/test_assets/rna_de_individual"
+
+    def _load_synthetic_test_data(
+        self, data_files: List[str]
+    ) -> Dict[str, pd.DataFrame]:
+        """Load synthetic test data files as DataFrames."""
+        datasets = {}
+        input_path = os.path.join(self.data_files_path, "input")
+
+        file_to_key_mapping = {
+            "synthetic_rnaseq_genotype_label_map.csv": "rnaseq_genotype_label_map",
+            "synthetic_mouse_gene_metadata.csv": "mouse_gene_metadata",
+        }
+
+        for file_name in data_files:
+            if file_name.endswith(".csv"):
+                file_path = os.path.join(input_path, file_name)
+                df = pd.read_csv(file_path)
+                key = file_to_key_mapping.get(file_name, file_name.replace(".csv", ""))
+                datasets[key] = df
+
+        return datasets
+
+    def test_synthetic_basic_data(self) -> None:
+        """Test transformation with synthetic basic data."""
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_basic_individual_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+            ]
+        )
+
+        with open(
+            os.path.join(self.data_files_path, "output", "synthetic_basic_output.json")
+        ) as f:
+            expected_data = json.load(f)
+
+        output_data = transform_rna_de_individual(datasets=datasets)
+
+        # Sort for deterministic comparison
+        output_data_sorted = sorted(
+            output_data, key=lambda x: (x["ensembl_gene_id"], x["tissue"])
+        )
+        expected_data_sorted = sorted(
+            expected_data, key=lambda x: (x["ensembl_gene_id"], x["tissue"])
+        )
+
+        assert output_data_sorted == expected_data_sorted
+
+    def test_synthetic_model_group_data(self) -> None:
+        """Test transformation with model_group data (multiple genotypes)."""
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_model_group_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+            ]
+        )
+
+        with open(
+            os.path.join(
+                self.data_files_path, "output", "synthetic_model_group_output.json"
+            )
+        ) as f:
+            expected_data = json.load(f)
+
+        output_data = transform_rna_de_individual(datasets=datasets)
+
+        # Sort for deterministic comparison
+        output_data_sorted = sorted(
+            output_data, key=lambda x: (x["ensembl_gene_id"], x["tissue"])
+        )
+        expected_data_sorted = sorted(
+            expected_data, key=lambda x: (x["ensembl_gene_id"], x["tissue"])
+        )
+
+        assert output_data_sorted == expected_data_sorted
+
+    def test_transform_rna_de_individual_missing_required_dataset(self) -> None:
+        """Test that missing required datasets raise ValueError."""
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_basic_individual_data.csv",
+                "synthetic_mouse_gene_metadata.csv",
+                # Missing rnaseq_genotype_label_map
+            ]
+        )
+
+        with pytest.raises(ValueError):
+            transform_rna_de_individual(datasets=datasets)

--- a/tests/transform/test_rna_shared_utils.py
+++ b/tests/transform/test_rna_shared_utils.py
@@ -1,0 +1,430 @@
+"""
+Test suite for RNA-seq shared utilities.
+
+This module contains comprehensive tests for the shared utility functions used by
+multiple RNA-seq transforms (rna_de_aggregate and rna_de_individual).
+"""
+
+import pandas as pd
+import pytest
+import logging
+
+from agoradatatools.etl.transform.rna_shared_utils import (
+    filter_mouse_genes,
+    map_jax_tissue_name,
+    validate_and_sort_age_entries,
+    validate_model_group_consistency,
+    create_gene_metadata_dict,
+    create_model_group_dict,
+    create_label_map_dict,
+    log_file_processing_info,
+    validate_data_file_not_empty,
+    normalize_model_group_value,
+    extract_common_metadata,
+)
+
+
+class TestFilterMouseGenes:
+    """Tests for filter_mouse_genes function."""
+
+    def test_filters_human_genes(self) -> None:
+        """Test that human genes (ENSG*) are filtered out."""
+        df = pd.DataFrame(
+            {
+                "ensembl_gene_id": [
+                    "ENSMUSG00000000001",
+                    "ENSG00000000001",
+                    "ENSMUSG00000000002",
+                ],
+                "value": [1, 2, 3],
+            }
+        )
+
+        result = filter_mouse_genes(df)
+
+        assert len(result) == 2
+        assert all(result["ensembl_gene_id"].str.startswith("ENSMUSG"))
+        assert "ENSG00000000001" not in result["ensembl_gene_id"].values
+
+    def test_keeps_all_mouse_genes(self) -> None:
+        """Test that all mouse genes are kept."""
+        df = pd.DataFrame(
+            {
+                "ensembl_gene_id": [
+                    "ENSMUSG00000000001",
+                    "ENSMUSG00000000002",
+                    "ENSMUSG00000000003",
+                ],
+                "value": [1, 2, 3],
+            }
+        )
+
+        result = filter_mouse_genes(df)
+
+        assert len(result) == 3
+
+    def test_empty_dataframe(self) -> None:
+        """Test handling of empty DataFrame."""
+        df = pd.DataFrame({"ensembl_gene_id": pd.Series([], dtype=str), "value": []})
+
+        result = filter_mouse_genes(df)
+
+        assert len(result) == 0
+
+
+class TestMapJaxTissueName:
+    """Tests for map_jax_tissue_name function."""
+
+    def test_maps_right_cerebral_hemisphere(self) -> None:
+        """Test that 'Right Cerebral Hemisphere' is mapped to 'Hemibrain'."""
+        result = map_jax_tissue_name("Right Cerebral Hemisphere")
+        assert result == "Hemibrain"
+
+    def test_keeps_other_tissue_names(self) -> None:
+        """Test that other tissue names are unchanged."""
+        assert map_jax_tissue_name("Cortex") == "Cortex"
+        assert map_jax_tissue_name("Hippocampus") == "Hippocampus"
+        assert map_jax_tissue_name("Cerebellum") == "Cerebellum"
+
+    def test_case_sensitive(self) -> None:
+        """Test that mapping is case-sensitive."""
+        assert (
+            map_jax_tissue_name("right cerebral hemisphere")
+            == "right cerebral hemisphere"
+        )
+
+
+class TestValidateAndSortAgeEntries:
+    """Tests for validate_and_sort_age_entries function."""
+
+    def test_sorts_ages_numerically(self) -> None:
+        """Test that ages are sorted numerically."""
+        age_entries = {
+            "12 months": {"log2_fc": 0.8},
+            "4 months": {"log2_fc": 0.3},
+            "6 months": {"log2_fc": 0.5},
+        }
+
+        result = validate_and_sort_age_entries(
+            age_entries, "ENSMUSG00000000001", "Model_A", "Cortex", "Male"
+        )
+
+        assert list(result.keys()) == ["4 months", "6 months", "12 months"]
+
+    def test_single_age(self) -> None:
+        """Test handling of single age entry."""
+        age_entries = {"6 months": {"log2_fc": 0.5}}
+
+        result = validate_and_sort_age_entries(
+            age_entries, "ENSMUSG00000000001", "Model_A", "Cortex", "Male"
+        )
+
+        assert result == age_entries
+
+    def test_empty_age_raises_error(self) -> None:
+        """Test that empty age string raises ValueError."""
+        age_entries = {"": {"log2_fc": 0.5}}
+
+        with pytest.raises(ValueError, match="Empty or whitespace-only age value"):
+            validate_and_sort_age_entries(
+                age_entries, "ENSMUSG00000000001", "Model_A", "Cortex", "Male"
+            )
+
+    def test_invalid_age_format_raises_error(self) -> None:
+        """Test that invalid age format raises ValueError."""
+        age_entries = {"6months": {"log2_fc": 0.5}}
+
+        with pytest.raises(ValueError, match="Invalid age format"):
+            validate_and_sort_age_entries(
+                age_entries, "ENSMUSG00000000001", "Model_A", "Cortex", "Male"
+            )
+
+    def test_empty_dict(self) -> None:
+        """Test handling of empty age entries dictionary."""
+        age_entries = {}
+
+        result = validate_and_sort_age_entries(
+            age_entries, "ENSMUSG00000000001", "Model_A", "Cortex", "Male"
+        )
+
+        assert result == {}
+
+
+class TestValidateModelGroupConsistency:
+    """Tests for validate_model_group_consistency function."""
+
+    def test_consistent_model_groups(self) -> None:
+        """Test that consistent model_group values pass validation."""
+        df = pd.DataFrame(
+            {
+                "model": ["Model_A", "Model_A", "Model_B", "Model_B"],
+                "model_group": ["Group1", "Group1", "Group2", "Group2"],
+            }
+        )
+
+        # Should not raise
+        validate_model_group_consistency(df)
+
+    def test_inconsistent_model_groups_raises_error(self) -> None:
+        """Test that inconsistent model_group values raise ValueError."""
+        df = pd.DataFrame(
+            {
+                "model": ["Model_A", "Model_A", "Model_B", "Model_B"],
+                "model_group": ["Group1", "Group2", "Group3", "Group3"],
+            }
+        )
+
+        with pytest.raises(ValueError, match="consistent model_group value"):
+            validate_model_group_consistency(df)
+
+    def test_empty_model_groups(self) -> None:
+        """Test handling of empty model_group values."""
+        df = pd.DataFrame(
+            {
+                "model": ["Model_A", "Model_A"],
+                "model_group": ["", ""],
+            }
+        )
+
+        # Should not raise
+        validate_model_group_consistency(df)
+
+
+class TestCreateGeneMetadataDict:
+    """Tests for create_gene_metadata_dict function."""
+
+    def test_creates_correct_mapping(self) -> None:
+        """Test that dictionary is created correctly."""
+        df = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
+                "gene_symbol": ["Gene1", "Gene2"],
+            }
+        )
+
+        result = create_gene_metadata_dict(df)
+
+        assert result == {
+            "ENSMUSG00000000001": "Gene1",
+            "ENSMUSG00000000002": "Gene2",
+        }
+
+    def test_empty_dataframe(self) -> None:
+        """Test handling of empty DataFrame."""
+        df = pd.DataFrame({"ensembl_gene_id": [], "gene_symbol": []})
+
+        result = create_gene_metadata_dict(df)
+
+        assert result == {}
+
+
+class TestCreateModelGroupDict:
+    """Tests for create_model_group_dict function."""
+
+    def test_creates_correct_mapping(self) -> None:
+        """Test that dictionary is created correctly."""
+        df = pd.DataFrame(
+            {
+                "model": ["Model_A", "Model_A", "Model_B", "Model_B"],
+                "model_group": ["Group1", "Group1", "Group2", "Group2"],
+            }
+        )
+
+        result = create_model_group_dict(df)
+
+        assert result == {
+            "Model_A": "Group1",
+            "Model_B": "Group2",
+        }
+
+    def test_takes_first_value_per_model(self) -> None:
+        """Test that first value is taken when multiple exist."""
+        df = pd.DataFrame(
+            {
+                "model": ["Model_A", "Model_A"],
+                "model_group": ["Group1", "Group1"],
+            }
+        )
+
+        result = create_model_group_dict(df)
+
+        assert result == {"Model_A": "Group1"}
+
+
+class TestCreateLabelMapDict:
+    """Tests for create_label_map_dict function."""
+
+    def test_creates_correct_mapping(self) -> None:
+        """Test that dictionary is created correctly."""
+        df = pd.DataFrame(
+            {
+                "model": ["Model_A", "Model_A", "Model_B"],
+                "genotype": ["Geno1", "Geno2", "Geno1"],
+                "display_label": ["Label1", "Label2", "Label3"],
+            }
+        )
+
+        result = create_label_map_dict(df)
+
+        assert result == {
+            ("Model_A", "Geno1"): "Label1",
+            ("Model_A", "Geno2"): "Label2",
+            ("Model_B", "Geno1"): "Label3",
+        }
+
+    def test_empty_dataframe(self) -> None:
+        """Test handling of empty DataFrame."""
+        df = pd.DataFrame({"model": [], "genotype": [], "display_label": []})
+
+        result = create_label_map_dict(df)
+
+        assert result == {}
+
+
+class TestLogFileProcessingInfo:
+    """Tests for log_file_processing_info function."""
+
+    def test_logs_information(self, caplog) -> None:
+        """Test that file processing information is logged."""
+        df = pd.DataFrame(
+            {
+                "col1": [1, 2, 3],
+                "col2": [4, 5, 6],
+            }
+        )
+
+        with caplog.at_level(logging.INFO):
+            log_file_processing_info("test.csv", 0, 5, df)
+
+        assert "Processing test.csv (1/5)" in caplog.text
+        assert "3 rows" in caplog.text
+        assert "2 columns" in caplog.text
+
+
+class TestValidateDataFileNotEmpty:
+    """Tests for validate_data_file_not_empty function."""
+
+    def test_raises_error_for_empty_file(self) -> None:
+        """Test that empty file raises ValueError."""
+        df = pd.DataFrame()
+
+        with pytest.raises(ValueError, match="Data file test.csv is empty"):
+            validate_data_file_not_empty("test.csv", df)
+
+    def test_passes_for_non_empty_file(self) -> None:
+        """Test that non-empty file passes validation."""
+        df = pd.DataFrame({"col1": [1, 2, 3]})
+
+        # Should not raise
+        validate_data_file_not_empty("test.csv", df)
+
+
+class TestNormalizeModelGroupValue:
+    """Tests for normalize_model_group_value function."""
+
+    def test_converts_empty_string_to_none(self) -> None:
+        """Test that empty string is converted to None."""
+        assert normalize_model_group_value("") is None
+
+    def test_keeps_non_empty_strings(self) -> None:
+        """Test that non-empty strings are kept."""
+        assert normalize_model_group_value("Group1") == "Group1"
+        assert normalize_model_group_value("5xFAD") == "5xFAD"
+
+    def test_whitespace_is_not_converted(self) -> None:
+        """Test that whitespace strings are not converted to None."""
+        assert normalize_model_group_value("  ") == "  "
+
+
+class TestExtractCommonMetadata:
+    """Tests for extract_common_metadata function."""
+
+    def test_extracts_all_metadata(self) -> None:
+        """Test that all metadata fields are extracted correctly."""
+        gene_metadata_dict = {
+            "ENSMUSG00000000001": "Gene1",
+        }
+
+        result = extract_common_metadata(
+            "ENSMUSG00000000001", "Cortex", gene_metadata_dict
+        )
+
+        assert result == {
+            "ensembl_gene_id": "ENSMUSG00000000001",
+            "gene_symbol": "Gene1",
+            "tissue": "Cortex",
+        }
+
+    def test_maps_jax_tissue(self) -> None:
+        """Test that JAX tissue name is mapped."""
+        result = extract_common_metadata(
+            "ENSMUSG00000000001", "Right Cerebral Hemisphere", {}
+        )
+
+        assert result["tissue"] == "Hemibrain"
+
+    def test_handles_missing_gene_symbol(self) -> None:
+        """Test that missing gene symbol returns empty string."""
+        result = extract_common_metadata("ENSMUSG00000000001", "Cortex", {})
+
+        assert result["gene_symbol"] == ""
+
+    def test_preserves_ensembl_gene_id(self) -> None:
+        """Test that ensembl_gene_id is preserved."""
+        result = extract_common_metadata("ENSMUSG00000099999", "Cortex", {})
+
+        assert result["ensembl_gene_id"] == "ENSMUSG00000099999"
+
+
+class TestIntegration:
+    """Integration tests for multiple functions working together."""
+
+    def test_complete_workflow(self) -> None:
+        """Test a complete workflow using multiple shared utilities."""
+        # Create test data
+        genotype_df = pd.DataFrame(
+            {
+                "model": ["Model_A", "Model_A", "Model_B", "Model_B"],
+                "genotype": ["Geno1", "Geno2", "Geno1", "Geno2"],
+                "display_label": ["Label1", "Label2", "Label3", "Label4"],
+                "model_group": ["Group1", "Group1", "Group2", "Group2"],
+            }
+        )
+
+        gene_metadata_df = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
+                "gene_symbol": ["Gene1", "Gene2"],
+            }
+        )
+
+        data_df = pd.DataFrame(
+            {
+                "ensembl_gene_id": [
+                    "ENSMUSG00000000001",
+                    "ENSG00000000001",
+                    "ENSMUSG00000000002",
+                ],
+                "value": [1, 2, 3],
+            }
+        )
+
+        # Test workflow
+        validate_model_group_consistency(genotype_df)
+        model_group_dict = create_model_group_dict(genotype_df)
+        label_map_dict = create_label_map_dict(genotype_df)
+        gene_metadata_dict = create_gene_metadata_dict(gene_metadata_df)
+        filtered_data = filter_mouse_genes(data_df)
+
+        # Verify results
+        assert len(filtered_data) == 2
+        assert model_group_dict["Model_A"] == "Group1"
+        assert label_map_dict[("Model_A", "Geno1")] == "Label1"
+        assert gene_metadata_dict["ENSMUSG00000000001"] == "Gene1"
+
+        # Test metadata extraction
+        metadata = extract_common_metadata(
+            "ENSMUSG00000000001", "Right Cerebral Hemisphere", gene_metadata_dict
+        )
+        assert metadata["gene_symbol"] == "Gene1"
+        assert metadata["tissue"] == "Hemibrain"


### PR DESCRIPTION
We recently added a column header to the CT primary column, enabling display of a column name and sort indicator.

This PR adds tooltip values for the primary column names for all CTs.