### PR TITLE
AG-1961: Update Sage team membership

### DIFF
--- a/configs/agora_preprod.yaml
+++ b/configs/agora_preprod.yaml
@@ -198,7 +198,7 @@ datasets:
           id: syn12615624.18
           format: csv
         - name: team_member_info
-          id: syn12615633.20
+          id: syn12615633.21
           format: csv
       final_format: json
       custom_transformations: transform_team_info

--- a/configs/agora_prod.yaml
+++ b/configs/agora_prod.yaml
@@ -198,7 +198,7 @@ datasets:
           id: syn12615624.18
           format: csv
         - name: team_member_info
-          id: syn12615633.20
+          id: syn12615633.21
           format: csv
       final_format: json
       custom_transformations: transform_team_info


### PR DESCRIPTION
## Problem
The Sage team (as represented in Agora) is out of date, listing several people that no longer work at Sage. It also does not list several new hires, as well as existing sagers that have only recently started contribute to Agora.

## Solution
I've updated the team_member_info source file to list the correct sagers. This PR adjusts the source file version in configs so that we pick up the new team members the next time we reprocessed.