### PR TITLE
MG-710: Align model.name and modified_genes filter options with per-CT data values

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -67,38 +67,6 @@ biodomain_filter_vals <- c('Apoptosis',
                            'Vasculature')
 model_type_filter_vals <- c('Familial AD',
                             'Late Onset AD')
-model_name_filter_vals <- c('3xTg-AD',
-                            '5xFAD (IU/Jax/Pitt)',
-                            '5xFAD (UCI)',
-                            'Abca7*V1599M',
-                            'APOE4',
-                            'LOAD1',
-                            'LOAD1.Abca7A1527G',
-                            'LOAD1.Ceacam1KO',
-                            'LOAD1.Clasp2L163P',
-                            'LOAD1.CR1long',
-                            'LOAD1.Il1rapExon2KO',
-                            'LOAD1.MthfrC677T',
-                            'LOAD1.Plcg2M28L',
-                            'LOAD1.Snx1D465N',
-                            'Trem2-R47H_NSS',
-                            'Trem2R47H')
-modified_gene_filter_vals <- c('Abca7',
-                               'APOE',
-                               'App',
-                               'APP',
-                               'Ceacam1',
-                               'Clasp2',
-                               'CR1',
-                               'CR2',
-                               'Il1rap',
-                               'MAPT',
-                               'Mthfr',
-                               'Plcg2',
-                               'Psen1',
-                               'PSEN1',
-                               'Snx1',
-                               'Trem2')
 sex_filter_vals <- c('Female', 'Male')
 
 
@@ -231,10 +199,20 @@ ge_filters <- data.frame(
 
 # Gene Expression Filter values
 # -----------------------------
+# Only include model.name filter values for models with Gene Expression results
+ge_model_name_filter_vals <- c('3xTg-AD',
+                            '5xFAD (IU/Jax/Pitt)',
+                            '5xFAD (UCI)',
+                            'Abca7*V1599M',
+                            'APOE4',
+                            'LOAD1',
+                            'Trem2-R47H_NSS',
+                            'Trem2R47H')
+
 ge_filter_values <- list(
   biodomain_filter_vals,
   model_type_filter_vals,
-  model_name_filter_vals
+  ge_model_name_filter_vals
 )
 
 # Generates Gene Expression ui_config objects
@@ -353,11 +331,36 @@ dc_filters <- data.frame(
 
 # Disease Correlation Filter values
 # ---------------------------------
+# Only include model.name filter values for models with Disease Correlation results
+dc_model_name_filter_vals <- c('5xFAD (IU/Jax/Pitt)',
+                            'APOE4',
+                            'LOAD1',
+                            'LOAD1.Abca7A1527G',
+                            'LOAD1.Ceacam1KO',
+                            'LOAD1.Clasp2L163P',
+                            'LOAD1.CR1long',
+                            'LOAD1.Il1rapExon2KO',
+                            'LOAD1.MthfrC677T',
+                            'LOAD1.Snx1D465N',
+                            'Trem2R47H')
+# Only include modified_gene filter values for genes modified in models with Disease Correlation results
+dc_modified_gene_filter_vals <- c('Abca7',
+                               'APOE',
+                               'APP',
+                               'Ceacam1',
+                               'Clasp2',
+                               'CR1',
+                               'CR2',
+                               'Il1rap',
+                               'Mthfr',
+                               "PSEN1",
+                               'Snx1',
+                               'Trem2')
 dc_filter_values <- list(
   c('4 months', '8 months', '12 months'),
   model_type_filter_vals,
-  modified_gene_filter_vals,
-  model_name_filter_vals,
+  dc_modified_gene_filter_vals,
+  dc_model_name_filter_vals,
   sex_filter_vals
 )
 
@@ -442,11 +445,28 @@ mo_filters <- data.frame(
 
 # Model Overview Filter Values
 # ----------------------------
+# Include modified_gene filter values for genes modified in any included model
+mo_modified_gene_filter_vals <- c('Abca7',
+                               'APOE',
+                               'APP',
+                               'Ceacam1',
+                               'Clasp2',
+                               'CR1',
+                               'CR2',
+                               'Il1rap',
+                               'MAPT',
+                               'Mthfr',
+                               'Plcg2',
+                               'Psen1',
+                               'PSEN1',
+                               'Snx1',
+                               'Trem2')
+
 mo_filter_values <- list(
   c('Biomarkers', 'Disease Correlation', 'Gene Expression', 'Pathology'),
   c('IU/Jax/Pitt', 'UCI'),
   model_type_filter_vals,
-  modified_gene_filter_vals
+  mo_modified_gene_filter_vals
 )
 
 # Generates Model Overview ui_config objects


### PR DESCRIPTION
## Problem
Currently users can apply CT filter options that don't match any data rows, resulting in a filtered table with no results. This is not a particularly useful state.

This happens because the`model.name` and `modified_genes` filter value lists defined in `ui_config` were defined once, then shared across all relevant CTs without accounting for whether or not the actual values being present in the data.

## Solution

Since each CT can include results for a different subset of models (and hence genetic_modifications), we need to control the set of supported filter values for these filtersets per CT.

This PR updates `ui_config` to separately specify supported filter values per CT.

A new version of `ui_config` has been uploaded to synapse: syn66527739 v27