### PR TITLE
MG-687: Add age_numeric to disease_correlation

### DIFF
--- a/src/agoradatatools/etl/transform/disease_correlation.py
+++ b/src/agoradatatools/etl/transform/disease_correlation.py
@@ -83,6 +83,20 @@ def extract_module_name(module: str) -> str:
     return match.group(0) if match else module
 
 
+def extract_age_numeric(age: str) -> int:
+    """
+    Extracts the numeric value from an age string.
+
+    Args:
+        age (str): The age string that contains a numeric value (e.g. '8 months', '12 months')
+
+    Returns:
+        int: The numeric age value (e.g. 8, 12). Returns 0 if no numeric value is found.
+    """
+    match = re.search(r"(\d+)", age)
+    return int(match.group(1)) if match else 0
+
+
 def process_group(
     group: pd.DataFrame,
     model_info: Dict[str, Any],
@@ -127,6 +141,7 @@ def process_group(
         "modified_genes": modified_genes,
         "cluster": cluster,
         "age": age,
+        "age_numeric": extract_age_numeric(age),
         "sex": sex,
     }
 
@@ -186,6 +201,7 @@ def transform_disease_correlation(
                 "model_type": str,
                 "cluster": str,
                 "age": str,
+                "age_numeric": int,
                 "sex": str,
                 "<module name>": Dict[str, float] correlation and adj_p_val
             }

--- a/src/agoradatatools/etl/transform/disease_correlation.py
+++ b/src/agoradatatools/etl/transform/disease_correlation.py
@@ -12,6 +12,7 @@ from agoradatatools.etl.utils import (
     flatten_list,
     remove_duplicates_keep_order,
     input_validation_model_info,
+    extract_age_numeric,
 )
 
 
@@ -81,20 +82,6 @@ def extract_module_name(module: str) -> str:
     """
     match = re.match(r"^[A-Z]+", module)
     return match.group(0) if match else module
-
-
-def extract_age_numeric(age: str) -> int:
-    """
-    Extracts the numeric value from an age string.
-
-    Args:
-        age (str): The age string that contains a numeric value (e.g. '8 months', '12 months')
-
-    Returns:
-        int: The numeric age value (e.g. 8, 12). Returns 0 if no numeric value is found.
-    """
-    match = re.search(r"(\d+)", age)
-    return int(match.group(1)) if match else 0
 
 
 def process_group(

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -1,4 +1,5 @@
 from typing import Union, Dict, Any, List
+import re
 
 import numpy as np
 import pandas as pd
@@ -410,3 +411,23 @@ def normalize_zero(value: float) -> float:
     """
     # Using a tolerance of 1e-15 to account for floating point precision issues
     return 0.0 if abs(value) < 1e-15 else value
+
+
+def extract_age_numeric(age: str) -> int:
+    """
+    Extracts the numeric value from an age string.
+
+    Args:
+        age (str): The age string that contains a numeric value (e.g. '8 months', '12 months')
+
+    Returns:
+        int: The numeric age value (e.g. 8, 12). Returns 0 if no numeric value is found.
+
+    Example:
+        extract_age_numeric('8 months')
+        8
+        extract_age_numeric('12 months')
+        12
+    """
+    match = re.search(r"(\d+)", age)
+    return int(match.group(1)) if match else 0

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -413,7 +413,7 @@ def normalize_zero(value: float) -> float:
     return 0.0 if abs(value) < 1e-15 else value
 
 
-def extract_age_numeric(age: str) -> int:
+def extract_age_numeric(age: str) -> Union[int, None]:
     """
     Extracts the numeric value from an age string.
 
@@ -421,7 +421,7 @@ def extract_age_numeric(age: str) -> int:
         age (str): The age string that contains a numeric value (e.g. '8 months', '12 months')
 
     Returns:
-        int: The numeric age value (e.g. 8, 12). Returns 0 if no numeric value is found.
+        Union[int, None]: The numeric age value (e.g. 8, 12). Returns None if no numeric value is found.
 
     Example:
         extract_age_numeric('8 months')
@@ -430,4 +430,4 @@ def extract_age_numeric(age: str) -> int:
         12
     """
     match = re.search(r"(\d+)", age)
-    return int(match.group(1)) if match else 0
+    return int(match.group(1)) if match else None

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -429,5 +429,7 @@ def extract_age_numeric(age: str) -> Union[int, None]:
         extract_age_numeric('12 months')
         12
     """
+    if age is None:
+        return None
     match = re.search(r"(\d+)", age)
     return int(match.group(1)) if match else None

--- a/tests/test_assets/disease_correlation/output/disease_correlation_expected_output.json
+++ b/tests/test_assets/disease_correlation/output/disease_correlation_expected_output.json
@@ -9,6 +9,7 @@
     ],
     "cluster": "Consensus Cluster A (ECM organization)",
     "age": "4 months",
+    "age_numeric": 4,
     "sex": "Female",
     "IFG": {
       "correlation": 0.0829228557717283,
@@ -29,6 +30,7 @@
     ],
     "cluster": "Consensus Cluster A (ECM organization)",
     "age": "12 months",
+    "age_numeric": 12,
     "sex": "Female",
     "IFG": {
       "correlation": 0.0970533422952034,
@@ -49,6 +51,7 @@
     ],
     "cluster": "Consensus Cluster A (ECM organization)",
     "age": "4 months",
+    "age_numeric": 4,
     "sex": "Male",
     "IFG": {
       "correlation": 0.0341639955699389,
@@ -69,6 +72,7 @@
     ],
     "cluster": "Consensus Cluster A (ECM organization)",
     "age": "12 months",
+    "age_numeric": 12,
     "sex": "Male",
     "IFG": {
       "correlation": 0.1802025471199635,
@@ -88,15 +92,16 @@
     ],
     "cluster": "Consensus Cluster A (ECM organization)",
     "age": "4 months",
+    "age_numeric": 4,
     "sex": "Female",
-      "IFG": {
-        "correlation": 0.070482336169501,
-        "adj_p_val": 0.5318004865047494
-      },
-      "PHG": {
-        "correlation": 0.0794770495092502,
-        "adj_p_val": 0.4366165051976555
-      }
+    "IFG": {
+      "correlation": 0.070482336169501,
+      "adj_p_val": 0.5318004865047494
+    },
+    "PHG": {
+      "correlation": 0.0794770495092502,
+      "adj_p_val": 0.4366165051976555
+    }
   },
   {
     "name": "APOE4",
@@ -107,10 +112,11 @@
     ],
     "cluster": "Consensus Cluster A (ECM organization)",
     "age": "8 months",
+    "age_numeric": 8,
     "sex": "Female",
     "IFG": {
       "correlation": 0.0695648292036998,
-        "adj_p_val": 0.5371683491780308
+      "adj_p_val": 0.5371683491780308
     },
     "PHG": {
       "correlation": 0.0136311661990827,
@@ -126,6 +132,7 @@
     ],
     "cluster": "Consensus Cluster A (ECM organization)",
     "age": "12 months",
+    "age_numeric": 12,
     "sex": "Female",
     "IFG": {
       "correlation": 0.0827022307818794,
@@ -146,6 +153,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "4 months",
+    "age_numeric": 4,
     "sex": "Female",
     "CBE": {
       "correlation": 0.470098530032772,
@@ -166,6 +174,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "12 months",
+    "age_numeric": 12,
     "sex": "Female",
     "CBE": {
       "correlation": 0.449727558161722,
@@ -186,6 +195,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "4 months",
+    "age_numeric": 4,
     "sex": "Male",
     "CBE": {
       "correlation": 0.379834234698666,
@@ -206,6 +216,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "12 months",
+    "age_numeric": 12,
     "sex": "Male",
     "CBE": {
       "correlation": 0.48792346411812,
@@ -225,6 +236,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "4 months",
+    "age_numeric": 4,
     "sex": "Female",
     "CBE": {
       "correlation": 0.0958176679386717,
@@ -244,6 +256,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "8 months",
+    "age_numeric": 8,
     "sex": "Female",
     "CBE": {
       "correlation": 0.0390288304703237,
@@ -263,6 +276,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "12 months",
+    "age_numeric": 12,
     "sex": "Female",
     "CBE": {
       "correlation": 0.0996113320636796,
@@ -282,6 +296,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "4 months",
+    "age_numeric": 4,
     "sex": "Male",
     "CBE": {
       "correlation": 0.0994513071661718,
@@ -301,6 +316,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "8 months",
+    "age_numeric": 8,
     "sex": "Male",
     "CBE": {
       "correlation": 0.0068586454130309,
@@ -320,6 +336,7 @@
     ],
     "cluster": "Consensus Cluster B (Immune System)",
     "age": "12 months",
+    "age_numeric": 12,
     "sex": "Male",
     "CBE": {
       "correlation": 0.130312470603861,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -905,6 +905,8 @@ class TestExtractAgeNumeric:
             ("100 days", 100),  # Age with days
             ("", None),  # Empty string
             ("no number here", None),  # String without number
+            ("4 8 12 months", 4),  # Multiple numbers - should return first
+            (None, None),  # None input
         ],
     )
     def test_extract_age_numeric(self, input_age, expected):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -905,7 +905,8 @@ class TestExtractAgeNumeric:
             ("100 days", 100),  # Age with days
             ("", None),  # Empty string
             ("no number here", None),  # String without number
-            ("4 8 12 months", 4),  # Multiple numbers - should return first
+            ("number 10", 10),  # String with number
+            ("10 11 12", 10),  # String with multiple numbers
             (None, None),  # None input
         ],
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -887,3 +887,33 @@ class TestNormalizeZero:
         # Verify result is non-negative (positive zero, not negative zero)
         assert result >= 0
         assert math.copysign(1.0, result) > 0
+
+
+class TestExtractAgeNumeric:
+    """
+    Test class for validating the extract_age_numeric utility function.
+    This function extracts the numeric value from an age string.
+    """
+
+    @pytest.mark.parametrize(
+        "input_age,expected",
+        [
+            ("4 months", 4),  # Age with months
+            ("8 months", 8),  # Age with months
+            ("12 months", 12),  # Age with months
+            ("6 weeks", 6),  # Age with weeks
+            ("100 days", 100),  # Age with days
+            ("", 0),  # Empty string
+            ("no number here", 0),  # String without number
+        ],
+    )
+    def test_extract_age_numeric(self, input_age, expected):
+        """
+        Test that extract_age_numeric correctly extracts the numeric value
+        from age strings with various formats.
+
+        Args:
+            input_age: Input string that may contain age and unit
+            expected: Expected numeric age value
+        """
+        assert utils.extract_age_numeric(input_age) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -903,8 +903,8 @@ class TestExtractAgeNumeric:
             ("12 months", 12),  # Age with months
             ("6 weeks", 6),  # Age with weeks
             ("100 days", 100),  # Age with days
-            ("", 0),  # Empty string
-            ("no number here", 0),  # String without number
+            ("", None),  # Empty string
+            ("no number here", None),  # String without number
         ],
     )
     def test_extract_age_numeric(self, input_age, expected):
@@ -914,6 +914,6 @@ class TestExtractAgeNumeric:
 
         Args:
             input_age: Input string that may contain age and unit
-            expected: Expected numeric age value
+            expected: Expected numeric age value or None if no number found
         """
         assert utils.extract_age_numeric(input_age) == expected

--- a/tests/transform/test_disease_correlation.py
+++ b/tests/transform/test_disease_correlation.py
@@ -6,6 +6,7 @@ from agoradatatools.etl.transform.disease_correlation import (
     transform_disease_correlation,
     create_lookup,
     extract_module_name,
+    extract_age_numeric,
     process_group,
 )
 
@@ -145,6 +146,7 @@ class TestTransformDiseaseCorrelation:
                     "modified_genes": ["APOE4", "TREM2"],
                     "cluster": "Cluster A",
                     "age": "4 months",
+                    "age_numeric": 4,
                     "sex": "Female",
                     "IFG": {"correlation": 0.5, "adj_p_val": 0.01},
                     "PHG": {"correlation": 0.6, "adj_p_val": 0.02},
@@ -156,6 +158,7 @@ class TestTransformDiseaseCorrelation:
                     "modified_genes": ["APP"],  # Single gene is returned as a list
                     "cluster": "Cluster B",
                     "age": "6 months",
+                    "age_numeric": 6,
                     "sex": "Male",
                     "TCX": {"correlation": 0.7, "adj_p_val": 0.03},
                 },
@@ -206,6 +209,7 @@ class TestTransformDiseaseCorrelation:
                     "modified_genes": ["APOE4"],  # Deduplicated from duplicate entries
                     "cluster": "Cluster A",
                     "age": "4 months",
+                    "age_numeric": 4,
                     "sex": "Female",
                     "IFG": {"correlation": 0.5, "adj_p_val": 0.01},
                 }
@@ -552,6 +556,7 @@ class TestProcessGroup:
             "modified_genes": ["APOE4", "TREM2"],
             "cluster": "Cluster A",
             "age": "4 months",
+            "age_numeric": 4,
             "sex": "Female",
             "IFG": {"correlation": 0.5, "adj_p_val": 0.01},
             "PHG": {"correlation": 0.6, "adj_p_val": 0.02},
@@ -585,6 +590,7 @@ class TestProcessGroup:
             "modified_genes": [],
             "cluster": "Cluster A",
             "age": "4 months",
+            "age_numeric": 4,
             "sex": "Female",
             "IFG": {"correlation": 0.5, "adj_p_val": 0.01},
         }
@@ -617,3 +623,33 @@ class TestProcessGroup:
 
         # Should take first element from the list
         assert result["matched_control"] == "C57BL6J"
+
+
+class TestExtractAgeNumeric:
+    """
+    Test class for validating the extract_age_numeric utility function.
+    This function extracts the numeric value from an age string.
+    """
+
+    @pytest.mark.parametrize(
+        "input_age,expected",
+        [
+            ("4 months", 4),  # Age with months
+            ("8 months", 8),  # Age with months
+            ("12 months", 12),  # Age with months
+            ("6 weeks", 6),  # Age with weeks
+            ("100 days", 100),  # Age with days
+            ("", 0),  # Empty string
+            ("no number here", 0),  # String without number
+        ],
+    )
+    def test_extract_age_numeric(self, input_age, expected):
+        """
+        Test that extract_age_numeric correctly extracts the numeric value
+        from age strings with various formats.
+
+        Args:
+            input_age: Input string that may contain age and unit
+            expected: Expected numeric age value
+        """
+        assert extract_age_numeric(input_age) == expected

--- a/tests/transform/test_disease_correlation.py
+++ b/tests/transform/test_disease_correlation.py
@@ -6,7 +6,6 @@ from agoradatatools.etl.transform.disease_correlation import (
     transform_disease_correlation,
     create_lookup,
     extract_module_name,
-    extract_age_numeric,
     process_group,
 )
 
@@ -623,33 +622,3 @@ class TestProcessGroup:
 
         # Should take first element from the list
         assert result["matched_control"] == "C57BL6J"
-
-
-class TestExtractAgeNumeric:
-    """
-    Test class for validating the extract_age_numeric utility function.
-    This function extracts the numeric value from an age string.
-    """
-
-    @pytest.mark.parametrize(
-        "input_age,expected",
-        [
-            ("4 months", 4),  # Age with months
-            ("8 months", 8),  # Age with months
-            ("12 months", 12),  # Age with months
-            ("6 weeks", 6),  # Age with weeks
-            ("100 days", 100),  # Age with days
-            ("", 0),  # Empty string
-            ("no number here", 0),  # String without number
-        ],
-    )
-    def test_extract_age_numeric(self, input_age, expected):
-        """
-        Test that extract_age_numeric correctly extracts the numeric value
-        from age strings with various formats.
-
-        Args:
-            input_age: Input string that may contain age and unit
-            expected: Expected numeric age value
-        """
-        assert extract_age_numeric(input_age) == expected


### PR DESCRIPTION
# Add `age_numeric` Field to Disease Correlation Transform

## Problem

The disease correlation dataset contains an `age` field stored as a string (e.g., "4 months", "8 months", "12 months"). This format makes it difficult to:
- Perform numeric operations or sorting on age values
- Filter or query data by age ranges efficiently
- Use age as a numeric parameter in downstream analyses

Additionally, other transforms in the codebase may need similar functionality to extract numeric values from formatted age strings.

## Solution

### 1. Added `age_numeric` Field
- Added a new `age_numeric` field to the disease correlation transform output
- The field contains the integer value extracted from the `age` string (e.g., "8 months" → 8)
- Positioned directly after the `age` field in the output structure for logical grouping

### 2. Created Reusable Utility Function
- Implemented `extract_age_numeric()` function in `src/agoradatatools/etl/utils.py`
- Uses regex to extract the first numeric value from an age string
- Returns 0 if no numeric value is found
- Well-documented with examples for easy reuse across other transforms

### 3. Updated Transform Logic
- Modified `process_group()` in `disease_correlation.py` to include the new field
- Updated function documentation to reflect the new output structure
- Imported `extract_age_numeric()` from utils instead of defining locally

## Testing

### Unit Tests
- **7 new test cases** for `extract_age_numeric()` covering:
  - Standard age formats: "4 months", "8 months", "12 months"
  - Alternative time units: "6 weeks", "100 days"
  - Edge cases: empty strings, strings without numbers
- **Updated all existing tests** in disease_correlation to include `age_numeric` field
- **Test asset integration tests** updated with new field expectations

## Example Output
```
{
  "name": "5xFAD",
  "cluster": "Consensus Cluster A (ECM organization)",
  "age": "4 months",
  "age_numeric": 4,
  "sex": "Female",
  "IFG": {
    "correlation": 0.0829228557717283,
    "adj_p_val": 0.4617459764146099
  }
}
```