### PR TITLE
Individual gene expression pages have duplicate plots for 4x UCI models

### DIFF
--- a/docs/RNA_DE_INDIVIDUAL_TRANSFORM.md
+++ b/docs/RNA_DE_INDIVIDUAL_TRANSFORM.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `rna_de_individual` transform processes individual-level RNA expression (normalized expression) data from Model AD mouse models. It transforms raw individual expression measurements into a structured format that groups data by gene, tissue, model_group, and name, with individual data points organized by age.
+The `rna_de_individual` transform processes individual-level RNA expression (normalized expression) data from Model AD mouse models. It transforms raw individual expression measurements into a structured format that groups data by gene, tissue, and effective_model_group, with individual data points organized by age.
 
 **Module Location:** `src/agoradatatools/etl/transform/rna_de_individual.py`
 
@@ -69,39 +69,46 @@ The transform requires three types of input:
    - Maps Ensembl gene IDs to gene symbols
    - **Purpose:** Enriches output with human-readable gene names
 
-### Step 2: File Processing (Shared Pattern)
+### Step 2: File Grouping and Preprocessing
 
-The transform uses a **shared file processing pattern** (`process_data_files` from `rna_de_individual_utils`) that handles common preprocessing steps for all data files:
+Before transform-specific processing, the main function groups input files by their `effective_model_group` and preprocesses each file individually.
 
-#### 2.1 Common Preprocessing (Shared)
-Automatically applied to each file before transform-specific processing:
-- **File iteration:** Processes files one at a time (excluding required input files)
-- **Logging:** Logs file name, index, row count, column count, and memory usage
+#### 2.1 File Grouping by effective_model_group
+- Reads the `model` column of each input file to determine its `effective_model_group` using the genotype metadata lookup
+- Groups files with the same `effective_model_group` together (e.g. UCI models whose data is split across two CSV files)
+- Single-file groups are processed without any concatenation overhead
+- This strategy keeps memory usage proportional to the largest group rather than the total dataset size
+
+#### 2.2 Common Preprocessing (`preprocess_data_file`)
+Applied to each file individually before it is combined within its group:
+- **Logging:** Logs file name, global index, row count, column count, and memory usage
 - **Empty file validation:** Raises error if file is empty
 - **Column validation:** Checks all required columns are present
 - **Gene filtering:** Filters to mouse genes only (keeps `ENSMUSG*`, removes `ENSG*`)
 - **Sex conversion:** Converts sex values to sentence case (M/m/male → Male, F/f/female → Female)
 - **Numeric rounding:** Rounds all numeric columns to 5 decimal places
-- **Memory cleanup:** Deletes DataFrame and runs garbage collection after processing
 
-#### 2.2 Transform-Specific Processing (`_process_individual_data_file_core`)
+After all files in a group are preprocessed, they are concatenated (via `pd.concat`) into a single DataFrame that is passed to `_process_individual_data_file_core`. Memory is explicitly freed (via `del` and `gc.collect()`) after each group is processed.
 
-After preprocessing, the individual transform applies its specific logic:
+#### 2.3 Transform-Specific Processing (`_process_individual_data_file_core`)
+
+After preprocessing and concatenation, the individual transform applies its specific logic:
 
 **Genotype Enrichment (Vectorized Merge):**
 - Converts genotype metadata dictionary to DataFrame
 - Performs left join on `(model, genotype)` to add:
   - `genotype_display`: Human-readable genotype label
   - `result_order`: Ordering value for display
+  - `model_group`: Explicit model group (empty string if none)
+  - `effective_model_group`: `model_group` when set, otherwise `model` name
 - **Fallback for unmapped genotypes:**
   - `genotype_display` = original `genotype` value
   - `result_order` = 999 (treated as non-control)
 - **Merge validation:** Uses `validate="many_to_one"` to ensure each `(model, genotype)` maps to exactly one label
 
-**Model Group Assignment:**
-- Maps each model to its model_group using genotype metadata
-- Empty string if no model_group defined
-- Adds `name` field equal to `model` (not model_group) since each file represents a single model
+**name Field Assignment:**
+- `name` is set to `effective_model_group` (the model_group when explicitly set, or the model name for solo models)
+- This consolidates multi-file model_groups (e.g. all UCI models sharing "Trem2-R47H_NSS") under a single display name while preserving solo-model names
 
 **Genotype Filtering by Model Group:**
 - **Critical filtering step:** Filters data to include only genotypes that belong to the effective model_group
@@ -114,9 +121,9 @@ After preprocessing, the individual transform applies its specific logic:
 ### Step 3: Grouping and Output Entry Creation
 
 #### 3.1 Grouping Strategy
-- Groups data by: `(ensembl_gene_id, tissue, model_group, name)`
-- Each group represents a unique combination of gene, tissue, and model
-- **Design decision:** Groups by `model_group` to support multiple controls paradigm
+- Groups data by: `(ensembl_gene_id, tissue, effective_model_group)`
+- Each group represents a unique combination of gene, tissue, and effective model group
+- **Design decision:** Groups by `effective_model_group` rather than individual model name so that all models sharing the same `model_group` (including data split across multiple input files) produce a single consolidated output entry
 
 #### 3.2 Output Entry Creation (`_create_output_entry_from_group`)
 
@@ -132,8 +139,8 @@ For each grouped combination, this function directly creates output entries (one
   - **Sentence case conversion:** All tissue names converted to sentence case (e.g., "hippocampus" → "Hippocampus", "CORTEX" → "Cortex")
 
 **Model Information:**
-- `name`: Model name (from the `model` field, NOT model_group)
-- `model_group`: Model group name (normalized to `None` if empty string)
+- `name`: `effective_model_group` value — equals `model_group` when explicitly set, or the model name for solo models
+- `model_group`: Explicit model group name (normalized to `None` if empty string)
 
 **Control Identification:**
 - `matched_control`: Display label of the control genotype
@@ -164,7 +171,7 @@ For each grouped combination, this function directly creates output entries (one
   - `value`: Expression value (converted to float)
 
 **Processing Steps:**
-1. Groups the input data by age within each (gene, tissue, model) combination
+1. Groups the input data by age within each (gene, tissue, effective_model_group) combination
 2. For each age group, creates a complete output entry with all metadata fields
 3. Sorts output entries by numeric age value for consistent ordering
 4. Returns one output entry per age timepoint
@@ -172,7 +179,7 @@ For each grouped combination, this function directly creates output entries (one
 **Unnesting Decision:** Unlike some transforms that nest age data, this transform creates **one output entry per age** (unnested structure). Each entry has a single age with its associated data points.
 
 ### Step 4: Consolidation
-- Combines output entries from all processed files
+- Combines output entries from all processed effective_model_groups
 - Returns single list of all entries
 
 ## Key Assumptions
@@ -201,9 +208,10 @@ This transform is designed to handle two distinct experimental scenarios:
 - Display can show multiple model variants alongside their shared controls
 
 **Implementation Details:**
-- **Effective Model Group:** When `model_group` is empty, the model itself serves as its own group
-- **Name vs Model Group:** The `name` field preserves the actual model name (not model_group), maintaining model-level granularity
-- **Grouping Key:** Data is grouped by `model_group` to enable proper control sharing across related models
+- **Effective Model Group:** When `model_group` is empty, the model itself serves as its own group (`effective_model_group = model`)
+- **Name Field:** The `name` field is set to `effective_model_group`, consolidating multi-file model_groups (e.g. UCI models) under a single display name while preserving solo-model names
+- **File Grouping:** Input files are first grouped by `effective_model_group`; only files within the same group are concatenated before processing
+- **Grouping Key:** Data is grouped by `(ensembl_gene_id, tissue, effective_model_group)` to produce one consolidated output entry per group, regardless of how many input files contributed data
 
 ### 4. Genotype Mapping Completeness
 - **Assumption:** Most genotypes in data files have entries in rnaseq_genotype_label_map
@@ -269,15 +277,15 @@ This transform is designed to handle two distinct experimental scenarios:
 - **Failure mode:** Raises error if same (model, genotype) maps to multiple labels
 
 ### 2. Grouping Strategy
-- **Primary group:** (ensembl_gene_id, tissue, model_group, name)
+- **Primary group:** (ensembl_gene_id, tissue, effective_model_group)
 - **Secondary group:** age (within each primary group)
-- **Why:** Organizes data hierarchically for efficient display
-- **Impact:** Creates nested structure suitable for visualization
+- **Why:** Organizes data hierarchically for efficient display and consolidates multi-file model_groups
+- **Impact:** Creates one output entry per (gene, tissue, effective_model_group, age) regardless of how many input files contributed data
 
 ### 3. Cross-File Merging
-- **Method:** Sequential processing with list concatenation
-- **Why:** Minimizes memory usage for large datasets
-- **Trade-off:** No cross-file validation or deduplication
+- **Method:** Files are grouped by `effective_model_group`; within each group, preprocessed DataFrames are concatenated with `pd.concat` before core processing; memory is explicitly freed after each group
+- **Why:** Minimizes peak memory usage — only files belonging to the same group are held in memory simultaneously
+- **Trade-off:** No cross-group validation or deduplication
 
 ### 4. Model to Model Group Mapping
 - **Method:** Extracts from genotype metadata (one entry per model)
@@ -287,14 +295,14 @@ This transform is designed to handle two distinct experimental scenarios:
 
 ## Output Structure
 
-Each output entry represents a unique combination of (gene, tissue, model_group, name, age) with the following schema:
+Each output entry represents a unique combination of (gene, tissue, effective_model_group, age) with the following schema:
 
 ```json
 {
   "ensembl_gene_id": "ENSMUSG00000000001",
   "gene_symbol": "Gnai3",
   "tissue": "Hemibrain",
-  "name": "Jax.IU.Pitt_APOE4",
+  "name": "APOE4",
   "model_group": "APOE4",
   "matched_control": "C57BL/6J",
   "units": "Log2 Counts per Million",
@@ -323,7 +331,7 @@ Each output entry represents a unique combination of (gene, tissue, model_group,
 - **ensembl_gene_id**: Mouse gene Ensembl identifier (ENSMUSG*)
 - **gene_symbol**: Human-readable gene symbol (empty if not found in metadata)
 - **tissue**: Tissue name (with JAX transformation and sentence case applied)
-- **name**: Actual model name (not model_group)
+- **name**: `effective_model_group` value — equals `model_group` when explicitly set, or the model name for solo models
 - **model_group**: Model group for display purposes (null if empty)
 - **matched_control**: Display label of the control genotype (empty if no control present in data)
 - **units**: Always "Log2 Counts per Million"
@@ -340,8 +348,8 @@ Each output entry represents a unique combination of (gene, tissue, model_group,
 
 1. **Vectorized Operations:** Uses pandas merge instead of row-by-row lookups
 2. **Pre-computed Dictionaries:** Creates lookup dictionaries once before file processing
-3. **Sequential File Processing:** Processes files one at a time with explicit garbage collection
-4. **Memory Cleanup:** Deletes DataFrames and runs gc.collect() after each file
+3. **Group-Based File Processing:** Groups input files by `effective_model_group` and processes one group at a time; single-file groups incur no concatenation overhead
+4. **Memory Cleanup:** Explicitly deletes DataFrames and runs `gc.collect()` after each group is processed, keeping peak memory proportional to the largest group rather than the total dataset
 5. **Efficient Grouping:** Uses pandas groupby instead of manual iteration
 
 ## Validation and Error Handling
@@ -413,4 +421,4 @@ output = transform_rna_de_individual(datasets)
 ### Issue: Memory errors with large files
 - **Cause:** Processing very large expression files
 - **Impact:** Out of memory errors
-- **Solution:** Files are processed sequentially with cleanup; consider splitting input files
+- **Solution:** Files are processed group by group with explicit memory cleanup after each group; consider splitting input files further if individual groups remain too large

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -31,6 +31,9 @@ Required Inputs:
       ensembl_gene_id, expression, model, genotype, age, sex, tissue, individualid
 """
 
+import gc
+from collections import defaultdict
+
 import pandas as pd
 from typing import Dict, List, Any
 import logging
@@ -45,7 +48,7 @@ from agoradatatools.etl.transform.rna_de_individual_utils import (
     create_genotype_metadata_dict,
     normalize_model_group_value,
     extract_common_metadata,
-    process_data_files,
+    preprocess_data_file,
 )
 
 logger = logging.getLogger(__name__)
@@ -102,7 +105,7 @@ def _determine_result_order(
 
 
 def _create_output_entry_from_group(
-    group_key: tuple[str, str, str, str],
+    group_key: tuple[str, str, str],
     group: pd.DataFrame,
     gene_metadata_dict: Dict[str, str],
     genotype_metadata_dict: Dict[tuple[str, str], Dict[str, Any]],
@@ -110,15 +113,17 @@ def _create_output_entry_from_group(
     """
     Creates output entries from a grouped DataFrame, one entry per age timepoint.
 
-    This function takes a group of individual expression data (gene, tissue, model combination)
-    and creates separate output entries for each age timepoint. Each entry contains all the
-    individual data points for that specific age.
+    This function takes a group of individual expression data (gene, tissue, and
+    effective_model_group combination) and creates separate output entries for each
+    age timepoint. Each entry contains all individual data points for that age,
+    potentially spanning multiple models that share the same model_group.
 
     Args:
-        group_key: Tuple containing (ensembl_gene_id, tissue, model_group, model)
+        group_key: Tuple containing (ensembl_gene_id, tissue, effective_model_group).
+            effective_model_group is model_group when set, otherwise the model name.
         group: DataFrame group containing individual expression data with columns:
             genotype, genotype_display, age, sex, individualid, expression, result_order,
-            effective_model_group
+            model_group, effective_model_group
         gene_metadata_dict: Dictionary mapping Ensembl gene IDs to gene symbols
         genotype_metadata_dict: Dictionary mapping (model, genotype) tuples to metadata dicts
             containing 'display_label', 'result_order', and 'effective_model_group'
@@ -130,31 +135,30 @@ def _create_output_entry_from_group(
             - age_numeric: Numeric age for sorting
             - data: List of individual data points for this age
     """
-    ensembl_gene_id, tissue, model_group, model = group_key
+    ensembl_gene_id, tissue, effective_model_group = group_key
 
     # Extract common metadata (gene_symbol, tissue mapping)
     common_metadata = extract_common_metadata(
         ensembl_gene_id, tissue, gene_metadata_dict
     )
 
-    # Get effective_model_group from the DataFrame (pre-computed during merge)
-    # All rows in the group have the same effective_model_group
-    effective_model_group = group.iloc[0]["effective_model_group"]
+    # Get the actual model_group value from data (empty string if none defined).
+    # effective_model_group equals model_group when set, or model name when not.
+    model_group = group.iloc[0]["model_group"]
 
-    # Identify the matched control genotype (lowest result_order value)
-    # This assumes lower result_order values represent control genotypes
+    # name is the effective_model_group: model_group when explicitly set,
+    # otherwise the model name. This consolidates multi-file model_groups under
+    # a single display name while preserving solo-model names.
+    name = effective_model_group
+
+    # Identify the matched control genotype (lowest result_order value).
+    # Use genotype_display directly since the group may span multiple models.
     matched_control = ""
     if "result_order" in group.columns:
         min_order = group["result_order"].min()
         control_mask = group["result_order"] == min_order
         if control_mask.any():
-            control_genotype = group.loc[control_mask, "genotype"].iloc[0]
-            metadata = genotype_metadata_dict.get((model, control_genotype), {})
-            matched_control = metadata.get("display_label", "")
-
-    # Use the actual model name (not model_group) as 'name' since each file
-    # represents data from a single model
-    name = model
+            matched_control = group.loc[control_mask, "genotype_display"].iloc[0]
 
     # Get ordered list of display labels for this model_group
     result_order = _determine_result_order(
@@ -271,9 +275,6 @@ def _process_individual_data_file_core(
         data_file["model_group"] = ""
         data_file["effective_model_group"] = data_file["model"]
 
-    # Step 2: Add name column (alias for model)
-    data_file["name"] = data_file["model"]
-
     # Step 3: Filter to valid genotype combinations for each model_group
     # This prevents processing invalid genotype combinations that may exist in the data
     # Build set of valid (effective_model_group, genotype) pairs from metadata
@@ -290,8 +291,10 @@ def _process_individual_data_file_core(
     data_file = data_file[filter_mask]
 
     # Step 4: Group and create output entries
-    # Group by gene, tissue, model_group, and model name
-    grouped = data_file.groupby(["ensembl_gene_id", "tissue", "model_group", "name"])
+    # Group by gene, tissue, and effective_model_group so that all models sharing
+    # the same model_group (e.g. data split across multiple input files) are
+    # combined into a single output entry.
+    grouped = data_file.groupby(["ensembl_gene_id", "tissue", "effective_model_group"])
 
     output_entries = []
     for group_key, group in grouped:
@@ -398,18 +401,77 @@ def transform_rna_de_individual(
         "individualid",
     ]
 
-    # Step 6: Process all data files
-    # The process_data_files function handles common preprocessing (filtering, rounding)
-    # and calls our core transformation logic for each file
-    logger.info("Transform rna_de_individual starting file processing")
-    output = process_data_files(
-        datasets=datasets,
-        required_input=required_input,
-        data_file_required_columns=data_file_required_columns,
-        process_file_callback=lambda file_name, data_file, file_index, total_files: _process_individual_data_file_core(
-            data_file, gene_metadata_dict, genotype_metadata_dict
-        ),
+    # Step 6: Group files by effective_model_group so that models sharing the same
+    # group (e.g. UCI models split across two input files) are processed together,
+    # while unrelated files are processed and freed independently.
+    #
+    # This preserves the original memory-efficient sequential processing for the
+    # majority of files (which each represent their own group) while only
+    # holding multiple files in memory simultaneously when they genuinely need to
+    # be combined.  The alternative of concatenating ALL files first would hold
+    # the full ~5+ GB in memory at once regardless of grouping need.
+    file_list = [k for k in datasets.keys() if k not in required_input]
+    total_files = len(file_list)
+    logger.info(
+        f"Transform rna_de_individual: processing {total_files} data files: {file_list}"
     )
+
+    # Build a model → effective_model_group lookup from the metadata dict
+    model_to_emg: Dict[str, str] = {
+        model: metadata["effective_model_group"]
+        for (model, genotype), metadata in genotype_metadata_dict.items()
+    }
+
+    # Assign each file to the effective_model_group of its data.
+    # Reading the 'model' column from the already-loaded DataFrame is cheap.
+    emg_to_files: Dict[str, List[str]] = defaultdict(list)
+    for file_name in file_list:
+        df = datasets[file_name]
+        # A single file should contain only one model's data; use the first value.
+        raw_model = df["model"].iloc[0] if len(df) > 0 else ""
+        emg = model_to_emg.get(raw_model, raw_model)
+        emg_to_files[emg].append(file_name)
+
+    logger.info(
+        "Transform rna_de_individual: file groups by effective_model_group: "
+        + ", ".join(f"{emg}={files}" for emg, files in emg_to_files.items())
+    )
+
+    # Step 7: Process one effective_model_group at a time.
+    # Groups with a single file are processed without any extra concatenation.
+    # Groups with multiple files (e.g. UCI split-file models) are concatenated
+    # only within that group before processing, then freed immediately after.
+    output = []
+    for group_idx, (emg, files_in_group) in enumerate(emg_to_files.items()):
+        logger.info(
+            f"Transform rna_de_individual: processing group {group_idx + 1}/"
+            f"{len(emg_to_files)} ({emg}): {files_in_group}"
+        )
+
+        preprocessed_dfs = []
+        for file_idx, file_name in enumerate(files_in_group):
+            preprocessed_df = preprocess_data_file(
+                file_name=file_name,
+                data_file=datasets[file_name],
+                file_index=group_idx * len(files_in_group) + file_idx,
+                total_files=total_files,
+                data_file_required_columns=data_file_required_columns,
+            )
+            preprocessed_dfs.append(preprocessed_df)
+
+        combined_data = (
+            pd.concat(preprocessed_dfs, ignore_index=True)
+            if len(preprocessed_dfs) > 1
+            else preprocessed_dfs[0]
+        )
+
+        group_output = _process_individual_data_file_core(
+            combined_data, gene_metadata_dict, genotype_metadata_dict
+        )
+        output.extend(group_output)
+
+        del preprocessed_dfs, combined_data
+        gc.collect()
 
     logger.info(f"Transform rna_de_individual total output entries: {len(output)}")
 

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -5,13 +5,15 @@ This module transforms individual RNA expression (normalized expression) data fo
 It processes multiple RNA-seq datasets and combines them into a unified output format.
 
 The transformation includes gene metadata, genotype labels, and individual expression
-values to create a structured output format grouped by model_group.
+values to create a structured output format grouped by effective_model_group.
 
 The transformation:
 - Filters to mouse genes only (ENSMUSG*), excluding human genes (ENSG*)
-- Groups individual expression data by gene, tissue, model_group, and name
+- Groups files by effective_model_group so that models sharing a model_group (e.g. UCI
+  models whose data is split across two input files) are combined before output creation
+- Groups individual expression data by gene, tissue, and effective_model_group
 - Creates age-based entries containing individual expression values for all genotypes
-- Organizes data by model_group to support both single and multiple control display paradigms
+- Organizes data by effective_model_group to support both single and multiple control display paradigms
 - Enriches data with gene symbols from gene metadata
 - Maps genotypes to display labels for better readability
 - Converts sex values to sentence case (M/F/male/female → Male/Female)
@@ -219,7 +221,7 @@ def _process_individual_data_file_core(
     This function contains the individual-transform-specific processing logic:
     1. Enriches data with genotype metadata (display labels, result_order, model_group, effective_model_group)
     2. Filters to include only valid genotype combinations for each model_group
-    3. Groups data by gene, tissue, model_group, and model name
+    3. Groups data by gene, tissue, and effective_model_group
     4. Creates output entries for each group with individual measurements
 
     Note: This function expects preprocessed data (mouse genes only, rounded numeric values).
@@ -234,7 +236,7 @@ def _process_individual_data_file_core(
             containing 'display_label', 'result_order', 'model_group', 'effective_model_group'
 
     Returns:
-        List of output entry dictionaries for this file, one per (gene, tissue, model, age)
+        List of output entry dictionaries, one per (gene, tissue, effective_model_group, age)
     """
     # Step 1: Enrich with genotype metadata using vectorized merge
     # This adds display labels, result_order, model_group, and effective_model_group to each row
@@ -324,15 +326,20 @@ def transform_rna_de_individual(
         1. Validates required datasets and columns
         2. Creates gene and genotype metadata lookup dictionaries
         3. Validates data consistency (model_group values)
-        4. Processes each data file:
-           - Filters to mouse genes only
-           - Converts sex values to sentence case (Male/Female)
-           - Rounds numeric values to 5 decimal places
+        4. Groups input files by effective_model_group so that models whose data is
+           split across multiple files (e.g. UCI models) are combined before output
+           creation, while unrelated files are processed and freed independently
+        5. For each effective_model_group:
+           - Preprocesses each file (filters to mouse genes, converts sex to sentence
+             case, rounds numeric values to 5 decimal places)
+           - Concatenates preprocessed DataFrames within the group (no-op for
+             single-file groups)
            - Enriches with genotype metadata
            - Filters to valid genotype combinations
-           - Groups by gene, tissue, model, and age
+           - Groups by gene, tissue, and effective_model_group
            - Creates output entries with individual data points
-        5. Consolidates output from all files
+           - Frees memory before moving to the next group
+        6. Consolidates output from all groups
 
     Args:
         datasets: Dictionary mapping dataset names to DataFrames. Must include:
@@ -348,12 +355,13 @@ def transform_rna_de_individual(
 
     Returns:
         List of dictionaries, each representing a unique combination of gene, tissue,
-        model, and age. Each entry contains:
+        effective_model_group, and age. Each entry contains:
             - ensembl_gene_id: Mouse gene identifier (ENSMUSG*)
             - gene_symbol: Human-readable gene name (empty string if not found)
             - tissue: Tissue name (with JAX-specific mappings and sentence case applied)
-            - name: Model name
-            - model_group: Model group for display (None if not grouped)
+            - name: effective_model_group value (equals model_group when explicitly set,
+              otherwise equals the model name for solo models)
+            - model_group: Explicit model group for display (None if not set)
             - matched_control: Display label of the control genotype
             - units: "Log2 Counts per Million"
             - age: Age timepoint string (e.g., "3 months")

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -442,6 +442,7 @@ def transform_rna_de_individual(
     # Groups with multiple files (e.g. UCI split-file models) are concatenated
     # only within that group before processing, then freed immediately after.
     output = []
+    global_file_idx = 0
     for group_idx, (emg, files_in_group) in enumerate(emg_to_files.items()):
         logger.info(
             f"Transform rna_de_individual: processing group {group_idx + 1}/"
@@ -449,15 +450,16 @@ def transform_rna_de_individual(
         )
 
         preprocessed_dfs = []
-        for file_idx, file_name in enumerate(files_in_group):
+        for file_name in files_in_group:
             preprocessed_df = preprocess_data_file(
                 file_name=file_name,
                 data_file=datasets[file_name],
-                file_index=group_idx * len(files_in_group) + file_idx,
+                file_index=global_file_idx,
                 total_files=total_files,
                 data_file_required_columns=data_file_required_columns,
             )
             preprocessed_dfs.append(preprocessed_df)
+            global_file_idx += 1
 
         combined_data = (
             pd.concat(preprocessed_dfs, ignore_index=True)

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -224,7 +224,7 @@ def _process_individual_data_file_core(
 
     Note: This function expects preprocessed data (mouse genes only, rounded numeric values).
     Preprocessing (filtering human genes, rounding, validation) is handled by the
-    process_data_files function before this function is called.
+    preprocess_data_file function before this function is called.
 
     Args:
         data_file: Preprocessed DataFrame containing individual expression data with columns:

--- a/src/agoradatatools/etl/transform/rna_de_individual_utils.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual_utils.py
@@ -332,6 +332,47 @@ def extract_common_metadata(
     }
 
 
+def preprocess_data_file(
+    file_name: str,
+    data_file: pd.DataFrame,
+    file_index: int,
+    total_files: int,
+    data_file_required_columns: List[str],
+) -> pd.DataFrame:
+    """
+    Preprocess a single data file with common validation and transformation steps.
+
+    Applies the same preprocessing as process_data_files (validation, filtering,
+    sex conversion, rounding) but returns the preprocessed DataFrame directly,
+    allowing callers to accumulate and concatenate multiple files before processing.
+
+    Args:
+        file_name: Name of the file being processed
+        data_file: DataFrame to preprocess
+        file_index: Index of this file in the processing sequence (0-based)
+        total_files: Total number of files being processed
+        data_file_required_columns: List of column names that must be present
+
+    Returns:
+        Preprocessed DataFrame with mouse genes only, sentence-cased sex values,
+        and numeric values rounded to 5 decimal places.
+
+    Raises:
+        ValueError: If the file is empty or missing required columns.
+    """
+    log_file_processing_info(file_name, file_index, total_files, data_file)
+    validate_data_file_not_empty(file_name, data_file)
+    check_required_datasets_and_columns(
+        {file_name: data_file}, {file_name: data_file_required_columns}
+    )
+    data_file = filter_mouse_genes(data_file)
+    if "sex" in data_file.columns:
+        data_file = data_file.copy()
+        data_file["sex"] = data_file["sex"].apply(convert_sex_to_sentence_case)
+    data_file = data_file.round(decimals=5)
+    return data_file
+
+
 def process_data_files(
     datasets: Dict[str, pd.DataFrame],
     required_input: Dict[str, List[str]],

--- a/tests/test_assets/rna_de_individual/input/synthetic_multi_model_file1.csv
+++ b/tests/test_assets/rna_de_individual/input/synthetic_multi_model_file1.csv
@@ -1,0 +1,5 @@
+ensembl_gene_id,individualid,expression,tissue,sex,age,genotype,model
+ENSMUSG00000000001,Ind001,5.12345,Hippocampus,Male,4 months,Trem2-R47H_NSS_homozygous,Trem2-R47H_NSS
+ENSMUSG00000000001,Ind002,4.98765,Hippocampus,Female,4 months,Trem2-R47H_NSS_homozygous,Trem2-R47H_NSS
+ENSMUSG00000000001,Ind003,3.55555,Hippocampus,Male,4 months,5XFAD_noncarrier,Trem2-R47H_NSS
+ENSMUSG00000000001,Ind004,3.67890,Hippocampus,Female,4 months,5XFAD_noncarrier,Trem2-R47H_NSS

--- a/tests/test_assets/rna_de_individual/input/synthetic_multi_model_file2.csv
+++ b/tests/test_assets/rna_de_individual/input/synthetic_multi_model_file2.csv
@@ -1,0 +1,5 @@
+ensembl_gene_id,individualid,expression,tissue,sex,age,genotype,model
+ENSMUSG00000000001,Ind005,6.11111,Hippocampus,Male,4 months,5XFAD_carrier; Trem2-R47H_NSS_homozygous,Trem2-R47H_NSS.5xFAD
+ENSMUSG00000000001,Ind006,5.88888,Hippocampus,Female,4 months,5XFAD_carrier; Trem2-R47H_NSS_homozygous,Trem2-R47H_NSS.5xFAD
+ENSMUSG00000000001,Ind007,4.44444,Hippocampus,Male,4 months,5XFAD_carrier,Trem2-R47H_NSS.5xFAD
+ENSMUSG00000000001,Ind008,4.22222,Hippocampus,Female,4 months,5XFAD_carrier,Trem2-R47H_NSS.5xFAD

--- a/tests/test_assets/rna_de_individual/output/synthetic_multi_model_output.json
+++ b/tests/test_assets/rna_de_individual/output/synthetic_multi_model_output.json
@@ -1,0 +1,69 @@
+[
+  {
+    "ensembl_gene_id": "ENSMUSG00000000001",
+    "gene_symbol": "Gnai3",
+    "tissue": "Hippocampus",
+    "name": "Trem2-R47H_NSS",
+    "model_group": "Trem2-R47H_NSS",
+    "matched_control": "C57BL/6J",
+    "units": "Log2 Counts per Million",
+    "age": "4 months",
+    "age_numeric": 4,
+    "result_order": [
+      "C57BL/6J",
+      "Trem2-R47H_NSS",
+      "5xFAD",
+      "Trem2-R47H_NSS.5xFAD"
+    ],
+    "data": [
+      {
+        "genotype": "Trem2-R47H_NSS",
+        "sex": "Male",
+        "individual_id": "Ind001",
+        "value": 5.12345
+      },
+      {
+        "genotype": "Trem2-R47H_NSS",
+        "sex": "Female",
+        "individual_id": "Ind002",
+        "value": 4.98765
+      },
+      {
+        "genotype": "C57BL/6J",
+        "sex": "Male",
+        "individual_id": "Ind003",
+        "value": 3.55555
+      },
+      {
+        "genotype": "C57BL/6J",
+        "sex": "Female",
+        "individual_id": "Ind004",
+        "value": 3.6789
+      },
+      {
+        "genotype": "Trem2-R47H_NSS.5xFAD",
+        "sex": "Male",
+        "individual_id": "Ind005",
+        "value": 6.11111
+      },
+      {
+        "genotype": "Trem2-R47H_NSS.5xFAD",
+        "sex": "Female",
+        "individual_id": "Ind006",
+        "value": 5.88888
+      },
+      {
+        "genotype": "5xFAD",
+        "sex": "Male",
+        "individual_id": "Ind007",
+        "value": 4.44444
+      },
+      {
+        "genotype": "5xFAD",
+        "sex": "Female",
+        "individual_id": "Ind008",
+        "value": 4.22222
+      }
+    ]
+  }
+]

--- a/tests/transform/test_rna_de_individual.py
+++ b/tests/transform/test_rna_de_individual.py
@@ -285,7 +285,7 @@ class TestCreateOutputEntryFromGroup:
 
     def test_basic_output_entry(self) -> None:
         """Test basic output entry creation with all fields."""
-        group_key = ("ENSMUSG00000000001", "Cortex", "", "Model_A")
+        group_key = ("ENSMUSG00000000001", "Cortex", "Model_A")
         group = pd.DataFrame(
             {
                 "age": ["6 months", "6 months"],
@@ -295,6 +295,7 @@ class TestCreateOutputEntryFromGroup:
                 "individualid": ["Ind001", "Ind002"],
                 "expression": [5.0, 3.0],
                 "result_order": [2, 1],
+                "model_group": ["", ""],
                 "effective_model_group": ["Model_A", "Model_A"],
             }
         )
@@ -333,7 +334,7 @@ class TestCreateOutputEntryFromGroup:
 
     def test_jax_tissue_mapping(self) -> None:
         """Test that JAX tissue name is mapped correctly."""
-        group_key = ("ENSMUSG00000000001", "Right Cerebral Hemisphere", "", "Model_A")
+        group_key = ("ENSMUSG00000000001", "Right Cerebral Hemisphere", "Model_A")
         group = pd.DataFrame(
             {
                 "age": ["6 months"],
@@ -343,6 +344,7 @@ class TestCreateOutputEntryFromGroup:
                 "individualid": ["Ind001"],
                 "expression": [5.0],
                 "result_order": [2],
+                "model_group": [""],
                 "effective_model_group": ["Model_A"],
             }
         )
@@ -364,7 +366,7 @@ class TestCreateOutputEntryFromGroup:
 
     def test_matched_control_determination(self) -> None:
         """Test that matched control is the genotype with minimum result_order."""
-        group_key = ("ENSMUSG00000000001", "Cortex", "GroupX", "Model_B")
+        group_key = ("ENSMUSG00000000001", "Cortex", "GroupX")
         group = pd.DataFrame(
             {
                 "age": ["6 months", "6 months", "6 months"],
@@ -374,6 +376,7 @@ class TestCreateOutputEntryFromGroup:
                 "individualid": ["Ind001", "Ind002", "Ind003"],
                 "expression": [5.0, 3.0, 6.0],
                 "result_order": [2, 1, 3],
+                "model_group": ["GroupX", "GroupX", "GroupX"],
                 "effective_model_group": ["GroupX", "GroupX", "GroupX"],
             }
         )
@@ -405,8 +408,8 @@ class TestCreateOutputEntryFromGroup:
 
     def test_model_group_handling(self) -> None:
         """Test that model_group is properly set (null for empty, value for non-empty)."""
-        # Test with empty model_group
-        group_key = ("ENSMUSG00000000001", "Cortex", "", "Model_A")
+        # Test with empty model_group (effective_model_group falls back to model name)
+        group_key = ("ENSMUSG00000000001", "Cortex", "Model_A")
         group = pd.DataFrame(
             {
                 "age": ["6 months"],
@@ -416,6 +419,7 @@ class TestCreateOutputEntryFromGroup:
                 "individualid": ["Ind001"],
                 "expression": [5.0],
                 "result_order": [2],
+                "model_group": [""],
                 "effective_model_group": ["Model_A"],
             }
         )
@@ -436,7 +440,7 @@ class TestCreateOutputEntryFromGroup:
         assert result[0]["model_group"] is None
 
         # Test with non-empty model_group
-        group_key = ("ENSMUSG00000000001", "Cortex", "GroupX", "Model_B")
+        group_key = ("ENSMUSG00000000001", "Cortex", "GroupX")
         group = pd.DataFrame(
             {
                 "age": ["6 months"],
@@ -446,6 +450,7 @@ class TestCreateOutputEntryFromGroup:
                 "individualid": ["Ind001"],
                 "expression": [5.0],
                 "result_order": [2],
+                "model_group": ["GroupX"],
                 "effective_model_group": ["GroupX"],
             }
         )
@@ -465,7 +470,7 @@ class TestCreateOutputEntryFromGroup:
 
     def test_multiple_ages_creates_multiple_entries(self) -> None:
         """Test that multiple ages create separate output entries."""
-        group_key = ("ENSMUSG00000000001", "Cortex", "", "Model_A")
+        group_key = ("ENSMUSG00000000001", "Cortex", "Model_A")
         group = pd.DataFrame(
             {
                 "age": ["3 months", "6 months"],
@@ -475,6 +480,7 @@ class TestCreateOutputEntryFromGroup:
                 "individualid": ["Ind001", "Ind002"],
                 "expression": [4.0, 5.0],
                 "result_order": [2, 2],
+                "model_group": ["", ""],
                 "effective_model_group": ["Model_A", "Model_A"],
             }
         )
@@ -987,6 +993,72 @@ class TestTransformRnaDeIndividual:
         # Explicitly verify rounding (1.123456789 -> 1.12346, 2.987654321 -> 2.98765)
         assert output_data_sorted[0]["data"][0]["value"] == pytest.approx(1.12346)
         assert output_data_sorted[0]["data"][1]["value"] == pytest.approx(2.98765)
+
+    def test_synthetic_multi_model_data(self) -> None:
+        """Test that models sharing a model_group but split across two input files
+        are combined into a single output entry with all four genotypes.
+
+        This covers the UCI model bug where e.g. Trem2-R47H_NSS and
+        Trem2-R47H_NSS.5xFAD both belong to model_group 'Trem2-R47H_NSS' but
+        their expression data lives in separate files. Before the fix each file
+        produced its own 2-genotype entry; after the fix they produce a single
+        4-genotype entry.
+        """
+        datasets = self._load_synthetic_test_data(
+            [
+                "rnaseq_genotype_label_map.csv",
+                "mouse_gene_metadata.csv",
+                "synthetic_multi_model_file1.csv",
+                "synthetic_multi_model_file2.csv",
+            ]
+        )
+
+        with open(
+            os.path.join(
+                self.data_files_path, "output", "synthetic_multi_model_output.json"
+            )
+        ) as f:
+            expected_data = json.load(f)
+
+        output_data = transform_rna_de_individual(datasets=datasets)
+
+        # Should produce exactly one consolidated entry (one gene, one age)
+        assert len(output_data) == 1
+        entry = output_data[0]
+
+        # Verify metadata
+        assert entry["name"] == "Trem2-R47H_NSS"
+        assert entry["model_group"] == "Trem2-R47H_NSS"
+        assert entry["matched_control"] == "C57BL/6J"
+        assert entry["result_order"] == [
+            "C57BL/6J",
+            "Trem2-R47H_NSS",
+            "5xFAD",
+            "Trem2-R47H_NSS.5xFAD",
+        ]
+
+        # All four genotypes should be present in data
+        genotypes_in_data = {d["genotype"] for d in entry["data"]}
+        assert genotypes_in_data == {
+            "C57BL/6J",
+            "Trem2-R47H_NSS",
+            "5xFAD",
+            "Trem2-R47H_NSS.5xFAD",
+        }
+        assert len(entry["data"]) == 8  # 2 individuals per genotype
+
+        # Full comparison with expected JSON (data order may vary)
+        output_data_sorted = sorted(output_data, key=lambda x: x["ensembl_gene_id"])
+        expected_data_sorted = sorted(expected_data, key=lambda x: x["ensembl_gene_id"])
+        for out_entry, exp_entry in zip(output_data_sorted, expected_data_sorted):
+            assert out_entry["ensembl_gene_id"] == exp_entry["ensembl_gene_id"]
+            assert out_entry["name"] == exp_entry["name"]
+            assert out_entry["model_group"] == exp_entry["model_group"]
+            assert out_entry["matched_control"] == exp_entry["matched_control"]
+            assert out_entry["result_order"] == exp_entry["result_order"]
+            assert sorted(
+                out_entry["data"], key=lambda x: x["individual_id"]
+            ) == sorted(exp_entry["data"], key=lambda x: x["individual_id"])
 
     def test_inconsistent_model_group_values(self) -> None:
         """Test error handling for inconsistent model_group values within the same model.


### PR DESCRIPTION
## Problem

The `rna_de_individual` transform produced incorrect output for UCI models that share a `model_group` but have their expression data split across two separate input files. Specifically, the `Trem2-R47H_NSS` and `Abca7*V1599M` model groups were each represented by two files:

- `UCI_Trem2-R47H_NSS_normalized_expression.csv` (model = `Trem2-R47H_NSS`) — contains C57BL/6J and Trem2-R47H_NSS genotypes
- `UCI_Trem2-R47H_NSS.5XFAD_normalized_expression.csv` (model = `Trem2-R47H_NSS.5xFAD`) — contains 5xFAD and Trem2-R47H_NSS.5xFAD genotypes

The app expects a single output entry per gene/tissue/age with all four genotypes in `data` and the full `result_order` list. Instead, the transform was producing two separate entries, each with only two genotypes:

```
[
  {
    "name": "Trem2-R47H_NSS",
    "model_group": "Trem2-R47H_NSS",
    "result_order": ["C57BL/6J", "Trem2-R47H_NSS", "5xFAD", "Trem2-R47H_NSS.5xFAD"],
    "data": [ ...C57BL/6J and Trem2-R47H_NSS individuals only... ]
  },
  {
    "name": "Trem2-R47H_NSS.5xFAD",
    "model_group": "Trem2-R47H_NSS",
    "result_order": ["C57BL/6J", "Trem2-R47H_NSS", "5xFAD", "Trem2-R47H_NSS.5xFAD"],
    "data": [ ...5xFAD and Trem2-R47H_NSS.5xFAD individuals only... ]
  }
]
```


This caused the app to render two separate plots per age — each with only two populated lanes — instead of one plot with all four genotypes.

Two bugs compounded to produce this result:

1. **File-by-file processing**: `process_data_files` ran each input file through the core transform independently, so data from files belonging to the same model group was never combined.
2. **Groupby included the model name**: `_process_individual_data_file_core` grouped data by `(ensembl_gene_id, tissue, model_group, name)` where `name = model`. Because each file has a different model name, they produced separate output groups even when their `model_group` was identical.

JAX models were unaffected because each JAX model file already contains all genotypes for that model group — there is no cross-file splitting.

## Solution

The fix has three components:

**1. Group input files by `effective_model_group` before processing.**

`transform_rna_de_individual` now uses the `genotype_metadata_dict` to build a `model → effective_model_group` lookup and assigns each input file to its group by inspecting its `model` column. Files are then processed one group at a time: within each group, files are preprocessed individually (validation, filtering, rounding, sex conversion) and then concatenated before being passed to the core transform. After each group is processed, its DataFrames are explicitly deleted and garbage collected, preserving the sequential memory-efficient processing pattern from the original design.

For the common case — files that are their own group — no concatenation happens and the memory behaviour is identical to before. Only files that genuinely need to be combined (currently the two UCI split-file model groups) are held in memory simultaneously, with a worst-case peak overhead of approximately 1.4 GB rather than the 5+ GB that would result from naively concatenating all files at once.

**2. Remove the model name from the groupby key.**

`_process_individual_data_file_core` now groups by `(ensembl_gene_id, tissue, effective_model_group)` instead of including `name` (= `model`). This allows data from multiple model files that share the same `effective_model_group` to be combined into a single output entry.

**3. Derive output fields from `effective_model_group` rather than the raw model name.**

`_create_output_entry_from_group` now accepts a 3-element group key `(ensembl_gene_id, tissue, effective_model_group)`. The `name` output field is set to `effective_model_group` (which equals the explicit `model_group` when set, or the model name when no group is defined). The actual `model_group` output field is read directly from the group DataFrame. The `matched_control` field is resolved from the `genotype_display` column of the row with the minimum `result_order`, which works correctly when data spans multiple models.

A `preprocess_data_file` utility function was also extracted into `rna_de_individual_utils.py` to encapsulate the per-file validation and preprocessing steps that were previously embedded inside `process_data_files`. This allows callers to preprocess files individually and accumulate results without being forced into the callback pattern.

## Testing

**Existing tests (30 passing):** All 29 pre-existing unit and integration tests continue to pass without modification to their assertions. The `TestCreateOutputEntryFromGroup` tests were updated to pass the new 3-element group key and to include a `model_group` column in their test DataFrames, reflecting the changed function signature.

**New integration test — `test_synthetic_multi_model_data`:** Two synthetic input CSV files (`synthetic_multi_model_file1.csv`, `synthetic_multi_model_file2.csv`) replicate the exact UCI split-file structure: both belong to `model_group = Trem2-R47H_NSS`, with the first file containing C57BL/6J and Trem2-R47H_NSS genotypes and the second containing 5xFAD and Trem2-R47H_NSS.5xFAD genotypes. The test asserts:

- Exactly one output entry is produced (not two)
- `name = "Trem2-R47H_NSS"` and `model_group = "Trem2-R47H_NSS"`
- `matched_control = "C57BL/6J"` (lowest `result_order` genotype)
- `result_order = ["C57BL/6J", "Trem2-R47H_NSS", "5xFAD", "Trem2-R47H_NSS.5xFAD"]`
- All four genotypes appear in `data` with the correct individuals

**End-to-end validation against staging data:** A targeted comparison (separating UCI multi-model entries from all others) confirmed:
- All 607,438 non-UCI entries are unchanged in every data field.
- The two UCI model groups (`Trem2-R47H_NSS`, `Abca7*V1599M`) each correctly collapsed from two entries to one, with all four genotypes present in `data`.