### PR TITLE
MG-847: Update Disease Correlation cluster labels

### DIFF
--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -52,7 +52,7 @@ datasets:
   - disease_correlation:
       files:
         - name: disease_correlation_results
-          id: syn65467849.5
+          id: syn65467849.6
           format: csv
         - <<: *model_info_file
         - name: allele_info

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -52,7 +52,7 @@ datasets:
   - disease_correlation:
       files:
         - name: disease_correlation_results
-          id: syn65467849.5
+          id: syn65467849.6
           format: csv
         - <<: *model_info_file
         - name: allele_info

--- a/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
+++ b/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
@@ -83,11 +83,11 @@ disease_correlation_source <- download_file('syn65467849.1', type = "csv")
 Update the Cluster labels to the new display format, and fix 'Biogenesis' typo from legacy explorer data
 ```{r}
 disease_correlation_final <- disease_correlation_source %>% mutate(Cluster = case_when(
-  Cluster == "Consensus Cluster A (ECM organization)" ~ "Consensus Cluster A - ECM Organization",
-  Cluster == "Consensus Cluster B (Immune system)" ~ "Consensus Cluster B - Immune system",
-  Cluster == "Consensus Cluster C (Neuronal system)" ~ "Consensus Cluster C - Neuronal system",
-  Cluster == "Consensus Cluster D (Cell Cycle, NMD)" ~ "Consensus Cluster D - Cell Cycle, NMD",
-  Cluster == "Consensus Cluster E (Organelle Biogensis, Cellular stress response)" ~ "Consensus Cluster E - Organelle Biogenesis, Cellular stress response"
+  Cluster == "Consensus Cluster A (ECM organization)" ~ "ECM Organization - Consensus Cluster A",
+  Cluster == "Consensus Cluster B (Immune system)" ~ "Immune System - Consensus Cluster B",
+  Cluster == "Consensus Cluster C (Neuronal system)" ~ "Neuronal System - Consensus Cluster C",
+  Cluster == "Consensus Cluster D (Cell Cycle, NMD)" ~ "Cell Cycle, NMD Consensus Cluster D",
+  Cluster == "Consensus Cluster E (Organelle Biogensis, Cellular stress response)" ~ "Organelle Biogenesis, Cellular Stress Response - Consensus Cluster E"
 ))
 ```
 


### PR DESCRIPTION
## Problem

MG-816 renamed the Disease Correlation CT's dropdown menu options in ui_config based on UAT feedback, but forgot to update the cluster labels in the related disease_correlation data collection so that the values align properly when querying for the corresponding data.


## Solution

Update the cluster labels in the source file for the disease_correlation data collection. 

This PR updates the Disease Correlation cluster identifiers so that they match the new expected values in the front end by:
- Updating the R notebook used to generate the source data file to align the labels
- Updating the ADT config files to consume a new version of the source file that contains the adjusted labels