### PR TITLE
Bump versions of most RNA DE files to latest version

### DIFF
--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -112,22 +112,22 @@ datasets:
           id: syn66351272.1
           format: csv
         - name: Jax.IU.Pitt_5XFAD_differential_expression
-          id: syn69058660.1
+          id: syn69058660.2
           format: csv
         - name: Jax.IU.Pitt_APOE4.Trem2.R47H_differential_expression
-          id: syn69693082.2
+          id: syn69693082.3
           format: csv
         - name: UCI_3xTg-AD_differential_expression
-          id: syn69058661.1
+          id: syn69058661.2
           format: csv
         - name: UCI_5XFAD_differential_expression
           id: syn69058664.1
           format: csv
         - name: UCI_ABCA7_differential_expression
-          id: syn69058663.2
+          id: syn69058663.3
           format: csv
         - name: UCI_Trem2-R47H_NSS_differential_expression
-          id: syn69058662.2
+          id: syn69058662.3
           format: csv
       final_format: json
       destination: *dest

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -112,22 +112,22 @@ datasets:
           id: syn66351272.1
           format: csv
         - name: Jax.IU.Pitt_5XFAD_differential_expression
-          id: syn69058660.1
+          id: syn69058660.2
           format: csv
         - name: Jax.IU.Pitt_APOE4.Trem2.R47H_differential_expression
-          id: syn69693082.2
+          id: syn69693082.3
           format: csv
         - name: UCI_3xTg-AD_differential_expression
-          id: syn69058661.1
+          id: syn69058661.2
           format: csv
         - name: UCI_5XFAD_differential_expression
           id: syn69058664.1
           format: csv
         - name: UCI_ABCA7_differential_expression
-          id: syn69058663.2
+          id: syn69058663.3
           format: csv
         - name: UCI_Trem2-R47H_NSS_differential_expression
-          id: syn69058662.2
+          id: syn69058662.3
           format: csv
       final_format: json
       destination: *dest


### PR DESCRIPTION
Per [MG-838](https://sagebionetworks.jira.com/browse/MG-838), Jess requested that I add provenance on Synapse to the RNA DE and individual expression files for MODEL-AD.

I incorporated provenance into my pipeline, re-ran the DE/individual expression part, and uploaded the result. However several of the DE files have updated versions now. **The only difference between the previous versions and the most current ones are slight precision differences** in the log2foldchange or padj columns. I think there's an element of randomness to the DESeq2 algorithm somewhere.

Since we round these values to 5 decimals, the data won't look any different in the ADT output. The individual expression files didn't change, and the UCI_5XFAD differential expression file didn't change. Only the differential expression files for 5 of the studies (Jax.IU.Pitt_5XFAD, Jax.IU.Pitt_APOE4.Trem2.R47H, UCI_3xTg-AD, UCI_ABCA7, and UCI_Trem2-R47H_NSS) have new versions.

[MG-838]: https://sagebionetworks.jira.com/browse/MG-838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ