### PR TITLE
MG-668: Use the correct set of filter values for model overview modified_genes

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -445,7 +445,7 @@ mo_filter_values <- list(
   c('Biomarkers', 'Disease Correlation', 'Gene Expression', 'Pathology'),
   c('IU/Jax/Pitt', 'UCI'),
   model_type_filter_vals,
-  model_name_filter_vals
+  modified_gene_filter_vals
 )
 
 # Generates Model Overview ui_config objects


### PR DESCRIPTION
# Problem
The `ui_config` filter defintion for the Model Overview`modified_genes` filterset is incorrectly populated with model names.

# Solution
Populate the filter defintion with the correct list of values.