### PR TITLE
GX fix: don't infer column dtype when calling pd.read_json()

### DIFF
--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -228,7 +228,10 @@ class GreatExpectationsRunner:
 
         logger.info(f"Running data validation on {self.expectation_suite_name}")
 
-        gx_df = pd.read_json(self.dataset_path, dtype=False)
+        # Do not infer dtype from fields like strings that have numbers in them. The .replace is
+        # necessary because without dtype inference, all JSON nulls are read in as pd.NA, which
+        # causes issues with GX expectations expecting these values to be None.
+        gx_df = pd.read_json(self.dataset_path, dtype=False).replace({pd.NA: None})
         if self.nested_columns:
             gx_df = self.convert_nested_columns_to_json(
                 df=gx_df, nested_columns=self.nested_columns

--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -228,7 +228,7 @@ class GreatExpectationsRunner:
 
         logger.info(f"Running data validation on {self.expectation_suite_name}")
 
-        gx_df = pd.read_json(self.dataset_path)
+        gx_df = pd.read_json(self.dataset_path, dtype=False)
         if self.nested_columns:
             gx_df = self.convert_nested_columns_to_json(
                 df=gx_df, nested_columns=self.nested_columns

--- a/tests/test_gx.py
+++ b/tests/test_gx.py
@@ -246,7 +246,7 @@ class TestGreatExpectationsRunner:
             self.good_runner.run()
             patch_check_if_expectation_suite_exists.assert_called_once()
             patch_read_json.assert_called_once_with(
-                self.good_runner.dataset_path,
+                self.good_runner.dataset_path, dtype=False
             )
             patch_convert_nested_columns_to_json.assert_called_once()
             patch_checkpoint_run.assert_called_once()
@@ -281,7 +281,7 @@ class TestGreatExpectationsRunner:
             self.good_runner.run()
             patch_check_if_expectation_suite_exists.assert_called_once()
             patch_read_json.assert_called_once_with(
-                self.good_runner.dataset_path,
+                self.good_runner.dataset_path, dtype=False
             )
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_checkpoint_run.assert_called_once()
@@ -345,7 +345,9 @@ class TestGreatExpectationsRunner:
         ) as patch_set_warnings_and_failures:
             self.good_runner.run()
             patch_check_if_expectation_suite_exists.assert_called_once()
-            patch_read_json.assert_called_once_with(self.good_runner.dataset_path)
+            patch_read_json.assert_called_once_with(
+                self.good_runner.dataset_path, dtype=False
+            )
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_checkpoint_run.assert_called_once()
             patch_get_results_path.assert_called_once()
@@ -379,7 +381,9 @@ class TestGreatExpectationsRunner:
             self.good_runner.upload_folder = None
             self.good_runner.run()
             patch_check_if_expectation_suite_exists.assert_called_once()
-            patch_read_json.assert_called_once_with(self.good_runner.dataset_path)
+            patch_read_json.assert_called_once_with(
+                self.good_runner.dataset_path, dtype=False
+            )
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_checkpoint_run.assert_called_once()
             patch_get_results_path.assert_called_once()


### PR DESCRIPTION
## Problem

We have a column in a Model-AD output (`jax_id`) that should be read in as a string, but because the values inside the strings are all numbers, `pd.read_json()` infers that this column should be an integer and removes leading zeros from the values. This is undesired behavior.

Example json:
```
...
"jax_id": "008730",
...
"jax_id": "035316",
```
Values in pandas data frame:
```
jax_id (int)
8730
35316
```
Currently, we can not write a GX test suite that verifies that each `jax_id` is a 6-character long string of numeric values because of this dtype change.

## Solution

In the gx.py `run` function, calling `pd.read_json()` with `dtype=False` will result in pandas NOT inferring that this string field should be an int, but still reads actual int and float values from the JSON with the correct dtypes. 

Now, JSON that looks like this:
```
...
"jax_id": "008730",
"value": 167.5916274,
...
```
keeps the `jax_id` column as a string with the 0-padding preserved, but still correctly has "float" as the dtype for the value column. 

## Code updates

`gx.py`: added `dtype=False` argument to `pd.read_json()`
`test_gx.py`: updated several tests. Previously they checked for `read_json()` called once with the dataset path and no other arguments. Now they check for `read_json()` called once with dataset path + `dtype=False`

**I have confirmed that all data sets for Agora still pass GX after this change.** All data types appear to be read in correctly and no strings are getting converted to something else. 