### PR TITLE
MG-681 / MG-384: Update ui_config to adjust column order and remove row_counts

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -38,9 +38,10 @@ Sources the required variables and functions.
 # *******************************
 # STATIC ROW COUNTS (MG-384)
 # *******************************
-gene_expression_row_count = "over 200000" # THIS IS NOT THE REAL VALUE
-disease_correlation_row_count = "1800" # 1800 source rows/total results, 300 CT rows, 60 rows/cluster, variable results per row
-model_overview_row_count = "16"
+# we don't need row_count values for ModelAD CT loading indicators since we've introduced server-side pagination
+gene_expression_row_count = NA
+disease_correlation_row_count = NA
+model_overview_row_count = NA
 
 # *************
 # FILTER VALUES
@@ -409,8 +410,8 @@ build_dc_objects <- function() {
 #
 mo_columns <- data.frame(
   name = c("Model", "Model Type", "Matched Controls",
-           "Gene Expression", "Disease Correlation", "Pathology",
-           "Biomarkers", "Study Data", "JAX Strain",
+           "Gene Expression", "Disease Correlation", "Biomarkers",
+           "Pathology", "Study Data", "JAX Strain",
            "Center", NA, NA
   ),
   type = c("primary", "text", "text",
@@ -419,7 +420,7 @@ mo_columns <- data.frame(
     "link_external", "text", "text"
   ),
   data_key = c("name", "model_type", "matched_controls", "gene_expression",
-                 "disease_correlation", "pathology", "biomarkers",
+                 "disease_correlation", "biomarkers", "pathology",
                  "study_data", "jax_strain", "center", "modified_genes", "available_data"),
   tooltip = c("Mouse Model",  rep(NA, times = 11)),
   sort_tooltip = rep(NA, times = 12),
@@ -569,4 +570,3 @@ json_list <-  build_ge_objects()
 
 toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)
 ```
-


### PR DESCRIPTION
Problems
1. The column order of the Model Overview CT (Pathology, Biomarkers) and the Details page tab ordering (Biomarkers, Pathology) are not aligned
2. The `row_count` values for the loading spinner are no longer necessary since we no longer load the full data set, and we don't want to display them

Solution
Adjust the R notebook used to generate the `ui_config` source file to:
1. Update the order of the CT columns to present them in a consistent order (Biomarkers, Pathology)
2. Update `row_count` values to null for all views across all CTs