### PR TITLE
MG-817: Update model_overview transform and ui_config

### DIFF
--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -43,6 +43,7 @@ datasets:
         model: name
         key: dataset_name
         items: evidence_type
+        gene_expression: transcriptomics
       gx_nested_columns:
         - genetic_info
         - biomarkers

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -98,6 +98,7 @@ datasets:
         gene: modified_gene
         ensembl_id: human_ensembl_id
         model: name
+        gene_expression: transcriptomics
 
   - rna_de_aggregate:
       files:

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -25,7 +25,7 @@ datasets:
           id: syn64846805.2
           format: csv
         - name: model_results_info
-          id: syn68377668.4
+          id: syn68377668.5
           format: csv
         - name: immunohisto_measure_order
           id: syn71305327.2
@@ -43,7 +43,6 @@ datasets:
         model: name
         key: dataset_name
         items: evidence_type
-        gene_expression: transcriptomics
       gx_nested_columns:
         - genetic_info
         - biomarkers
@@ -84,7 +83,7 @@ datasets:
       files:
         - <<: *model_info_file
         - name: model_results_info
-          id: syn68377668.4
+          id: syn68377668.5
           format: csv
         - name: allele_info
           id: syn64618791.6
@@ -99,7 +98,6 @@ datasets:
         gene: modified_gene
         ensembl_id: human_ensembl_id
         model: name
-        gene_expression: transcriptomics
 
   - rna_de_aggregate:
       files:

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -71,7 +71,7 @@ datasets:
   - ui_config:
       files:
         - name: ui_config
-          id: syn66527739.29
+          id: syn66527739.30
           format: json
       final_format: json
       destination: *dest

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -43,6 +43,7 @@ datasets:
         model: name
         key: dataset_name
         items: evidence_type
+        gene_expression: transcriptomics
       gx_nested_columns:
         - genetic_info
         - biomarkers
@@ -98,6 +99,7 @@ datasets:
         gene: modified_gene
         ensembl_id: human_ensembl_id
         model: name
+        gene_expression: transcriptomics
 
   - rna_de_aggregate:
       files:

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -25,7 +25,7 @@ datasets:
           id: syn64846805.2
           format: csv
         - name: model_results_info
-          id: syn68377668.4
+          id: syn68377668.5
           format: csv
         - name: immunohisto_measure_order
           id: syn71305327.2
@@ -43,7 +43,6 @@ datasets:
         model: name
         key: dataset_name
         items: evidence_type
-        gene_expression: transcriptomics
       gx_nested_columns:
         - genetic_info
         - biomarkers
@@ -84,7 +83,7 @@ datasets:
       files:
         - <<: *model_info_file
         - name: model_results_info
-          id: syn68377668.4
+          id: syn68377668.5
           format: csv
         - name: allele_info
           id: syn64618791.6
@@ -99,7 +98,6 @@ datasets:
         gene: modified_gene
         ensembl_id: human_ensembl_id
         model: name
-        gene_expression: transcriptomics
 
   - rna_de_aggregate:
       files:

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -71,7 +71,7 @@ datasets:
   - ui_config:
       files:
         - name: ui_config
-          id: syn66527739.29
+          id: syn66527739.30
           format: json
       final_format: json
       destination: *dest

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -447,23 +447,24 @@ build_dc_objects <- function() {
 #
 mo_columns <- data.frame(
   name = c("Model", "Model Type", "Matched Controls",
-           "Gene Expression", "Disease Correlation", "Biomarkers",
+           "Transcriptomics", "Disease Correlation", "Biomarkers",
            "Pathology", "Study Data", "JAX Strain",
            "Center", NA, NA
   ),
   type = c("primary", "text", "text",
-    "link_internal", "link_internal", "link_internal",
-    "link_internal","link_external", "link_external",
-    "link_external", "text", "text"
+           "link_internal", "link_internal", "link_internal",
+           "link_internal","link_external", "link_external",
+           "text", "text", "text"
   ),
-  data_key = c("name", "model_type", "matched_controls", "gene_expression",
-                 "disease_correlation", "biomarkers", "pathology",
-                 "study_data", "jax_strain", "center", "modified_genes", "available_data"),
+  data_key = c("name", "model_type", "matched_controls",
+               "transcriptomics", "disease_correlation", "biomarkers",
+              "pathology", "study_data", "jax_strain",
+              "center", "modified_genes", "available_data"),
   tooltip = c("Mouse Model",  rep(NA, times = 11)),
   sort_tooltip = rep(NA, times = 12),
   link_url = rep(NA, times = 12),
   link_text = c(NA, NA, NA, "Results", "Results", "Results", "Results", "View Data", "View Strain", NA, NA, NA),
-  is_exported = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE, TRUE, FALSE),
+  is_exported = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE),
   is_hidden = c(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE),
   stringsAsFactors = FALSE
 )
@@ -498,7 +499,7 @@ mo_modified_gene_filter_vals <- c('Abca7',
                                'Trem2')
 
 mo_filter_values <- list(
-  c('Biomarkers', 'Disease Correlation', 'Gene Expression', 'Pathology'),
+  c('Biomarkers', 'Disease Correlation', 'Pathology', 'Transcriptomics'),
   c('IU/Jax/Pitt', 'UCI'),
   model_type_filter_vals,
   mo_modified_gene_filter_vals

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -344,13 +344,13 @@ get_dc_dynamic_names <- function(cluster_label) {
 
 # Brain region acronym expansions for tooltips
 dc_tooltip_map <- c(
-  CBE = "Human gene module: Cerebellum",
-  DLPFC = "Human gene module: Dorsolateral Prefrontal Cortex",
-  FP = "Human gene module: Frontal Pole",
-  IFG = "Human gene module: Inferior Frontal Gyrus",
-  PHG = "Human gene module: Parahippocampal Gyrus",
-  STG = "Human gene module: Superior Frontal Gyrus",
-  TCX = "Human gene module: Temporal Cortex"
+  "CBE module" = "Human gene module: Cerebellum",
+  "DLPFC module" = "Human gene module: Dorsolateral Prefrontal Cortex",
+  "FP module" = "Human gene module: Frontal Pole",
+  "IFG module" = "Human gene module: Inferior Frontal Gyrus",
+  "PHG module" = "Human gene module: Parahippocampal Gyrus",
+  "STG module" = "Human gene module: Superior Frontal Gyrus",
+  "TCX module" = "Human gene module: Temporal Cortex"
 )
 
 # Disease Correlation Filters
@@ -421,9 +421,10 @@ build_dc_objects <- function() {
       tooltip_text <- dc_tooltip_map[[name]]
 
       # The data_key values for the disease_correlation dataset are exact matches to the name value
-      build_column(name, dc_dynamic_column_type, data_key = name, tooltip_text, dc_dynamic_column_sort_tooltip,
-                   NA, NA, dc_dynamic_column_is_exported, dc_dynamic_column_is_hidden)
-    })
+      build_column(name, dc_dynamic_column_type, data_key = sub(" module", "", name),
+                   tooltip_text, dc_dynamic_column_sort_tooltip, NA,
+                   NA, dc_dynamic_column_is_exported, dc_dynamic_column_is_hidden
+    )})
 
     # The column ordering is mirrored when a CSV is generated
     columns <- c(list(primary, cluster, age, sex), dynamic_columns, c(list(model_type, matched_control, modified_genes)))
@@ -452,14 +453,14 @@ mo_columns <- data.frame(
            "Center", NA, NA
   ),
   type = c("primary", "text", "text",
-           "link_internal", "link_internal", "link_internal",
-           "link_internal","link_external", "link_external",
-           "text", "text", "text"
+    "link_internal", "link_internal", "link_internal",
+    "link_internal","link_external", "link_external",
+    "text", "text", "text"
   ),
   data_key = c("name", "model_type", "matched_controls",
                "transcriptomics", "disease_correlation", "biomarkers",
-              "pathology", "study_data", "jax_strain",
-              "center", "modified_genes", "available_data"),
+               "pathology", "study_data", "jax_strain",
+               "center", "modified_genes", "available_data"),
   tooltip = c("Mouse Model",  rep(NA, times = 11)),
   sort_tooltip = rep(NA, times = 12),
   link_url = rep(NA, times = 12),

--- a/src/agoradatatools/etl/transform/model_ad_transform_utils.py
+++ b/src/agoradatatools/etl/transform/model_ad_transform_utils.py
@@ -3,7 +3,7 @@ This file contains utility functions that may be used across multiple transforms
 
 Functions:
     process_genetic_info - process a gene information DataFrame into a dictionary for model details/overview
-    build_gene_expression_url - build a URL linking to the gene comparison table for a given study
+    build_transcriptomics_url - build a URL linking to the gene comparison table for a given study
 """
 
 from typing import Any, Dict, List, Union
@@ -77,7 +77,7 @@ def process_genetic_info(
     ].to_dict(orient="records")
 
 
-def build_gene_expression_url(model_row: pd.Series) -> Union[str, None]:
+def build_transcriptomics_url(model_row: pd.Series) -> Union[str, None]:
     """
     Creates the link-url to the gene comparison table for a given model. The default string is
     "comparison/expression?models=<model_name>".
@@ -127,7 +127,7 @@ def build_gene_expression_url(model_row: pd.Series) -> Union[str, None]:
     )
     url = (
         f"comparison/expression?{categories_value}models={models_value}"
-        if bool(model_row["gene_expression"])
+        if bool(model_row["transcriptomics"])
         else None
     )
     return url

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -124,7 +124,7 @@ def transform_model_details(
         how="left",
         on="name",
         validate="one_to_one",
-    ).fillna({"transcriptomics": False, "disease_correlation": False}) # TODO is this going to work?? I had to change a test case to use NONE instead of FALSE...
+    ).fillna({"transcriptomics": False, "disease_correlation": False})
 
     # Ensure jax_id preserves leading zeros by converting to string with proper formatting
     if "jax_id" in model_info_df.columns:

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -10,7 +10,7 @@ import pandas as pd
 from agoradatatools.etl.transform.immunohisto_transform import immunohisto_transform
 from agoradatatools.etl.utils import check_required_datasets_and_columns
 from agoradatatools.etl.transform.model_ad_transform_utils import (
-    build_gene_expression_url,
+    build_transcriptomics_url,
     process_genetic_info,
 )
 
@@ -40,7 +40,7 @@ REQUIRED_INPUT = {
     ],
     "model_results_info": [
         "name",
-        "gene_expression",
+        "transcriptomics",
         "disease_correlation",
         "pathology",
         "biomarkers",
@@ -124,7 +124,7 @@ def transform_model_details(
         how="left",
         on="name",
         validate="one_to_one",
-    ).fillna({"gene_expression": False, "disease_correlation": False})
+    ).fillna({"transcriptomics": False, "disease_correlation": False}) # TODO is this going to work?? I had to change a test case to use NONE instead of FALSE...
 
     # Ensure jax_id preserves leading zeros by converting to string with proper formatting
     if "jax_id" in model_info_df.columns:
@@ -173,7 +173,7 @@ def transform_model_details(
             "alzforum_id": model_row["alzforum_id"],
             "genotype": model_row["genotype"],
             "aliases": model_row["aliases"],
-            "gene_expression": None,
+            "transcriptomics": None,
             "disease_correlation": None,
             "spatial_transcriptomics": None,
             "genetic_info": genetic_info,
@@ -181,8 +181,8 @@ def transform_model_details(
             "pathology": model_pathology,
         }
 
-        # Add gene expression and disease correlation links if they exist
-        model_entry["gene_expression"] = build_gene_expression_url(model_row)
+        # Add transcriptomics and disease correlation links if they exist
+        model_entry["transcriptomics"] = build_transcriptomics_url(model_row)
         model_entry["disease_correlation"] = (
             f"comparison/correlation?models={model_name}"
             if bool(model_row["disease_correlation"])

--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -66,7 +66,7 @@ def get_list_of_available_data(row: Dict[str, Any]) -> List[str]:
         List[str]: A list of available data for the model.
     """
     fields = {
-        "gene_expression": "Gene Expression",
+        "gene_expression": "Transcriptomics",
         "disease_correlation": "Disease Correlation",
         "pathology": "Pathology",
         "biomarkers": "Biomarkers",
@@ -162,8 +162,8 @@ def transform_model_overview(
             gene for gene in modified_genes if gene is not None and str(gene) != "nan"
         ]
 
-        # Build the links first
-        row["gene_expression"] = (
+        # Build the links
+        row["transcriptomics"] = (
             {"link_url": build_gene_expression_url(row)}
             if bool(row["gene_expression"])
             else None
@@ -195,14 +195,7 @@ def transform_model_overview(
             if row["jax_id"]
             else None
         )
-        row["center"] = (
-            {
-                "link_text": row["contributing_group"],
-                "link_url": get_center_link_url(row["contributing_group"]),
-            }
-            if row["contributing_group"]
-            else None
-        )
+        row["center"] = row["contributing_group"]
 
         # Calculate available_data based on which links are actually present
         row["available_data"] = get_list_of_available_data(row)
@@ -219,7 +212,7 @@ def transform_model_overview(
             "name",
             "model_type",
             "matched_controls",
-            "gene_expression",
+            "transcriptomics",
             "disease_correlation",
             "pathology",
             "biomarkers",

--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -11,7 +11,7 @@ from agoradatatools.etl.utils import (
     remove_duplicates_keep_order,
 )
 from agoradatatools.etl.transform.model_ad_transform_utils import (
-    build_gene_expression_url,
+    build_transcriptomics_url,
     process_genetic_info,
 )
 
@@ -32,7 +32,7 @@ REQUIRED_INPUT = {
     ],
     "model_results_info": [
         "name",
-        "gene_expression",
+        "transcriptomics",
         "disease_correlation",
         "pathology",
         "biomarkers",
@@ -66,7 +66,7 @@ def get_list_of_available_data(row: Dict[str, Any]) -> List[str]:
         List[str]: A list of available data for the model.
     """
     fields = {
-        "gene_expression": "Transcriptomics",
+        "transcriptomics": "Transcriptomics",
         "disease_correlation": "Disease Correlation",
         "pathology": "Pathology",
         "biomarkers": "Biomarkers",
@@ -164,8 +164,8 @@ def transform_model_overview(
 
         # Build the links
         row["transcriptomics"] = (
-            {"link_url": build_gene_expression_url(row)}
-            if bool(row["gene_expression"])
+            {"link_url": build_transcriptomics_url(row)}
+            if bool(row["transcriptomics"])
             else None
         )
         row["disease_correlation"] = (

--- a/tests/test_assets/model_details/input/model_details_model_results_info_good_test_input_1.csv
+++ b/tests/test_assets/model_details/input/model_details_model_results_info_good_test_input_1.csv
@@ -1,2 +1,2 @@
-name,gene_expression,disease_correlation,pathology,biomarkers
+name,transcriptomics,disease_correlation,pathology,biomarkers
 3xTg-AD,TRUE,,TRUE,TRUE

--- a/tests/test_assets/model_details/input/model_details_model_results_info_good_test_input_2.csv
+++ b/tests/test_assets/model_details/input/model_details_model_results_info_good_test_input_2.csv
@@ -1,2 +1,2 @@
-name,gene_expression,disease_correlation,pathology,biomarkers
+name,transcriptomics,disease_correlation,pathology,biomarkers
 3xTg-AD,TRUE,TRUE,TRUE,TRUE

--- a/tests/test_assets/model_details/input/model_details_model_results_info_good_test_input_3.csv
+++ b/tests/test_assets/model_details/input/model_details_model_results_info_good_test_input_3.csv
@@ -1,2 +1,2 @@
-name,gene_expression,disease_correlation,pathology,biomarkers
+name,transcriptomics,disease_correlation,pathology,biomarkers
 3xTg-AD,,,,TRUE

--- a/tests/test_assets/model_details/input/model_details_model_results_info_url_test_input.csv
+++ b/tests/test_assets/model_details/input/model_details_model_results_info_url_test_input.csv
@@ -1,4 +1,4 @@
-name,gene_expression,disease_correlation,pathology,biomarkers
+name,transcriptomics,disease_correlation,pathology,biomarkers
 Model_url_default,TRUE,,,
 Model_url_categories,TRUE,,,
 Model_url_models,TRUE,,,

--- a/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_empty_measurements_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "transcriptomics": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -73,7 +73,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_extra_column_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_extra_column_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -431,7 +431,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_extra_columns_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_extra_columns_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "transcriptomics": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -431,7 +431,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_good_test_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "transcriptomics": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -467,7 +467,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_missing_allele_data_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_allele_data_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "transcriptomics": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -446,7 +446,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_missing_allele_info_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_allele_info_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "transcriptomics": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -446,7 +446,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_missing_data_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_data_output.json
@@ -12,7 +12,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "transcriptomics": "comparison/expression?models=3xTg-AD",
     "disease_correlation": "comparison/correlation?models=3xTg-AD",
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -327,7 +327,7 @@
     "alzforum_id": "",
     "genotype": "B6.Cg-Mapttm1(EGFP)Klt Tg(MAPT)8cPdav/J",
     "aliases": [],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_missing_models_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "transcriptomics": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -417,7 +417,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -640,7 +640,7 @@
     "aliases": [
       "New1"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -714,7 +714,7 @@
     "aliases": [
       "New2"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_no_human_match_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "transcriptomics": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -467,7 +467,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_no_matching_alleles_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_no_matching_alleles_output.json
@@ -14,7 +14,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?models=3xTg-AD",
+    "transcriptomics": "comparison/expression?models=3xTg-AD",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [
@@ -467,7 +467,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [

--- a/tests/test_assets/model_details/output/model_details_transform_url_test_good_output.json
+++ b/tests/test_assets/model_details/output/model_details_transform_url_test_good_output.json
@@ -15,7 +15,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": "comparison/expression?models=Model_url_default",
+    "transcriptomics": "comparison/expression?models=Model_url_default",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [],
@@ -37,7 +37,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?categories=category_string&models=Model_url_categories",
+    "transcriptomics": "comparison/expression?categories=category_string&models=Model_url_categories",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [],
@@ -60,7 +60,7 @@
       "hTau",
       "Mapt-/-"
     ],
-    "gene_expression": "comparison/expression?models=model1,model2",
+    "transcriptomics": "comparison/expression?models=model1,model2",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [],
@@ -82,7 +82,7 @@
     "aliases": [
       "3xTg"
     ],
-    "gene_expression": "comparison/expression?categories=category_string&models=model3,model4",
+    "transcriptomics": "comparison/expression?categories=category_string&models=model3,model4",
     "disease_correlation": null,
     "spatial_transcriptomics": null,
     "genetic_info": [],

--- a/tests/test_assets/model_overview/input/model_overview_model_results_info_extra_column_input.csv
+++ b/tests/test_assets/model_overview/input/model_overview_model_results_info_extra_column_input.csv
@@ -1,4 +1,4 @@
-name,gene_expression,disease_correlation,pathology,biomarkers,extra_column
+name,transcriptomics,disease_correlation,pathology,biomarkers,extra_column
 3xTg-AD,TRUE,,TRUE,TRUE,extra_value
 5xFAD (UCI),TRUE,,TRUE,TRUE,extra_value
 APOE4,TRUE,TRUE,,,extra_value

--- a/tests/test_assets/model_overview/input/model_overview_model_results_info_good_test_input.csv
+++ b/tests/test_assets/model_overview/input/model_overview_model_results_info_good_test_input.csv
@@ -1,4 +1,4 @@
-name,gene_expression,disease_correlation,pathology,biomarkers
+name,transcriptomics,disease_correlation,pathology,biomarkers
 3xTg-AD,TRUE,,TRUE,TRUE
 5xFAD (UCI),TRUE,,TRUE,TRUE
 APOE4,TRUE,TRUE,,

--- a/tests/test_assets/model_overview/input/model_overview_model_results_info_missing_column_input.csv
+++ b/tests/test_assets/model_overview/input/model_overview_model_results_info_missing_column_input.csv
@@ -1,4 +1,4 @@
-name,gene_expression,disease_correlation,pathology
+name,transcriptomics,disease_correlation,pathology
 3xTg-AD,TRUE,,TRUE
 5xFAD (UCI),TRUE,,TRUE
 APOE4,TRUE,TRUE,

--- a/tests/test_assets/model_overview/input/model_overview_model_results_info_missing_data_input.csv
+++ b/tests/test_assets/model_overview/input/model_overview_model_results_info_missing_data_input.csv
@@ -1,4 +1,4 @@
-name,gene_expression,disease_correlation,pathology,biomarkers
+name,transcriptomics,disease_correlation,pathology,biomarkers
 3xTg-AD,TRUE,,TRUE,TRUE
 5xFAD (UCI),TRUE,,TRUE,
 APOE4,TRUE,TRUE,,

--- a/tests/test_assets/model_overview/input/model_overview_model_results_info_missing_models_test.csv
+++ b/tests/test_assets/model_overview/input/model_overview_model_results_info_missing_models_test.csv
@@ -1,2 +1,2 @@
-name,gene_expression,disease_correlation,pathology,biomarkers
+name,transcriptomics,disease_correlation,pathology,biomarkers
 3xTg-AD,TRUE,,TRUE,TRUE

--- a/tests/test_assets/model_overview/input/model_overview_model_results_info_no_results_input.csv
+++ b/tests/test_assets/model_overview/input/model_overview_model_results_info_no_results_input.csv
@@ -1,4 +1,4 @@
-name,gene_expression,disease_correlation,pathology,biomarkers
+name,transcriptomics,disease_correlation,pathology,biomarkers
 3xTg-AD,TRUE,,TRUE,TRUE
 5xFAD (UCI),TRUE,,TRUE,TRUE
 APOE4,TRUE,TRUE,,

--- a/tests/test_assets/model_overview/input/model_overview_model_results_info_url_test_input.csv
+++ b/tests/test_assets/model_overview/input/model_overview_model_results_info_url_test_input.csv
@@ -1,4 +1,4 @@
-name,gene_expression,disease_correlation,pathology,biomarkers
+name,transcriptomics,disease_correlation,pathology,biomarkers
 Model_url_default,TRUE,,,
 Model_url_categories,TRUE,,,
 Model_url_models,TRUE,,,

--- a/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_extra_column_output.json
@@ -3,7 +3,7 @@
     "name": "3xTg-AD",
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
@@ -19,17 +19,14 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [
       "App",
       "Mapt",
       "Psen1"
     ],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Pathology",
       "Biomarkers"
     ]
@@ -38,7 +35,7 @@
     "name": "5xFAD (UCI)",
     "model_type": "Familial AD",
     "matched_controls": ["C57BL6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=5xFAD (UCI)"
     },
     "disease_correlation": null,
@@ -54,13 +51,10 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Pathology",
       "Biomarkers"
     ]
@@ -69,7 +63,7 @@
     "name": "APOE4",
     "model_type": "Late Onset AD",
     "matched_controls": ["C57BL6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=APOE4"
     },
     "disease_correlation": {
@@ -83,13 +77,10 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/27894"
     },
-    "center": {
-      "link_text": "IU/JAX/PITT",
-      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
-    },
+    "center": "IU/JAX/PITT",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Disease Correlation"
     ]
   }

--- a/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_good_test_output.json
@@ -3,7 +3,7 @@
     "name": "3xTg-AD",
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
@@ -19,17 +19,14 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [
       "App",
       "Mapt",
       "Psen1"
     ],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Pathology",
       "Biomarkers"
     ]
@@ -38,7 +35,7 @@
     "name": "5xFAD (UCI)",
     "model_type": "Familial AD",
     "matched_controls": ["C57BL6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=5xFAD (UCI)"
     },
     "disease_correlation": null,
@@ -54,13 +51,10 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Pathology",
       "Biomarkers"
     ]
@@ -69,7 +63,7 @@
     "name": "APOE4",
     "model_type": "Late Onset AD",
     "matched_controls": ["C57BL6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=APOE4"
     },
     "disease_correlation": {
@@ -83,13 +77,10 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/27894"
     },
-    "center": {
-      "link_text": "IU/JAX/PITT",
-      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
-    },
+    "center": "IU/JAX/PITT",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Disease Correlation"
     ]
   }

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_data_output.json
@@ -3,7 +3,7 @@
     "name": "3xTg-AD",
     "model_type": "Familial AD",
     "matched_controls": [],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
@@ -19,15 +19,12 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [
       "Psen1"
     ],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Pathology",
       "Biomarkers"
     ]
@@ -36,7 +33,7 @@
     "name": "5xFAD (UCI)",
     "model_type": null,
     "matched_controls": ["C57BL6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=5xFAD (UCI)"
     },
     "disease_correlation": null,
@@ -50,13 +47,10 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Pathology"
     ]
   },
@@ -64,7 +58,7 @@
     "name": "APOE4",
     "model_type": "Late Onset AD",
     "matched_controls": ["C57BL6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=APOE4"
     },
     "disease_correlation": {
@@ -78,13 +72,10 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/27894"
     },
-    "center": {
-      "link_text": "IU/JAX/PITT",
-      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
-    },
+    "center": "IU/JAX/PITT",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Disease Correlation"
     ]
   }

--- a/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_missing_models_output.json
@@ -3,7 +3,7 @@
     "name": "3xTg-AD",
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
@@ -19,17 +19,14 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [
       "APP",
       "Mapt",
       "Psen1"
     ],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Pathology",
       "Biomarkers"
     ]
@@ -38,7 +35,7 @@
     "name": "5xFAD (UCI)",
     "model_type": "Familial AD",
     "matched_controls": ["C57BL6J"],
-    "gene_expression": null,
+    "transcriptomics": null,
     "disease_correlation": null,
     "pathology": null,
     "biomarkers": null,
@@ -48,10 +45,7 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [],
     "available_data": []
   }

--- a/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_no_results_output.json
@@ -3,7 +3,7 @@
     "name": "3xTg-AD",
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=3xTg-AD"
     },
     "disease_correlation": null,
@@ -19,17 +19,14 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [
       "App",
       "Mapt",
       "Psen1"
     ],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Pathology",
       "Biomarkers"
     ]
@@ -38,7 +35,7 @@
     "name": "5xFAD (UCI)",
     "model_type": "Familial AD",
     "matched_controls": ["C57BL6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=5xFAD (UCI)"
     },
     "disease_correlation": null,
@@ -54,13 +51,10 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/8730"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Pathology",
       "Biomarkers"
     ]
@@ -69,7 +63,7 @@
     "name": "APOE4",
     "model_type": "Late Onset AD",
     "matched_controls": ["C57BL6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=APOE4"
     },
     "disease_correlation": {
@@ -83,13 +77,10 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/27894"
     },
-    "center": {
-      "link_text": "IU/JAX/PITT",
-      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
-    },
+    "center": "IU/JAX/PITT",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression",
+      "Transcriptomics",
       "Disease Correlation"
     ]
   }

--- a/tests/test_assets/model_overview/output/model_overview_transform_url_test_good_output.json
+++ b/tests/test_assets/model_overview/output/model_overview_transform_url_test_good_output.json
@@ -3,7 +3,7 @@
     "name": "Model_url_default",
     "model_type": "Tauopathy",
     "matched_controls": ["C57BL/6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=Model_url_default"
     },
     "disease_correlation": null,
@@ -15,20 +15,17 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/5491"
     },
-    "center": {
-      "link_text": "IU/JAX/PITT",
-      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
-    },
+    "center": "IU/JAX/PITT",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression"
+      "Transcriptomics"
     ]
   },
   {
     "name": "Model_url_categories",
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?categories=category_string&models=Model_url_categories"
     },
     "disease_correlation": null,
@@ -40,20 +37,17 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression"
+      "Transcriptomics"
     ]
   },
   {
     "name": "Model_url_models",
     "model_type": "Tauopathy",
     "matched_controls": ["C57BL/6J"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?models=model1,model2"
     },
     "disease_correlation": null,
@@ -65,20 +59,17 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/5491"
     },
-    "center": {
-      "link_text": "IU/JAX/PITT",
-      "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
-    },
+    "center": "IU/JAX/PITT",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression"
+      "Transcriptomics"
     ]
   },
   {
     "name": "Model_url_both",
     "model_type": "Familial AD",
     "matched_controls": ["B6129"],
-    "gene_expression": {
+    "transcriptomics": {
       "link_url": "comparison/expression?categories=category_string&models=model3,model4"
     },
     "disease_correlation": null,
@@ -90,13 +81,10 @@
     "jax_strain": {
       "link_url": "https://jax.org/strain/4807"
     },
-    "center": {
-      "link_text": "UCI",
-      "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/"
-    },
+    "center": "UCI",
     "modified_genes": [],
     "available_data": [
-      "Gene Expression"
+      "Transcriptomics"
     ]
   }
 ]

--- a/tests/transform/test_model_ad_transform_utils.py
+++ b/tests/transform/test_model_ad_transform_utils.py
@@ -6,7 +6,7 @@ import pandas as pd
 import pytest
 
 from agoradatatools.etl.transform.model_ad_transform_utils import (
-    build_gene_expression_url,
+    build_transcriptomics_url,
     process_genetic_info,
 )
 
@@ -207,11 +207,11 @@ class TestProcessGeneticInfo:
         assert output == expected_output
 
 
-class TestBuildGeneExpressionUrl:
+class TestBuildTranscriptomicsUrl:
     """
-    This class is for testing the build_gene_expression_url function for the model_details transform. The function takes
-    a pd.Series object (representing a single row from the model_info file) and builds a URL if the model has gene
-    expression data.
+    This class is for testing the build_transcriptomics_url function for the model_details & model_overview transforms.
+    The function takes a pd.Series object (representing a single row from the model_info file) and builds a URL if the
+    model has transcriptomics data.
     """
 
     @pytest.fixture
@@ -221,7 +221,7 @@ class TestBuildGeneExpressionUrl:
                 "name": "Model",
                 "url_categories_value": "category_string",
                 "url_models_value": "model1,model2",
-                "gene_expression": True,
+                "transcriptomics": True,
             }
         )
 
@@ -230,24 +230,24 @@ class TestBuildGeneExpressionUrl:
         [False, None],
         ids=["Pass with False boolean value", "Pass with NA value"],
     )
-    def test_build_gene_expression_url_no_gene_expression(
+    def test_build_transcriptomics_url_no_transcriptomics(
         self, false_val: bool, url_test_model: pd.Series
     ) -> None:
         """
-        The function should treat both None and False as gene_expression = False, and return None.
+        The function should treat both None and False as transcriptomics = False, and return None.
         """
-        url_test_model["gene_expression"] = false_val
+        url_test_model["transcriptomics"] = false_val
 
-        url = build_gene_expression_url(url_test_model)
+        url = build_transcriptomics_url(url_test_model)
         assert url is None
 
-    def test_build_gene_expression_url_all_default_values(
+    def test_build_transcriptomics_url_all_default_values(
         self, url_test_model: pd.Series
     ) -> None:
         url_test_model["url_categories_value"] = ""
         url_test_model["url_models_value"] = ""
 
-        url = build_gene_expression_url(url_test_model)
+        url = build_transcriptomics_url(url_test_model)
         assert url == "comparison/expression?models=Model"
 
     @pytest.mark.parametrize(
@@ -255,7 +255,7 @@ class TestBuildGeneExpressionUrl:
         ["", None],
         ids=["Pass with empty string value", "Pass with NA value"],
     )
-    def test_build_gene_expression_url_default_category(
+    def test_build_transcriptomics_url_default_category(
         self, empty_val: str, url_test_model: pd.Series
     ) -> None:
         """
@@ -263,7 +263,7 @@ class TestBuildGeneExpressionUrl:
         """
         url_test_model["url_categories_value"] = empty_val
 
-        url = build_gene_expression_url(url_test_model)
+        url = build_transcriptomics_url(url_test_model)
         assert url == "comparison/expression?models=model1,model2"
 
     @pytest.mark.parametrize(
@@ -271,7 +271,7 @@ class TestBuildGeneExpressionUrl:
         ["", None],
         ids=["Pass with empty string value", "Pass with NA value"],
     )
-    def test_build_gene_expression_url_default_models(
+    def test_build_transcriptomics_url_default_models(
         self, empty_val: str, url_test_model: pd.Series
     ) -> None:
         """
@@ -279,25 +279,25 @@ class TestBuildGeneExpressionUrl:
         """
         url_test_model["url_models_value"] = empty_val
 
-        url = build_gene_expression_url(url_test_model)
+        url = build_transcriptomics_url(url_test_model)
         assert url == "comparison/expression?categories=category_string&models=Model"
 
     @pytest.mark.parametrize(
         "missing_key",
-        ["name", "url_categories_value", "url_models_value", "gene_expression"],
+        ["name", "url_categories_value", "url_models_value", "transcriptomics"],
         ids=[
             "Fail with missing name column",
             "Fail with missing url_categories_value column",
             "Fail with missing url_models_value column",
-            "Fail with missing gene_expression column",
+            "Fail with missing transcriptomics column",
         ],
     )
-    def test_build_gene_expression_url_missing_field(
+    def test_build_transcriptomics_url_missing_field(
         self, missing_key: str, url_test_model: pd.Series
     ) -> None:
         """
         In the transform, the model_info and model_results_info data frames have already been validated to have all the
-        required columns to correctly call build_gene_expression_url. However, we verify anyway that calling the
+        required columns to correctly call build_transcriptomics_url. However, we verify anyway that calling the
         function with missing columns will throw errors.
         """
         url_test_model.pop(missing_key)
@@ -307,4 +307,4 @@ class TestBuildGeneExpressionUrl:
             url_test_model["url_models_value"] = ""
 
         with pytest.raises(KeyError):
-            build_gene_expression_url(url_test_model)
+            build_transcriptomics_url(url_test_model)

--- a/tests/transform/test_model_details.py
+++ b/tests/transform/test_model_details.py
@@ -350,7 +350,7 @@ class TestTransformModelDetails:
         model_results_info_df = pd.DataFrame(
             {
                 "name": pd.Series(dtype="object"),
-                "gene_expression": pd.Series(dtype="object"),
+                "transcriptomics": pd.Series(dtype="object"),
                 "disease_correlation": pd.Series(dtype="object"),
                 "pathology": pd.Series(dtype="object"),
                 "biomarkers": pd.Series(dtype="object"),

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -254,9 +254,9 @@ class TestTransformModelOverview:
             {
                 "name": ["test_model"],
                 "gene_expression": [True],
-                "disease_correlation": [False],
+                "disease_correlation": [None],
                 "pathology": [True],
-                "biomarkers": [False],
+                "biomarkers": [None],
             }
         )
         allele_info = pd.DataFrame(
@@ -294,7 +294,7 @@ class TestTransformModelOverview:
                 "name": "test_model",
                 "model_type": "Familial AD",
                 "matched_controls": ["C57BL6J"],
-                "gene_expression": {
+                "transcriptomics": {
                     "link_url": "comparison/expression?models=test_model"
                 },
                 "disease_correlation": None,
@@ -304,12 +304,9 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
-                "center": {
-                    "link_text": "UCI",
-                    "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/",
-                },
+                "center": "UCI",
                 "modified_genes": ["TestGene"],
-                "available_data": ["Gene Expression", "Pathology"],
+                "available_data": ["Transcriptomics", "Pathology"],
             }
         ]
 
@@ -378,7 +375,7 @@ class TestTransformModelOverview:
                 "name": "test_model",
                 "model_type": "Familial AD",
                 "matched_controls": [],
-                "gene_expression": None,
+                "transcriptomics": None,
                 "disease_correlation": None,
                 "pathology": None,
                 "biomarkers": None,
@@ -386,10 +383,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn123456"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/123456"},
-                "center": {
-                    "link_text": "IU/Jax/Pitt",
-                    "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/",
-                },
+                "center": "IU/Jax/Pitt",
                 "modified_genes": [],
                 "available_data": [],
             }
@@ -421,10 +415,10 @@ class TestTransformModelOverview:
         model_results_info = pd.DataFrame(
             {
                 "name": ["model1", "model2"],
-                "gene_expression": [True, False],
-                "disease_correlation": [False, True],
+                "gene_expression": [True, None],
+                "disease_correlation": [None, True],
                 "pathology": [True, True],
-                "biomarkers": [False, True],
+                "biomarkers": [None, True],
             }
         )
         allele_info = pd.DataFrame(
@@ -470,7 +464,7 @@ class TestTransformModelOverview:
                 "name": "model1",
                 "model_type": "Familial AD",
                 "matched_controls": ["C57BL6J"],
-                "gene_expression": {"link_url": "comparison/expression?models=model1"},
+                "transcriptomics": {"link_url": "comparison/expression?models=model1"},
                 "disease_correlation": None,
                 "pathology": {"link_url": "models/model1/pathology"},
                 "biomarkers": None,
@@ -478,18 +472,15 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn111"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/111"},
-                "center": {
-                    "link_text": "UCI",
-                    "link_url": "http://model-ad.org/uci-disease-model-development-and-phenotyping-dmp/",
-                },
+                "center": "UCI",
                 "modified_genes": ["Gene1", "Gene2"],
-                "available_data": ["Gene Expression", "Pathology"],
+                "available_data": ["Transcriptomics", "Pathology"],
             },
             {
                 "name": "model2",
                 "model_type": "Tauopathy",
                 "matched_controls": ["B6129", "B6130"],
-                "gene_expression": None,
+                "transcriptomics": None,
                 "disease_correlation": {
                     "link_url": "comparison/correlation?models=model2"
                 },
@@ -499,10 +490,7 @@ class TestTransformModelOverview:
                     "link_url": "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn222"
                 },
                 "jax_strain": {"link_url": "https://jax.org/strain/222"},
-                "center": {
-                    "link_text": "IU/Jax/Pitt",
-                    "link_url": "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/",
-                },
+                "center": "IU/Jax/Pitt",
                 "modified_genes": ["Gene3"],
                 "available_data": ["Disease Correlation", "Pathology", "Biomarkers"],
             },
@@ -526,7 +514,7 @@ class TestGetListOfAvailableData:
         }
         result = get_list_of_available_data(model)
         assert set(result) == {
-            "Gene Expression",
+            "Transcriptomics",
             "Disease Correlation",
             "Pathology",
             "Biomarkers",
@@ -544,7 +532,21 @@ class TestGetListOfAvailableData:
             "biomarkers": None,
         }
         result = get_list_of_available_data(model)
-        assert set(result) == {"Gene Expression", "Pathology"}
+        assert set(result) == {"Transcriptomics", "Pathology"}
+
+    def test_some_other_data_missing(self):
+        from agoradatatools.etl.transform.model_overview import (
+            get_list_of_available_data,
+        )
+
+        model = {
+            "gene_expression": None,
+            "disease_correlation": {"link_url": "url2"},
+            "pathology": None,
+            "biomarkers": {"link_url": "url1"},
+        }
+        result = get_list_of_available_data(model)
+        assert set(result) == {"Disease Correlation", "Biomarkers"}
 
     def test_all_data_missing(self):
         from agoradatatools.etl.transform.model_overview import (
@@ -581,7 +583,7 @@ class TestGetListOfAvailableData:
             # biomarkers missing
         }
         result = get_list_of_available_data(model)
-        assert result == ["Gene Expression"]
+        assert result == ["Transcriptomics"]
 
 
 class TestGetCenterLinkUrl:

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -4,7 +4,11 @@ import json
 import pandas as pd
 import pytest
 
-from agoradatatools.etl.transform.model_overview import transform_model_overview
+from agoradatatools.etl.transform.model_overview import (
+    get_list_of_available_data,
+    get_center_link_url,
+    transform_model_overview
+)
 
 
 class TestTransformModelOverview:
@@ -502,9 +506,6 @@ class TestTransformModelOverview:
 
 class TestGetListOfAvailableData:
     def test_all_data_present(self):
-        from agoradatatools.etl.transform.model_overview import (
-            get_list_of_available_data,
-        )
 
         model = {
             "transcriptomics": {"link_url": "url1"},
@@ -521,9 +522,6 @@ class TestGetListOfAvailableData:
         }
 
     def test_some_data_missing(self):
-        from agoradatatools.etl.transform.model_overview import (
-            get_list_of_available_data,
-        )
 
         model = {
             "transcriptomics": {"link_url": "url1"},
@@ -533,11 +531,6 @@ class TestGetListOfAvailableData:
         }
         result = get_list_of_available_data(model)
         assert set(result) == {"Transcriptomics", "Pathology"}
-
-    def test_some_other_data_missing(self):
-        from agoradatatools.etl.transform.model_overview import (
-            get_list_of_available_data,
-        )
 
         model = {
             "transcriptomics": None,
@@ -549,9 +542,6 @@ class TestGetListOfAvailableData:
         assert set(result) == {"Disease Correlation", "Biomarkers"}
 
     def test_all_data_missing(self):
-        from agoradatatools.etl.transform.model_overview import (
-            get_list_of_available_data,
-        )
 
         model = {
             "transcriptomics": None,
@@ -563,18 +553,12 @@ class TestGetListOfAvailableData:
         assert result == []
 
     def test_empty_model(self):
-        from agoradatatools.etl.transform.model_overview import (
-            get_list_of_available_data,
-        )
 
         model = {}
         result = get_list_of_available_data(model)
         assert result == []
 
     def test_partial_keys(self):
-        from agoradatatools.etl.transform.model_overview import (
-            get_list_of_available_data,
-        )
 
         model = {
             "transcriptomics": {"link_url": "url1"},
@@ -588,7 +572,6 @@ class TestGetListOfAvailableData:
 
 class TestGetCenterLinkUrl:
     def test_uci_contributing_group(self):
-        from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         result = get_center_link_url("UCI")
         expected = (
@@ -597,7 +580,6 @@ class TestGetCenterLinkUrl:
         assert result == expected
 
     def test_uci_contributing_group_lowercase(self):
-        from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         result = get_center_link_url("uci")
         expected = (
@@ -606,21 +588,18 @@ class TestGetCenterLinkUrl:
         assert result == expected
 
     def test_iu_jax_pitt_contributing_group_lowercase(self):
-        from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         result = get_center_link_url("IU/Jax/Pitt")
         expected = "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
         assert result == expected
 
     def test_iu_jax_pitt_uppercase_contributing_group(self):
-        from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         result = get_center_link_url("IU/JAX/PITT")
         expected = "https://www.model-ad.org/iu-jax-pitt-disease-modeling-project/"
         assert result == expected
 
     def test_invalid_contributing_group_raises_value_error(self):
-        from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         with pytest.raises(
             ValueError, match="Invalid contributing group: InvalidCenter"
@@ -628,19 +607,16 @@ class TestGetCenterLinkUrl:
             get_center_link_url("InvalidCenter")
 
     def test_empty_string_raises_value_error(self):
-        from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         with pytest.raises(ValueError, match="Invalid contributing group: "):
             get_center_link_url("")
 
     def test_none_contributing_group_raises_value_error(self):
-        from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         with pytest.raises(ValueError, match="Invalid contributing group: None"):
             get_center_link_url(None)
 
     def test_partial_matches_raise_value_error(self):
-        from agoradatatools.etl.transform.model_overview import get_center_link_url
 
         # Test partial matches that should not work
         with pytest.raises(ValueError, match="Invalid contributing group: IU/Jax"):

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -191,7 +191,7 @@ class TestTransformModelOverview:
         empty_model_results_info = pd.DataFrame(
             columns=[
                 "name",
-                "gene_expression",
+                "transcriptomics",
                 "disease_correlation",
                 "pathology",
                 "biomarkers",
@@ -253,7 +253,7 @@ class TestTransformModelOverview:
         model_results_info = pd.DataFrame(
             {
                 "name": ["test_model"],
-                "gene_expression": [True],
+                "transcriptomics": [True],
                 "disease_correlation": [None],
                 "pathology": [True],
                 "biomarkers": [None],
@@ -334,7 +334,7 @@ class TestTransformModelOverview:
         model_results_info = pd.DataFrame(
             {
                 "name": ["test_model"],
-                "gene_expression": [None],
+                "transcriptomics": [None],
                 "disease_correlation": [None],
                 "pathology": [None],
                 "biomarkers": [None],
@@ -415,7 +415,7 @@ class TestTransformModelOverview:
         model_results_info = pd.DataFrame(
             {
                 "name": ["model1", "model2"],
-                "gene_expression": [True, None],
+                "transcriptomics": [True, None],
                 "disease_correlation": [None, True],
                 "pathology": [True, True],
                 "biomarkers": [None, True],
@@ -507,7 +507,7 @@ class TestGetListOfAvailableData:
         )
 
         model = {
-            "gene_expression": {"link_url": "url1"},
+            "transcriptomics": {"link_url": "url1"},
             "disease_correlation": {"link_url": "url2"},
             "pathology": {"link_url": "url3"},
             "biomarkers": {"link_url": "url4"},
@@ -526,7 +526,7 @@ class TestGetListOfAvailableData:
         )
 
         model = {
-            "gene_expression": {"link_url": "url1"},
+            "transcriptomics": {"link_url": "url1"},
             "disease_correlation": None,
             "pathology": {"link_url": "url3"},
             "biomarkers": None,
@@ -540,7 +540,7 @@ class TestGetListOfAvailableData:
         )
 
         model = {
-            "gene_expression": None,
+            "transcriptomics": None,
             "disease_correlation": {"link_url": "url2"},
             "pathology": None,
             "biomarkers": {"link_url": "url1"},
@@ -554,7 +554,7 @@ class TestGetListOfAvailableData:
         )
 
         model = {
-            "gene_expression": None,
+            "transcriptomics": None,
             "disease_correlation": None,
             "pathology": None,
             "biomarkers": None,
@@ -577,7 +577,7 @@ class TestGetListOfAvailableData:
         )
 
         model = {
-            "gene_expression": {"link_url": "url1"},
+            "transcriptomics": {"link_url": "url1"},
             # disease_correlation missing
             "pathology": None,
             # biomarkers missing

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -506,9 +506,6 @@ class TestTransformModelOverview:
 
 class TestGetListOfAvailableData:
     def test_all_data_present(self):
-        from agoradatatools.etl.transform.model_overview import (
-            get_list_of_available_data,
-        )
 
         model = {
             "transcriptomics": {"link_url": "url1"},
@@ -525,9 +522,6 @@ class TestGetListOfAvailableData:
         }
 
     def test_some_data_missing(self):
-        from agoradatatools.etl.transform.model_overview import (
-            get_list_of_available_data,
-        )
 
         model = {
             "transcriptomics": {"link_url": "url1"},
@@ -548,9 +542,6 @@ class TestGetListOfAvailableData:
         assert set(result) == {"Disease Correlation", "Biomarkers"}
 
     def test_all_data_missing(self):
-        from agoradatatools.etl.transform.model_overview import (
-            get_list_of_available_data,
-        )
 
         model = {
             "transcriptomics": None,

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -254,9 +254,9 @@ class TestTransformModelOverview:
             {
                 "name": ["test_model"],
                 "transcriptomics": [True],
-                "disease_correlation": [None],
+                "disease_correlation": [False],
                 "pathology": [True],
-                "biomarkers": [None],
+                "biomarkers": [False],
             }
         )
         allele_info = pd.DataFrame(


### PR DESCRIPTION
# Problems

Based on UAT feedback and future plans for the explorer, we want to:

1. Update the Center column from type: link_external to type: text
2. Rename the Gene Expression column to Transcriptomics

# Solution

Coordinated updates across ui_config, custom transform, and transform utility code to:

1. Center column
- Update the `model_overview` transform to populate `center` with a string value, rather than a link structure
- Update `ui_config` to specify that the Center column is `type: text` 
- Update `ui_config` to reenable Center column export (was disabled to suppress exporting link URLs, but now we won't)


2. Transcriptomics column & Omics tile
- Update `model_overview` & `model_details` transforms, shared utility method, and tests to reflect the new name
- Adjust `ui_config.columns`& `ui_config.filters` to  align with the new name

3. Updated ui_config version to [syn66527739.30](https://www.synapse.org/Synapse:syn66527739.30).
This will pick up the new `ui_config` source file version, which includes cumulative changes from this and other UAT feedback tickets (MG-810, MG-812, MG-816, MG-830). 