### PR TITLE
MG-810: Enhance Disease Correlation heatmap column names

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -327,11 +327,11 @@ dc_dynamic_column_is_exported <- TRUE
 dc_dynamic_column_is_hidden <- FALSE
 
 # Dynamic column names vary by consensus cluster option
-dc_dynamic_names_A <- c("IFG", "PHG", "TCX")
-dc_dynamic_names_B <- c("CBE", "DLPFC", "PHG", "TCX", "FP", "IFG", "STG")
-dc_dynamic_names_C <- c("CBE", "DLPFC", "FP", "IFG", "PHG", "STG", "TCX")
-dc_dynamic_names_D <- c("CBE", "DLPFC", "FP", "IFG", "PHG", "STG", "TCX")
-dc_dynamic_names_E <- c("CBE", "DLPFC", "PHG", "STG", "TCX", "FP")
+dc_dynamic_names_A <- c("IFG module", "PHG module", "TCX module")
+dc_dynamic_names_B <- c("CBE module", "DLPFC module", "PHG module", "TCX module", "FP module", "IFG module", "STG module")
+dc_dynamic_names_C <- c("CBE module", "DLPFC module", "FP module", "IFG module", "PHG module", "STG module", "TCX module")
+dc_dynamic_names_D <- c("CBE module", "DLPFC module", "FP module", "IFG module", "PHG module", "STG module", "TCX-D module")
+dc_dynamic_names_E <- c("CBE module", "DLPFC module", "PHG module", "STG module", "TCX module", "FP module")
 
 get_dc_dynamic_names <- function(cluster_label) {
   if (grepl("Cluster A", cluster_label)) return(dc_dynamic_names_A)

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -4,7 +4,7 @@ title: "MG-402: Create ui_config source file"
 This notebook generates the ui_config.json source file (syn66527739) containing the data required to construct Comparison Tool interfaces for the Model-AD Explorer MVP.
 
 Interfaces that are currently handled by this notebook:
-* Gene Expression
+* Differential Expression
 * Disease Correlation
 * Model Overview
 
@@ -160,16 +160,16 @@ build_filters <- function(filter_defs, filter_values) {
 
 
 # ***************
-# Gene Expression
+# Differential Expression
 # ***************
 
-# Gene Expression Dropdown Menus
+# Differential Expression Dropdown Menus
 # ------------------------------
 ge_menu1 <- c("RNA - DIFFERENTIAL EXPRESSION")
 ge_menu2 <- c("Tissue - Hemibrain", "Tissue - Cerebral Cortex", "Tissue - Hippocampus")
 ge_menu3 <- c("Sex - Females & Males", "Sex - Females", "Sex - Males")
 
-# Gene Expression Columns
+# Differential Expression Columns
 # -------------------------
 # name, type, data_key, tooltip, sort_tooltip, link_url, link_text, is_exported, is_hidden
 #
@@ -197,7 +197,7 @@ ge_dynamic_column_is_hidden <- FALSE
 ge_dynamic_names_jax <- c("4 months", "12 months")
 ge_dynamic_names_uci <- c("4 months", "12 months", "18 months")
 
-# Gene Expression Filters
+# Differential Expression Filters
 # -----------------------
 ge_filters <- data.frame(
   name = c('Biological Domain', 'Model Type', 'Mouse Model'),
@@ -207,7 +207,7 @@ ge_filters <- data.frame(
   stringsAsFactors = FALSE
 )
 
-# Gene Expression Filter values
+# Differential Expression Filter values
 # -----------------------------
 # MG-750: Only include model filter values for models with results for the selected tissue
 
@@ -230,13 +230,7 @@ ge_model_name_filter_vals_hippocampus <- c(
                             'Trem2-R47H_NSS',
                             'Trem2-R47H_NSS.5xFAD')
 
-ge_filter_values <- list(
-  biodomain_filter_vals,
-  model_type_filter_vals,
-  ge_model_name_filter_vals
-)
-
-# Generates Gene Expression ui_config objects
+# Generates Differential Expression ui_config objects
 build_ge_objects <- function() {
 
   # Static columns are always the same
@@ -286,7 +280,7 @@ build_ge_objects <- function() {
     filters <- build_filters(ge_filters, ge_filter_values)
 
     list(
-      page = "Gene Expression",
+      page = "Differential Expression",
       dropdowns = c(combo$menu1, combo$menu2, combo$menu3),
       row_count = gene_expression_row_count,
       columns = columns,

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -330,7 +330,7 @@ dc_dynamic_column_is_hidden <- FALSE
 dc_dynamic_names_A <- c("IFG module", "PHG module", "TCX module")
 dc_dynamic_names_B <- c("CBE module", "DLPFC module", "PHG module", "TCX module", "FP module", "IFG module", "STG module")
 dc_dynamic_names_C <- c("CBE module", "DLPFC module", "FP module", "IFG module", "PHG module", "STG module", "TCX module")
-dc_dynamic_names_D <- c("CBE module", "DLPFC module", "FP module", "IFG module", "PHG module", "STG module", "TCX-D module")
+dc_dynamic_names_D <- c("CBE module", "DLPFC module", "FP module", "IFG module", "PHG module", "STG module", "TCX module")
 dc_dynamic_names_E <- c("CBE module", "DLPFC module", "PHG module", "STG module", "TCX module", "FP module")
 
 get_dc_dynamic_names <- function(cluster_label) {

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -298,11 +298,11 @@ build_ge_objects <- function() {
 # -----------------------------------
 dc_menu1 <- c("CONSENSUS NETWORK MODULES")
 dc_menu2 <- c(
-  "Consensus Cluster A - ECM Organization",
-  "Consensus Cluster B - Immune System",
-  "Consensus Cluster C - Neuronal System",
-  "Consensus Cluster D - Cell Cycle, NMD",
-  "Consensus Cluster E - Organelle Biogenesis, Cellular Stress Response"
+  "Immune System - Consensus Cluster B",
+  "Neuronal System - Consensus Cluster C",
+  "Organelle Biogenesis, Cellular Stress Response - Consensus Cluster E",
+  "Cell Cycle, NMD Consensus Cluster D",
+  "ECM Organization - Consensus Cluster A"
 )
 
 # Disease Correlation Columns

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -463,8 +463,8 @@ mo_columns <- data.frame(
   sort_tooltip = rep(NA, times = 12),
   link_url = rep(NA, times = 12),
   link_text = c(NA, NA, NA, "Results", "Results", "Results", "Results", "View Data", "View Strain", NA, NA, NA),
-  is_exported = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE),
-  is_hidden = c(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE),
+  is_exported = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, TRUE, FALSE),
+  is_hidden = c(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE),
   stringsAsFactors = FALSE
 )
 


### PR DESCRIPTION
# Problem

UAT feedback indicated that the heatmap column names for Disease Correlation are not informative enough.

# Solution

Add 'module' to these column names to ensure users understand that the column represents a gene module derived from a brain region, rather than representing the brain region directly.

Note that this PR contains cumulative changes from 
Note that this PR contains cumulative changes from [MG-830](https://github.com/Sage-Bionetworks/agora-data-tools/pull/279), [MG-812](https://github.com/Sage-Bionetworks/agora-data-tools/pull/280), & [MG-816](https://github.com/Sage-Bionetworks/agora-data-tools/pull/281).

[MG-830]: https://sagebionetworks.jira.com/browse/MG-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-812]: https://sagebionetworks.jira.com/browse/MG-812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MG-816]: https://sagebionetworks.jira.com/browse/MG-816?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ