### PR TITLE
MG-718: Update model parameter to models

### DIFF
--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -235,13 +235,13 @@ def transform_model_details(
             ].to_dict("records")[0]
 
             model_entry["gene_expression"] = (
-                f"comparison/expression?model={model_name}"
+                f"comparison/expression?models={model_name}"
                 if pd.notna(model_results_info_row_dict["gene_expression"])
                 and bool(model_results_info_row_dict["gene_expression"])
                 else None
             )
             model_entry["disease_correlation"] = (
-                f"comparison/correlation?model={model_name}"
+                f"comparison/correlation?models={model_name}"
                 if pd.notna(model_results_info_row_dict["disease_correlation"])
                 and bool(model_results_info_row_dict["disease_correlation"])
                 else None

--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -155,12 +155,12 @@ def transform_model_overview(
 
         # Build the links first
         row["gene_expression"] = (
-            {"link_url": f"comparison/expression?model={row['name']}"}
+            {"link_url": f"comparison/expression?models={row['name']}"}
             if bool(row["gene_expression"])
             else None
         )
         row["disease_correlation"] = (
-            {"link_url": f"comparison/correlation?model={row['name']}"}
+            {"link_url": f"comparison/correlation?models={row['name']}"}
             if bool(row["disease_correlation"])
             else None
         )

--- a/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?model=3xTg-AD",
+    "gene_expression": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_extra_columns_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_extra_columns_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?model=3xTg-AD",
+    "gene_expression": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?model=3xTg-AD",
+    "gene_expression": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_missing_allele_data_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_allele_data_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?model=3xTg-AD",
+    "gene_expression": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_missing_allele_info_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_allele_info_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?model=3xTg-AD",
+    "gene_expression": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_missing_data_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_data_output.json
@@ -12,8 +12,8 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?model=3xTg-AD",
-    "disease_correlation": "comparison/correlation?model=3xTg-AD",
+    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "disease_correlation": "comparison/correlation?models=3xTg-AD",
     "spatial_transcriptomics": null,
     "genetic_info": [
       {

--- a/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?model=3xTg-AD",
+    "gene_expression": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?model=3xTg-AD",
+    "gene_expression": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_no_matching_alleles_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_no_matching_alleles_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?model=3xTg-AD",
+    "gene_expression": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
@@ -4,7 +4,7 @@
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=3xTg-AD"
+      "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
     "pathology": {
@@ -39,7 +39,7 @@
     "model_type": "Familial AD",
     "matched_controls": ["C57BL6J"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=5xFAD (UCI)"
+      "link_url": "comparison/expression?models=5xFAD (UCI)"
     },
     "disease_correlation": null,
     "pathology": {
@@ -70,10 +70,10 @@
     "model_type": "Late Onset AD",
     "matched_controls": ["C57BL6J"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=APOE4"
+      "link_url": "comparison/expression?models=APOE4"
     },
     "disease_correlation": {
-      "link_url": "comparison/correlation?model=APOE4"
+      "link_url": "comparison/correlation?models=APOE4"
     },
     "pathology": null,
     "biomarkers": null,

--- a/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
@@ -4,7 +4,7 @@
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=3xTg-AD"
+      "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
     "pathology": {
@@ -39,7 +39,7 @@
     "model_type": "Familial AD",
     "matched_controls": ["C57BL6J"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=5xFAD (UCI)"
+      "link_url": "comparison/expression?models=5xFAD (UCI)"
     },
     "disease_correlation": null,
     "pathology": {
@@ -70,10 +70,10 @@
     "model_type": "Late Onset AD",
     "matched_controls": ["C57BL6J"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=APOE4"
+      "link_url": "comparison/expression?models=APOE4"
     },
     "disease_correlation": {
-      "link_url": "comparison/correlation?model=APOE4"
+      "link_url": "comparison/correlation?models=APOE4"
     },
     "pathology": null,
     "biomarkers": null,

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
@@ -4,7 +4,7 @@
     "model_type": "Familial AD",
     "matched_controls": [],
     "gene_expression": {
-      "link_url": "comparison/expression?model=3xTg-AD"
+      "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
     "pathology": {
@@ -37,7 +37,7 @@
     "model_type": null,
     "matched_controls": ["C57BL6J"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=5xFAD (UCI)"
+      "link_url": "comparison/expression?models=5xFAD (UCI)"
     },
     "disease_correlation": null,
     "pathology": {
@@ -65,10 +65,10 @@
     "model_type": "Late Onset AD",
     "matched_controls": ["C57BL6J"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=APOE4"
+      "link_url": "comparison/expression?models=APOE4"
     },
     "disease_correlation": {
-      "link_url": "comparison/correlation?model=APOE4"
+      "link_url": "comparison/correlation?models=APOE4"
     },
     "pathology": null,
     "biomarkers": null,

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
@@ -4,7 +4,7 @@
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=3xTg-AD"
+      "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
     "pathology": {

--- a/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
@@ -4,7 +4,7 @@
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=3xTg-AD"
+      "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
     "pathology": {
@@ -39,7 +39,7 @@
     "model_type": "Familial AD",
     "matched_controls": ["C57BL6J"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=5xFAD (UCI)"
+      "link_url": "comparison/expression?models=5xFAD (UCI)"
     },
     "disease_correlation": null,
     "pathology": {
@@ -70,10 +70,10 @@
     "model_type": "Late Onset AD",
     "matched_controls": ["C57BL6J"],
     "gene_expression": {
-      "link_url": "comparison/expression?model=APOE4"
+      "link_url": "comparison/expression?models=APOE4"
     },
     "disease_correlation": {
-      "link_url": "comparison/correlation?model=APOE4"
+      "link_url": "comparison/correlation?models=APOE4"
     },
     "pathology": null,
     "biomarkers": null,

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -280,7 +280,7 @@ class TestTransformModelOverview:
                 "model_type": "Familial AD",
                 "matched_controls": ["C57BL6J"],
                 "gene_expression": {
-                    "link_url": "comparison/expression?model=test_model"
+                    "link_url": "comparison/expression?models=test_model"
                 },
                 "disease_correlation": None,
                 "pathology": {"link_url": "models/test_model/pathology"},
@@ -451,7 +451,7 @@ class TestTransformModelOverview:
                 "name": "model1",
                 "model_type": "Familial AD",
                 "matched_controls": ["C57BL6J"],
-                "gene_expression": {"link_url": "comparison/expression?model=model1"},
+                "gene_expression": {"link_url": "comparison/expression?models=model1"},
                 "disease_correlation": None,
                 "pathology": {"link_url": "models/model1/pathology"},
                 "biomarkers": None,
@@ -472,7 +472,7 @@ class TestTransformModelOverview:
                 "matched_controls": ["B6129", "B6130"],
                 "gene_expression": None,
                 "disease_correlation": {
-                    "link_url": "comparison/correlation?model=model2"
+                    "link_url": "comparison/correlation?models=model2"
                 },
                 "pathology": {"link_url": "models/model2/pathology"},
                 "biomarkers": {"link_url": "models/model2/biomarkers"},


### PR DESCRIPTION
## Problem

The model_overview and model_details custom transforms both generate internal application link fragments that are used target filtered views of the Gene Expression and Disease Correlation CTs, where the desired filtering is specified by appending a `model=<name>` parameter on the CT URL fragment.

The application now expects this filter parameter to be plural: `models=<name>`

## Solution

* Update the impacted custom transforms to use the new plural parameter key for both CT links.
* Update related test assets to align with the update