### PR TITLE
MG-712: Add explicit filter query parameter names to filter definitions

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -14,6 +14,14 @@ This notebook must be updated when the Explorer is updated to:
 * Add or modify a CT dropdown menu or dropdown value
 * Add or modify a filterset or filter value
 
+
+Notes:
+* `query_param_key`: Values must be plural, camelCase, and should intelligibly align with the related display values presented to users on the page:
+   - filter.name (filter panels)
+   - filter.short_name (filter chiclets)
+   - column.name (column header)
+
+
 ## Library setup
 Install required packages:
 - synapser (also requires a Synapse account with an auth token)
@@ -67,38 +75,6 @@ biodomain_filter_vals <- c('Apoptosis',
                            'Vasculature')
 model_type_filter_vals <- c('Familial AD',
                             'Late Onset AD')
-model_name_filter_vals <- c('3xTg-AD',
-                            '5xFAD (IU/Jax/Pitt)',
-                            '5xFAD (UCI)',
-                            'Abca7*V1599M',
-                            'APOE4',
-                            'LOAD1',
-                            'LOAD1.Abca7A1527G',
-                            'LOAD1.Ceacam1KO',
-                            'LOAD1.Clasp2L163P',
-                            'LOAD1.CR1long',
-                            'LOAD1.Il1rapExon2KO',
-                            'LOAD1.MthfrC677T',
-                            'LOAD1.Plcg2M28L',
-                            'LOAD1.Snx1D465N',
-                            'Trem2-R47H_NSS',
-                            'Trem2R47H')
-modified_gene_filter_vals <- c('Abca7',
-                               'APOE',
-                               'App',
-                               'APP',
-                               'Ceacam1',
-                               'Clasp2',
-                               'CR1',
-                               'CR2',
-                               'Il1rap',
-                               'MAPT',
-                               'Mthfr',
-                               'Plcg2',
-                               'Psen1',
-                               'PSEN1',
-                               'Snx1',
-                               'Trem2')
 sex_filter_vals <- c('Female', 'Male')
 
 
@@ -156,25 +132,26 @@ build_column <- function(name, type, data_key, tooltip, sort_tooltip, link_url, 
 }
 
 # Builds a list of filter definitions
-# - filter_defs: A dataframe of filterset info
-#   -- name, data_field, short_name, filter_values
+# - filter_defs: A dataframe of filterset info:
+#   - name, data_field, short_name, query_param_key, filter_values
 # - filter_vals: A list of lists specifying the filter values for each filterset
 build_filters <- function(filter_defs, filter_values) {
 
   # Construct list of filters
-  filters <- Map(function(name, data_key, short_name, filter_values) {
+  filters <- Map(function(name, data_key, short_name, query_param_key, filter_values) {
 
     filter <- list(
       name = name,
       data_key = data_key,
       short_name = short_name,
+      query_param_key = query_param_key,
       values = filter_values
       )
 
       # Omit keys with NA values
       filter <- discard(filter, ~ is.null(.x) | all(is.na(.x)))
 
-    }, filter_defs$name, filter_defs$data_key, filter_defs$short_name, filter_values)
+    }, filter_defs$name, filter_defs$data_key, filter_defs$short_name, filter_defs$query_param_key, filter_values)
 
   # Remove names to ensure JSON is an array, not object
   names(filters) <- NULL
@@ -226,15 +203,26 @@ ge_filters <- data.frame(
   name = c('Biological Domain', 'Model Type', 'Mouse Model'),
   data_key = c('biodomains', 'model_type', 'name'),
   short_name = c('Biodomain', 'Type', 'Model'),
+  query_param_key = c('biodomains', 'modelTypes', 'models'),
   stringsAsFactors = FALSE
 )
 
 # Gene Expression Filter values
 # -----------------------------
+# Only include model.name filter values for models with Gene Expression results
+ge_model_name_filter_vals <- c('3xTg-AD',
+                            '5xFAD (IU/Jax/Pitt)',
+                            '5xFAD (UCI)',
+                            'Abca7*V1599M',
+                            'APOE4',
+                            'LOAD1',
+                            'Trem2-R47H_NSS',
+                            'Trem2R47H')
+
 ge_filter_values <- list(
   biodomain_filter_vals,
   model_type_filter_vals,
-  model_name_filter_vals
+  ge_model_name_filter_vals
 )
 
 # Generates Gene Expression ui_config objects
@@ -348,16 +336,42 @@ dc_filters <- data.frame(
   name = c('Age', 'Model Type', 'Modified Gene', 'Mouse Model', 'Sex'),
   data_key = c('age', 'model_type', 'modified_genes', 'name', 'sex'),
   short_name = c(NA, 'Type', 'Gene', 'Model', NA),
+  query_param_key = c('ages', 'modelTypes', 'modifiedGenes', 'models', 'sexes'),
   stringsAsFactors = FALSE
 )
 
 # Disease Correlation Filter values
 # ---------------------------------
+# Only include model.name filter values for models with Disease Correlation results
+dc_model_name_filter_vals <- c('5xFAD (IU/Jax/Pitt)',
+                            'APOE4',
+                            'LOAD1',
+                            'LOAD1.Abca7A1527G',
+                            'LOAD1.Ceacam1KO',
+                            'LOAD1.Clasp2L163P',
+                            'LOAD1.CR1long',
+                            'LOAD1.Il1rapExon2KO',
+                            'LOAD1.MthfrC677T',
+                            'LOAD1.Snx1D465N',
+                            'Trem2R47H')
+# Only include modified_gene filter values for genes modified in models with Disease Correlation results
+dc_modified_gene_filter_vals <- c('Abca7',
+                               'APOE',
+                               'APP',
+                               'Ceacam1',
+                               'Clasp2',
+                               'CR1',
+                               'CR2',
+                               'Il1rap',
+                               'Mthfr',
+                               "PSEN1",
+                               'Snx1',
+                               'Trem2')
 dc_filter_values <- list(
   c('4 months', '8 months', '12 months'),
   model_type_filter_vals,
-  modified_gene_filter_vals,
-  model_name_filter_vals,
+  dc_modified_gene_filter_vals,
+  dc_model_name_filter_vals,
   sex_filter_vals
 )
 
@@ -437,16 +451,34 @@ mo_filters <- data.frame(
   name = c('Available Data', 'Contributing Center', 'Model Type', 'Modified Gene'),
   data_key = c('available_data', 'center', 'model_type', 'modified_genes'),
   short_name = c('Data', 'Center', 'Type', 'Gene'),
+  query_param_key = c('availableData', 'centers', 'modelTypes', 'modifiedGenes'),
   stringsAsFactors = FALSE
 )
 
 # Model Overview Filter Values
 # ----------------------------
+# Include modified_gene filter values for genes modified in all included models
+mo_modified_gene_filter_vals <- c('Abca7',
+                               'APOE',
+                               'APP',
+                               'Ceacam1',
+                               'Clasp2',
+                               'CR1',
+                               'CR2',
+                               'Il1rap',
+                               'MAPT',
+                               'Mthfr',
+                               'Plcg2',
+                               'Psen1',
+                               'PSEN1',
+                               'Snx1',
+                               'Trem2')
+
 mo_filter_values <- list(
   c('Biomarkers', 'Disease Correlation', 'Gene Expression', 'Pathology'),
   c('IU/Jax/Pitt', 'UCI'),
   model_type_filter_vals,
-  modified_gene_filter_vals
+  mo_modified_gene_filter_vals
 )
 
 # Generates Model Overview ui_config objects


### PR DESCRIPTION
## Problem
We want to populate the application URL with query parameters that represent the currently applied CT filters so that we can reconstruct the current CT configuration from a bookmark or Share URL. We also want the filter query parameter values to:

1. Align with the conventions that we’ve already established with our sort parameters: 
- keys are camelCase (e.g. sortFields, sortOrders)
- since each key can specify multiple values, key values should be plural  (e.g.  sortFields=disease_correlation,pathology)
2. Intelligibly align with the related display values presented to users on the page (filter panels, filter chiclets, column names)
3. Must be explicitly defined for every filterset
4. Must be unique per CT across all supported filtersets

## Solution
Add a new `query_param_key` field to `ui_config.filters`, and populate it with conforming values for every filterset.

Note that items 3 and 4 will be validated  when we implement GX for ui_config via MG-210.