### PR TITLE
MG-399: Pin model-ad source file versions and align configs

### DIFF
--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -1,70 +1,30 @@
-destination: &dest syn51498092
+destination: &dest syn51498091 # preprod
 staging_path: ./staging
-gx_folder: syn63141015
-gx_table: syn63891939
+gx_folder: syn59934608         # preprod
+gx_table: syn71888382          # preprod
 datasets:
-  - biomarkers:
-      files:
-        - name: biomarkers
-          id: syn61250724
-          format: csv
-        - name: immunohisto_measure_order
-          id: syn71305327
-          format: yaml
-      final_format: json
-      destination: *dest
-      custom_transformations: immunohisto_transform
-      column_rename:
-        agedeath: age
-        age_death: age
-        measurement: value
-        type: evidence_type
-        model: name
-        key: dataset_name
-        items: evidence_type
-
-  - pathology:
-      files:
-        - name: pathology
-          id: syn61357279
-          format: csv
-        - name: immunohisto_measure_order
-          id: syn71305327
-          format: yaml
-      final_format: json
-      destination: *dest
-      custom_transformations: immunohisto_transform
-      column_rename:
-        agedeath: age
-        age_death: age
-        measurement: value
-        type: evidence_type
-        model: name
-        key: dataset_name
-        items: evidence_type
-
   - model_details:
       files:
         - name: model_info
-          id: syn61378590
+          id: syn61378590.11
           format: csv
         - name: allele_info
-          id: syn64618791
+          id: syn64618791.6
           format: csv
         - name: pathology
-          id: syn61357279
+          id: syn61357279.16
           format: csv
         - name: biomarkers
-          id: syn61250724
+          id: syn61250724.11
           format: csv
         - name: human_transgene_allele_map
-          id: syn64846805
+          id: syn64846805.2
           format: csv
         - name: model_results_info
-          id: syn68377668
+          id: syn68377668.4
           format: csv
         - name: immunohisto_measure_order
-          id: syn71305327
+          id: syn71305327.2
           format: yaml
       final_format: json
       destination: *dest
@@ -88,13 +48,13 @@ datasets:
   - disease_correlation:
       files:
         - name: disease_correlation_results
-          id: syn65467849
+          id: syn65467849.5
           format: csv
         - name: model_info
-          id: syn61378590
+          id: syn61378590.11
           format: csv
         - name: allele_info
-          id: syn64618791
+          id: syn64618791.6
           format: csv
       final_format: json
       destination: *dest
@@ -105,7 +65,7 @@ datasets:
   - ui_config:
       files:
         - name: ui_config
-          id: syn66527739
+          id: syn66527739.29
           format: json
       final_format: json
       destination: *dest
@@ -116,16 +76,16 @@ datasets:
   - model_overview:
       files:
         - name: model_info
-          id: syn61378590
+          id: syn61378590.11
           format: csv
         - name: model_results_info
-          id: syn68377668
+          id: syn68377668.4
           format: csv
         - name: allele_info
-          id: syn64618791
+          id: syn64618791.6
           format: csv
         - name: human_transgene_allele_map
-          id: syn64846805
+          id: syn64846805.2
           format: csv
       final_format: json
       destination: *dest
@@ -138,34 +98,34 @@ datasets:
   - rna_de_aggregate:
       files:
         - name: rnaseq_genotype_label_map
-          id: syn69014401
+          id: syn69014401.12
           format: csv
         - name: mouse_gene_metadata
-          id: syn51615422
+          id: syn51615422.4
           format: json
         - name: model_info
-          id: syn61378590
+          id: syn61378590.11
           format: csv
         - name: biodom_genes_mm
-          id: syn66351272
+          id: syn66351272.1
           format: csv
         - name: Jax.IU.Pitt_5XFAD_differential_expression
-          id: syn69058660
+          id: syn69058660.1
           format: csv
         - name: Jax.IU.Pitt_APOE4.Trem2.R47H_differential_expression
-          id: syn69693082
+          id: syn69693082.1
           format: csv
         - name: UCI_3xTg-AD_differential_expression
-          id: syn69058661
+          id: syn69058661.1
           format: csv
         - name: UCI_5XFAD_differential_expression
-          id: syn69058664
+          id: syn69058664.1
           format: csv
         - name: UCI_ABCA7_differential_expression
-          id: syn69058663
+          id: syn69058663.1
           format: csv
         - name: UCI_Trem2-R47H_NSS_differential_expression
-          id: syn69058662
+          id: syn69058662.1
           format: csv
       final_format: json
       destination: *dest

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -98,7 +98,7 @@ datasets:
   - rna_de_aggregate:
       files:
         - name: rnaseq_genotype_label_map
-          id: syn69014401.12
+          id: syn69014401.13
           format: csv
         - name: mouse_gene_metadata
           id: syn51615422.4
@@ -113,7 +113,7 @@ datasets:
           id: syn69058660.1
           format: csv
         - name: Jax.IU.Pitt_APOE4.Trem2.R47H_differential_expression
-          id: syn69693082.1
+          id: syn69693082.2
           format: csv
         - name: UCI_3xTg-AD_differential_expression
           id: syn69058661.1
@@ -122,10 +122,10 @@ datasets:
           id: syn69058664.1
           format: csv
         - name: UCI_ABCA7_differential_expression
-          id: syn69058663.1
+          id: syn69058663.2
           format: csv
         - name: UCI_Trem2-R47H_NSS_differential_expression
-          id: syn69058662.1
+          id: syn69058662.2
           format: csv
       final_format: json
       destination: *dest

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -1,70 +1,30 @@
-destination: &dest syn51498092
+destination: &dest syn51498088   # prod
 staging_path: ./staging
-gx_folder: syn63141015
-gx_table: syn63891939
+gx_folder: syn63141014           # prod
+gx_table: syn71888383            # prod
 datasets:
-  - biomarkers:
-      files:
-        - name: biomarkers
-          id: syn61250724
-          format: csv
-        - name: immunohisto_measure_order
-          id: syn71305327
-          format: yaml
-      final_format: json
-      destination: *dest
-      custom_transformations: immunohisto_transform
-      column_rename:
-        agedeath: age
-        age_death: age
-        measurement: value
-        type: evidence_type
-        model: name
-        key: dataset_name
-        items: evidence_type
-
-  - pathology:
-      files:
-        - name: pathology
-          id: syn61357279
-          format: csv
-        - name: immunohisto_measure_order
-          id: syn71305327
-          format: yaml
-      final_format: json
-      destination: *dest
-      custom_transformations: immunohisto_transform
-      column_rename:
-        agedeath: age
-        age_death: age
-        measurement: value
-        type: evidence_type
-        model: name
-        key: dataset_name
-        items: evidence_type
-
   - model_details:
       files:
         - name: model_info
-          id: syn61378590
+          id: syn61378590.11
           format: csv
         - name: allele_info
-          id: syn64618791
+          id: syn64618791.6
           format: csv
         - name: pathology
-          id: syn61357279
+          id: syn61357279.16
           format: csv
         - name: biomarkers
-          id: syn61250724
+          id: syn61250724.11
           format: csv
         - name: human_transgene_allele_map
-          id: syn64846805
+          id: syn64846805.2
           format: csv
         - name: model_results_info
-          id: syn68377668
+          id: syn68377668.4
           format: csv
         - name: immunohisto_measure_order
-          id: syn71305327
+          id: syn71305327.2
           format: yaml
       final_format: json
       destination: *dest
@@ -88,13 +48,13 @@ datasets:
   - disease_correlation:
       files:
         - name: disease_correlation_results
-          id: syn65467849
+          id: syn65467849.5
           format: csv
         - name: model_info
-          id: syn61378590
+          id: syn61378590.11
           format: csv
         - name: allele_info
-          id: syn64618791
+          id: syn64618791.6
           format: csv
       final_format: json
       destination: *dest
@@ -105,7 +65,7 @@ datasets:
   - ui_config:
       files:
         - name: ui_config
-          id: syn66527739
+          id: syn66527739.29
           format: json
       final_format: json
       destination: *dest
@@ -116,16 +76,16 @@ datasets:
   - model_overview:
       files:
         - name: model_info
-          id: syn61378590
+          id: syn61378590.11
           format: csv
         - name: model_results_info
-          id: syn68377668
+          id: syn68377668.4
           format: csv
         - name: allele_info
-          id: syn64618791
+          id: syn64618791.6
           format: csv
         - name: human_transgene_allele_map
-          id: syn64846805
+          id: syn64846805.2
           format: csv
       final_format: json
       destination: *dest
@@ -134,3 +94,39 @@ datasets:
         gene: modified_gene
         ensembl_id: human_ensembl_id
         model: name
+
+  - rna_de_aggregate:
+      files:
+        - name: rnaseq_genotype_label_map
+          id: syn69014401.12
+          format: csv
+        - name: mouse_gene_metadata
+          id: syn51615422.4
+          format: json
+        - name: model_info
+          id: syn61378590.11
+          format: csv
+        - name: biodom_genes_mm
+          id: syn66351272.1
+          format: csv
+        - name: Jax.IU.Pitt_5XFAD_differential_expression
+          id: syn69058660.1
+          format: csv
+        - name: Jax.IU.Pitt_APOE4.Trem2.R47H_differential_expression
+          id: syn69693082.1
+          format: csv
+        - name: UCI_3xTg-AD_differential_expression
+          id: syn69058661.1
+          format: csv
+        - name: UCI_5XFAD_differential_expression
+          id: syn69058664.1
+          format: csv
+        - name: UCI_ABCA7_differential_expression
+          id: syn69058663.1
+          format: csv
+        - name: UCI_Trem2-R47H_NSS_differential_expression
+          id: syn69058662.1
+          format: csv
+      final_format: json
+      destination: *dest
+      custom_transformations: transform_rna_de_aggregate

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -98,7 +98,7 @@ datasets:
   - rna_de_aggregate:
       files:
         - name: rnaseq_genotype_label_map
-          id: syn69014401.12
+          id: syn69014401.13
           format: csv
         - name: mouse_gene_metadata
           id: syn51615422.4
@@ -113,7 +113,7 @@ datasets:
           id: syn69058660.1
           format: csv
         - name: Jax.IU.Pitt_APOE4.Trem2.R47H_differential_expression
-          id: syn69693082.1
+          id: syn69693082.2
           format: csv
         - name: UCI_3xTg-AD_differential_expression
           id: syn69058661.1
@@ -122,10 +122,10 @@ datasets:
           id: syn69058664.1
           format: csv
         - name: UCI_ABCA7_differential_expression
-          id: syn69058663.1
+          id: syn69058663.2
           format: csv
         - name: UCI_Trem2-R47H_NSS_differential_expression
-          id: syn69058662.1
+          id: syn69058662.2
           format: csv
       final_format: json
       destination: *dest

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -130,3 +130,4 @@ datasets:
       final_format: json
       destination: *dest
       custom_transformations: transform_rna_de_aggregate
+ 

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -130,4 +130,3 @@ datasets:
       final_format: json
       destination: *dest
       custom_transformations: transform_rna_de_aggregate
- 


### PR DESCRIPTION
## Problem
The Model AD configuration files have been in flux during ongoing development, and as our MVP UAT release is rapidly approaching, we need to align the configs with our release plan.

## Solution
Update the model-ad config files to:
* Remove datasets that are no longer used by the application (biomarkers, pathology)
* Validate and pin all source file versions
* Target the correct output folders in synapse for datasets, GX records, and GX tracking
