### PR TITLE
AG-1974: Pull Drug data from OpenTargets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,7 @@ repos:
       - id: interrogate
         exclude: ^(setup.py|tests|data_analysis|gx_suite_definitions)
         args: [--config=pyproject.toml]
+        additional_dependencies: ['setuptools']
 
   - repo: https://github.com/jendrikseipp/vulture
     rev: "v2.7"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: nbstripout
 
   - repo: https://github.com/econchick/interrogate
-    rev: 1.8.0
+    rev: 1.7.0
     hooks:
       - id: interrogate
         exclude: ^(setup.py|tests|data_analysis|gx_suite_definitions)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,6 @@ repos:
       - id: interrogate
         exclude: ^(setup.py|tests|data_analysis|gx_suite_definitions)
         args: [--config=pyproject.toml]
-        additional_dependencies: ['setuptools']
 
   - repo: https://github.com/jendrikseipp/vulture
     rev: "v2.7"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,7 @@ repos:
       - id: nbstripout
 
   - repo: https://github.com/econchick/interrogate
-    rev: 1.5.0
+    rev: 1.8.0
     hooks:
       - id: interrogate
         exclude: ^(setup.py|tests|data_analysis|gx_suite_definitions)

--- a/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
@@ -107,8 +107,8 @@ download_csv <- function(synId, df_name) {
 # ***************
 
 # Get the list of chembl_ids from harmonized_drugs.csv
-drug_targets <- download_csv("syn73677240.5")
-chembl_ids <- drug_targets$ChEMBL_ID
+drug_targets <- download_csv("syn73677240.6")
+chembl_ids <- drug_targets$chembl_id
 ```
 
 # Download and adapt OpenTargets Drug data for nominated drugs
@@ -158,7 +158,7 @@ drug_info
 # clean up nested row structures
 drug_info <- drug_info %>%
   mutate(
-  mechanismsOfAction = map(mechanismsOfAction.rows, ~ unlist(.x$mechanismOfAction)),
+mechanismsOfAction = map(mechanismsOfAction.rows, ~ unlist(.x$mechanismOfAction)),
     linkedTargets = map(linkedTargets.rows, ~ unlist(.x$id))
   ) %>%
   # have to use - instead of ! to negate columns with . characters
@@ -205,7 +205,7 @@ drug_info <- drug_info %>%
   # If maximumClinicalTrialPhase == -1, convert to NA to avoid magic numbers
   mutate(maximumClinicalTrialPhase = na_if(maximumClinicalTrialPhase, -1)) %>%
 
-  # rename camelCase columns
+  # rename columns
   dplyr::rename(chembl_id = id) %>%
   dplyr::rename(drug_type = drugType) %>%
   dplyr::rename(maximum_clinical_trial_phase = maximumClinicalTrialPhase) %>%
@@ -219,12 +219,11 @@ drug_info
 # Generate source file and upload to Synapse
 ```{r}
 json_output <- toJSON(drug_info, pretty = TRUE, auto_unbox = FALSE)
-# cat(json_output)
 
 # write json file
 write(json_output, file.path(output_dir, "opentargets_drug_data.json"))
 
-# BREAK HERE FOR LOCAL VALIDATION - generated file is in ADT notebooks/output
+# BREAK HERE FOR LOCAL VALIDATION
 
 # upload to synapse
 synLogin()

--- a/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
@@ -99,8 +99,7 @@ download_csv <- function(synId, df_name) {
   cat("\n", synId, "\n- Modified on ", file$properties$modifiedOn, "\n- Version ", file$properties$versionNumber)
   cat("\npath: ", file$path, "\n")
 
-  data <- read.csv(path)
-  df_name <- as.data.frame(data)
+  as.data.frame(read.csv(path))
 }
 
 # ***************
@@ -108,7 +107,7 @@ download_csv <- function(synId, df_name) {
 # ***************
 
 # Get the list of chembl_ids from harmonized_drugs.csv
-drug_targets <- download_csv("syn73677240.5", drug_targets)
+drug_targets <- download_csv("syn73677240.5")
 chembl_ids <- drug_targets$ChEMBL_ID
 ```
 
@@ -159,7 +158,7 @@ drug_info
 # clean up nested row structures
 drug_info <- drug_info %>%
   mutate(
-mechanismsOfAction = map(mechanismsOfAction.rows, ~ unlist(.x$mechanismOfAction)),
+  mechanismsOfAction = map(mechanismsOfAction.rows, ~ unlist(.x$mechanismOfAction)),
     linkedTargets = map(linkedTargets.rows, ~ unlist(.x$id))
   ) %>%
   # have to use - instead of ! to negate columns with . characters
@@ -193,25 +192,33 @@ drug_info <- drug_info %>%
   mutate(drug_bank_id = coalesce(drug_bank_id, drug_bank_id_fix)) %>%
   select(-drug_bank_id_fix)
 
- # Collapse synonyms and tradeNames into a single set (case-insensitive)
+# Clean up values and align colnames
 drug_info <- drug_info %>%
+
+  # Collapse synonyms and tradeNames into a single set (case-insensitive)
   mutate(aliases = pmap(
     .l = list(name, synonyms, tradeNames),
     .f = resolve_drug_names
   )) %>%
-  select(-tradeNames, -synonyms, -name)
+  select(-tradeNames, -synonyms, -name) %>%
 
+  # If maximumClinicalTrialPhase == -1, convert to NA to avoid magic numbers
+  mutate(maximumClinicalTrialPhase = na_if(maximumClinicalTrialPhase, -1)) %>%
 
-# If maximumClinicalTrialPhase == -1, convert to NA to avoid magic numbers
-drug_info <- drug_info %>%
-  mutate(maximumClinicalTrialPhase = na_if(maximumClinicalTrialPhase, -1))
+  # rename camelCase columns
+  dplyr::rename(chembl_id = id) %>%
+  dplyr::rename(drug_type = drugType) %>%
+  dplyr::rename(maximum_clinical_trial_phase = maximumClinicalTrialPhase) %>%
+  dplyr::rename(year_of_first_approval = yearOfFirstApproval) %>%
+  dplyr::rename(mechanisms_of_action = mechanismsOfAction) %>%
+  dplyr::rename(linked_targets = linkedTargets)
 
 drug_info
 ```
 
 # Generate source file and upload to Synapse
 ```{r}
-json_output <- toJSON(drug_info, pretty = TRUE, auto_unbox = TRUE)
+json_output <- toJSON(drug_info, pretty = TRUE, auto_unbox = FALSE)
 # cat(json_output)
 
 # write json file

--- a/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
@@ -27,25 +27,33 @@ library(ghql)
 ```
 
 
-## Variables and functions
+## Set up clients, variables and functions
 Setup the required graphQL client and nominated drugs source file
 ```{r}
 # ***************************
 # OPEN TARGETS GRAPHQL CLIENT
 # ***************************
+
 url <- "https://api.platform.opentargets.org/api/v4/graphql"
 con <- GraphqlClient$new(url = url)
 
-# ************
-# DRUG TARGETS
-# ************
-source <- download_file("syn73677240", type = "csv")
-assign("drug_targets", source, envir = .GlobalEnv)
-chembl_ids <- drug_targets$ChEMBL_ID
+# **************************
+# PROVENANCE & LOCAL STORAGE
+# **************************
 
-# ********
-# FUNCTION
-# ********
+# Vector to store all downloaded synIds for Synapse provenance (populated via download_csv function)
+data_sources <- character()
+
+# Local file storage
+output_dir <- file.path("./", "output")
+if(!dir.exists(output_dir)){
+  dir.create(output_dir)
+}
+
+# *********
+# FUNCTIONS
+# *********
+
 # Combines the provided lists of values to produce a set of unique values.
 # - name: The canonical name of the drug, to removed from the list of alias values
 # - ...: A variable number of lists of values to combine
@@ -63,15 +71,54 @@ resolve_drug_names <- function(name, ...) {
   return(if(length(final_list) > 0) final_list else list())
 }
 
+# Download a csv file from Synapse by synId and read it into a dataframe
+# - synId: synapse ID of the file to download
+# - df_name: the name to use for the resulting dataframe
+download_csv <- function(synId, df_name) {
 
+  synLogin()
+
+  # Capture all downloaded synIds for provenance
+  data_sources <<- c(data_sources, synId)
+
+  input_dir <- file.path("./", "input")
+  id_parts <- strsplit(synId, '.', fixed = TRUE)
+  id_value <- id_parts[[1]][1]
+  version_value <- id_parts[[1]][2]
+
+  if (is.na(version_value)) {
+    version_value <- NULL
+  }
+
+  cat(paste0("Downloading ", synId, "..."))
+
+  file <- synGet(id_value, version = version_value, downloadLocation = input_dir, ifcollision='overwrite.local')
+  path <- file$path
+
+  cat("\nDownload on:  ", date())
+  cat("\n", synId, "\n- Modified on ", file$properties$modifiedOn, "\n- Version ", file$properties$versionNumber)
+  cat("\npath: ", file$path, "\n")
+
+  data <- read.csv(path)
+  df_name <- as.data.frame(data)
+}
+
+# ***************
+# DRUG TARGET IDs
+# ***************
+
+# Get the list of chembl_ids from harmonized_drugs.csv
+drug_targets <- download_csv("syn73677240.5", drug_targets)
+chembl_ids <- drug_targets$ChEMBL_ID
 ```
-# Download and adapt OpenTargets Drug data
+
+# Download and adapt OpenTargets Drug data for nominated drugs
 ```{r}
 # construct the GraphQL query
 drug_query <- Query$new()
 variables = list(chembl_ids = chembl_ids)
 
-drug_query$query('test_drugs', 'query getDrugs($chembl_ids: [String!]!){
+drug_query$query('drug_info', 'query getDrugs($chembl_ids: [String!]!){
   drugs (chemblIds: $chembl_ids){
     id
     description
@@ -99,14 +146,15 @@ drug_query$query('test_drugs', 'query getDrugs($chembl_ids: [String!]!){
 }')
 
 #Execute the GraphQL query
-result <- con$exec(drug_query$queries$test_drugs, variables)
-write(prettify(result), file.path(output_dir, "test_drugs"))
+result <- con$exec(drug_query$queries$drug_info, variables)
+
+# Uncomment to write response data to local file
+#write(prettify(result), file.path(output_dir, "drug_info_response"))
 
 # Read the JSON response into a dataframe
 response_df <- fromJSON(result, flatten = TRUE)
 drug_info <- response_df$data$drugs
 drug_info
-
 
 # clean up nested row structures
 drug_info <- drug_info %>%
@@ -167,11 +215,6 @@ json_output <- toJSON(drug_info, pretty = TRUE, auto_unbox = TRUE)
 # cat(json_output)
 
 # write json file
-output_dir <- file.path("./", "output")
-if(!dir.exists(output_dir)){
-  dir.create(output_dir)
-}
-
 write(json_output, file.path(output_dir, "opentargets_drug_data.json"))
 
 # BREAK HERE FOR LOCAL VALIDATION - generated file is in ADT notebooks/output
@@ -187,6 +230,7 @@ syn_file <- File(
 res <- synStore(
           syn_file,
           forceVersion = FALSE,
+          used = data_sources,
           executed = "https://github.com/Sage-Bionetworks/agora-data-tools/blob/dev/data_analysis/model_ad/notebooks/AG-1974:_OpenTarget_ Drug_Data.rmd"
         )
 # print synapse_id and new version number

--- a/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
@@ -1,0 +1,195 @@
+---
+title: "AG-1974: OpenTargets Drug Data"
+---
+This notebook pulls drug data from the OpenTargets GraphQL API and cleans it for use by downstream transforms:
+- nomianted_drugs
+- drug_info
+
+## Library setup
+Install required packages:
+- synapser (also requires a Synapse account with an auth token)
+- jsonlite
+- purrr
+- ghql
+```{r}
+if (!require("synapser", quietly = TRUE)) {
+  install.packages("synapser", repos = c("http://ran.synapse.org",
+                                         "https://cloud.r-project.org"))
+}
+if (!require("jsonlite", quietly = TRUE)) { install.packages("jsonlite") }
+if (!require("purrr")) { install.packages("purrr") }
+if (!require("ghql")) { install.packages("ghql") }
+
+library(synapser)
+library(purrr)
+library(jsonlite)
+library(ghql)
+```
+
+
+## Variables and functions
+Setup the required graphQL client and nominated drugs source file
+```{r}
+# ***************************
+# OPEN TARGETS GRAPHQL CLIENT
+# ***************************
+url <- "https://api.platform.opentargets.org/api/v4/graphql"
+con <- GraphqlClient$new(url = url)
+
+# ************
+# DRUG TARGETS
+# ************
+source <- download_file("syn73677240", type = "csv")
+assign("drug_targets", source, envir = .GlobalEnv)
+chembl_ids <- drug_targets$ChEMBL_ID
+
+# ********
+# FUNCTION
+# ********
+# Combines the provided lists of values to produce a set of unique values.
+# - name: The canonical name of the drug, to removed from the list of alias values
+# - ...: A variable number of lists of values to combine
+resolve_drug_names <- function(name, ...) {
+  combined <- unlist(list(...))
+  combined <- combined[!is.na(combined) & combined != ""]
+
+  # Remove the canonical name
+  filtered <- combined[tolower(combined) != tolower(name)]
+
+  # Case-insensitive deduplication, keeping original casing of the first occurrence found
+  final_list <- filtered[!duplicated(tolower(filtered))]
+
+  # Return as a list (or character(0) if empty for clean JSON)
+  return(if(length(final_list) > 0) final_list else list())
+}
+
+
+```
+# Download and adapt OpenTargets Drug data
+```{r}
+# construct the GraphQL query
+drug_query <- Query$new()
+variables = list(chembl_ids = chembl_ids)
+
+drug_query$query('test_drugs', 'query getDrugs($chembl_ids: [String!]!){
+  drugs (chemblIds: $chembl_ids){
+    id
+    description
+    drugType
+    maximumClinicalTrialPhase
+    yearOfFirstApproval
+    mechanismsOfAction {
+      rows {
+        mechanismOfAction
+      }
+    }
+    linkedTargets {
+      rows {
+        id
+      }
+    }
+    name
+    crossReferences {
+      source
+      ids
+    }
+    synonyms
+    tradeNames
+  }
+}')
+
+#Execute the GraphQL query
+result <- con$exec(drug_query$queries$test_drugs, variables)
+write(prettify(result), file.path(output_dir, "test_drugs"))
+
+# Read the JSON response into a dataframe
+response_df <- fromJSON(result, flatten = TRUE)
+drug_info <- response_df$data$drugs
+drug_info
+
+
+# clean up nested row structures
+drug_info <- drug_info %>%
+  mutate(
+mechanismsOfAction = map(mechanismsOfAction.rows, ~ unlist(.x$mechanismOfAction)),
+    linkedTargets = map(linkedTargets.rows, ~ unlist(.x$id))
+  ) %>%
+  # have to use - instead of ! to negate columns with . characters
+  select(-mechanismsOfAction.rows, -linkedTargets.rows)
+
+# Extract DrugBank ID from crossReferences
+drugbank_mapping <- drug_info %>%
+  select(id, crossReferences) %>%
+  unnest(crossReferences) %>%
+  filter(source == "drugbank") %>%
+  unnest(ids) %>%
+  select(id, drug_bank_id = ids)
+
+drug_info <- drug_info %>%
+  left_join(drugbank_mapping, by = "id") %>%
+  select(-crossReferences)
+
+# manually resolve missing DrugBank IDs
+manual_fixes <- tribble(
+  ~id,             ~drug_bank_id_fix,
+  "CHEMBL4435170",   "DB16650",
+  "CHEMBL4594217",   "DB08907",
+  "CHEMBL4084119",   "DB06655",
+  "CHEMBL4788758",   "DB19277",
+  "CHEMBL545437",    "DB05395"
+)
+
+# Populate the missing DrugBank IDs
+drug_info <- drug_info %>%
+  left_join(manual_fixes, by = "id") %>%
+  mutate(drug_bank_id = coalesce(drug_bank_id, drug_bank_id_fix)) %>%
+  select(-drug_bank_id_fix)
+
+ # Collapse synonyms and tradeNames into a single set (case-insensitive)
+drug_info <- drug_info %>%
+  mutate(aliases = pmap(
+    .l = list(name, synonyms, tradeNames),
+    .f = resolve_drug_names
+  )) %>%
+  select(-tradeNames, -synonyms, -name)
+
+
+# If maximumClinicalTrialPhase == -1, convert to NA to avoid magic numbers
+drug_info <- drug_info %>%
+  mutate(maximumClinicalTrialPhase = na_if(maximumClinicalTrialPhase, -1))
+
+drug_info
+```
+
+# Generate source file and upload to Synapse
+```{r}
+json_output <- toJSON(drug_info, pretty = TRUE, auto_unbox = TRUE)
+# cat(json_output)
+
+# write json file
+output_dir <- file.path("./", "output")
+if(!dir.exists(output_dir)){
+  dir.create(output_dir)
+}
+
+write(json_output, file.path(output_dir, "opentargets_drug_data.json"))
+
+# BREAK HERE FOR LOCAL VALIDATION - generated file is in ADT notebooks/output
+
+# upload to synapse
+synLogin()
+syn_file <- File(
+              file.path(output_dir, "opentargets_drug_data.json"),
+              description = "Open Targets Drug data for Agora",
+              parent = "syn7525089"
+            )
+
+res <- synStore(
+          syn_file,
+          forceVersion = FALSE,
+          executed = "https://github.com/Sage-Bionetworks/agora-data-tools/blob/dev/data_analysis/model_ad/notebooks/AG-1974:_OpenTarget_ Drug_Data.rmd"
+        )
+# print synapse_id and new version number
+print(paste0("ID: ", res$id, " v", res$versionNumber, ", Name: ", res$name))
+```
+

--- a/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
@@ -176,7 +176,7 @@ drug_info <- drug_info %>%
   left_join(drugbank_mapping, by = "id") %>%
   select(-crossReferences)
 
-# manually resolve missing DrugBank IDs
+# manually resolved missing DrugBank IDs
 manual_fixes <- tribble(
   ~id,             ~drug_bank_id_fix,
   "CHEMBL4435170",   "DB16650",
@@ -204,6 +204,10 @@ drug_info <- drug_info %>%
 
   # If maximumClinicalTrialPhase == -1, convert to NA to avoid magic numbers
   mutate(maximumClinicalTrialPhase = na_if(maximumClinicalTrialPhase, -1)) %>%
+
+  # collapse ensembl_gene_id and mechanisms_of_action lists to unique values
+  mutate(linkedTargets = map(linkedTargets, unique)) %>%
+  mutate(mechanismsOfAction = map(mechanismsOfAction, unique)) %>%
 
   # rename columns
   dplyr::rename(chembl_id = id) %>%

--- a/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Data.rmd
@@ -207,7 +207,7 @@ drug_info <- drug_info %>%
 
   # rename columns
   dplyr::rename(chembl_id = id) %>%
-  dplyr::rename(drug_type = drugType) %>%
+  dplyr::rename(modality = drugType) %>%
   dplyr::rename(maximum_clinical_trial_phase = maximumClinicalTrialPhase) %>%
   dplyr::rename(year_of_first_approval = yearOfFirstApproval) %>%
   dplyr::rename(mechanisms_of_action = mechanismsOfAction) %>%

--- a/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Metadata.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Metadata.rmd
@@ -111,7 +111,7 @@ drug_targets <- download_csv("syn73677240.6")
 chembl_ids <- drug_targets$chembl_id
 ```
 
-# Download and adapt OpenTargets Drug data for nominated drugs
+# Download and adapt OpenTargets drug metadata for nominated drugs
 ```{r}
 # construct the GraphQL query
 drug_query <- Query$new()
@@ -225,14 +225,14 @@ drug_info
 json_output <- toJSON(drug_info, pretty = TRUE, auto_unbox = FALSE)
 
 # write json file
-write(json_output, file.path(output_dir, "opentargets_drug_data.json"))
+write(json_output, file.path(output_dir, "opentargets_drug_metadata.json"))
 
 # BREAK HERE FOR LOCAL VALIDATION
 
 # upload to synapse
 synLogin()
 syn_file <- File(
-              file.path(output_dir, "opentargets_drug_data.json"),
+              file.path(output_dir, "opentargets_drug_metadata.json"),
               description = "Open Targets Drug data for Agora",
               parent = "syn7525089"
             )
@@ -241,7 +241,7 @@ res <- synStore(
           syn_file,
           forceVersion = FALSE,
           used = data_sources,
-          executed = "https://github.com/Sage-Bionetworks/agora-data-tools/blob/dev/data_analysis/model_ad/notebooks/AG-1974:_OpenTarget_ Drug_Data.rmd"
+          executed = "https://github.com/Sage-Bionetworks/agora-data-tools/blob/dev/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTarget_ Drug_Metadata.rmd"
         )
 # print synapse_id and new version number
 print(paste0("ID: ", res$id, " v", res$versionNumber, ", Name: ", res$name))

--- a/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Metadata.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-1974:_OpenTargets_Drug_Metadata.rmd
@@ -1,8 +1,8 @@
 ---
-title: "AG-1974: OpenTargets Drug Data"
+title: "AG-1974: OpenTargets Drug Metadata"
 ---
-This notebook pulls drug data from the OpenTargets GraphQL API and cleans it for use by downstream transforms:
-- nomianted_drugs
+This notebook pulls drug metadata from the OpenTargets GraphQL API and prepares it for use by downstream transforms:
+- nominated_drugs
 - drug_info
 
 ## Library setup


### PR DESCRIPTION
# Problem
Our Nominated Drug CT and Drug Details page designs look a little thin with just the data elements we got in the nominations file.

# Solution
Pull additional data from OpenTargets, so that we can join it to our Nominated Drug data to produce a richer user experience.

The generated file is at [syn73724873](https://www.synapse.org/Synapse:syn73724873)