### PR TITLE
MG-851: GIANT PR, SPLITTING INTO SMALLER PIECES

### DIFF
--- a/src/agoradatatools/etl/transform/biodomain_info.py
+++ b/src/agoradatatools/etl/transform/biodomain_info.py
@@ -1,4 +1,12 @@
+from typing import Dict, List
+
 import pandas as pd
+
+from agoradatatools.etl.utils import check_required_datasets_and_columns
+
+REQUIRED_INPUT: Dict[str, List[str]] = {
+    "genes_biodomains": ["name"],
+}
 
 
 def transform_biodomain_info(datasets: dict) -> pd.DataFrame:
@@ -12,6 +20,8 @@ def transform_biodomain_info(datasets: dict) -> pd.DataFrame:
     Returns:
         pd.DataFrame: 1-column DataFrame with column "name"
     """
+    check_required_datasets_and_columns(datasets, REQUIRED_INPUT)
+
     genes_biodomains = datasets["genes_biodomains"]
     biodomain_info = (
         genes_biodomains["name"]

--- a/src/agoradatatools/etl/transform/disease_correlation.py
+++ b/src/agoradatatools/etl/transform/disease_correlation.py
@@ -8,6 +8,8 @@ from typing import Dict, List, Any
 import re
 
 from agoradatatools.etl.utils import (
+    ColumnRule,
+    check_column_rules,
     check_required_datasets_and_columns,
     flatten_list,
     remove_duplicates_keep_order,
@@ -41,6 +43,12 @@ REQUIRED_INPUT = {
         "gene_symbol",
         "human_ensembl_id",
     ],
+}
+
+COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
+    "disease_correlation_results": {
+        "mouse_model": [ColumnRule(rule="not_empty")],
+    },
 }
 
 
@@ -250,6 +258,7 @@ def transform_disease_correlation(
         ValueError: If required datasets are missing or if required columns are missing from any dataset.
     """
     check_required_datasets_and_columns(datasets, required_input)
+    check_column_rules(datasets, COLUMN_RULES)
 
     # Load datasets and prepare lookups if necessary
     disease_correlation_df = datasets["disease_correlation_results"].fillna("")

--- a/src/agoradatatools/etl/transform/gene_info.py
+++ b/src/agoradatatools/etl/transform/gene_info.py
@@ -4,8 +4,6 @@ import numpy as np
 import pandas as pd
 
 from agoradatatools.etl.utils import (
-    ColumnRule,
-    check_column_rules,
     check_required_datasets_and_columns,
     nest_fields,
 )
@@ -27,12 +25,6 @@ REQUIRED_INPUT: Dict[str, List[str]] = {
     "ensg_to_uniprot_mapping": ["ensembl_gene_id", "uniprotkb_accessions"],
 }
 
-COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
-    "diff_exp_data": {
-        "ensembl_gene_id": [ColumnRule(rule="not_empty")],
-    },
-}
-
 
 def transform_gene_info(
     datasets: dict, adjusted_p_value_threshold: float, protein_level_threshold: float
@@ -42,7 +34,6 @@ def transform_gene_info(
     Each dataset will be left_joined onto gene_info, starting with gene_metadata.
     """
     check_required_datasets_and_columns(datasets, REQUIRED_INPUT)
-    check_column_rules(datasets, COLUMN_RULES)
 
     gene_metadata = datasets["gene_metadata"]
     igap = datasets["igap"]

--- a/src/agoradatatools/etl/transform/gene_info.py
+++ b/src/agoradatatools/etl/transform/gene_info.py
@@ -1,8 +1,37 @@
+from typing import Dict, List
+
 import numpy as np
 import pandas as pd
 
-from agoradatatools.etl.utils import nest_fields
+from agoradatatools.etl.utils import (
+    ColumnRule,
+    check_column_rules,
+    check_required_datasets_and_columns,
+    nest_fields,
+)
 from agoradatatools.etl import transform
+
+REQUIRED_INPUT: Dict[str, List[str]] = {
+    "gene_metadata": ["ensembl_gene_id"],
+    "igap": ["ensembl_gene_id"],
+    "eqtl": ["ensembl_gene_id"],
+    "proteomics": ["ensembl_gene_id", "uniqid"],
+    "diff_exp_data": ["ensembl_gene_id", "adj_p_val"],
+    "proteomics_tmt": ["ensembl_gene_id", "uniqid"],
+    "proteomics_srm": ["ensembl_gene_id", "uniqid"],
+    "target_list": ["ensembl_gene_id"],
+    "median_expression": ["ensembl_gene_id"],
+    "pharos_classes": ["ensembl_gene_id"],
+    "genes_biodomains": ["ensembl_gene_id", "biodomain"],
+    "tep_adi_info": ["ensembl_gene_id", "hgnc_symbol", "is_adi", "is_tep"],
+    "ensg_to_uniprot_mapping": ["ensembl_gene_id", "uniprotkb_accessions"],
+}
+
+COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
+    "diff_exp_data": {
+        "ensembl_gene_id": [ColumnRule(rule="not_empty")],
+    },
+}
 
 
 def transform_gene_info(
@@ -12,6 +41,9 @@ def transform_gene_info(
     This function will perform transformations and incrementally create a dataset called gene_info.
     Each dataset will be left_joined onto gene_info, starting with gene_metadata.
     """
+    check_required_datasets_and_columns(datasets, REQUIRED_INPUT)
+    check_column_rules(datasets, COLUMN_RULES)
+
     gene_metadata = datasets["gene_metadata"]
     igap = datasets["igap"]
     eqtl = datasets["eqtl"]

--- a/src/agoradatatools/etl/transform/genes_biodomains.py
+++ b/src/agoradatatools/etl/transform/genes_biodomains.py
@@ -1,8 +1,15 @@
-from typing import Union
+from typing import Dict, List, Union
 
 import pandas as pd
 
-from agoradatatools.etl.utils import nest_fields
+from agoradatatools.etl.utils import (
+    check_required_datasets_and_columns,
+    nest_fields,
+)
+
+REQUIRED_INPUT: Dict[str, List[str]] = {
+    "genes_biodomains": ["ensembl_gene_id", "biodomain", "go_terms"],
+}
 
 
 def count_grouped_total(
@@ -51,6 +58,8 @@ def transform_genes_biodomains(datasets: dict) -> pd.DataFrame:
         pd.DataFrame: 2 column DataFrame grouped by "ensembl_gene_id" including
                       a collapsed nested dictionary field "gene_biodomains"
     """
+    check_required_datasets_and_columns(datasets, REQUIRED_INPUT)
+
     genes_biodomains = datasets["genes_biodomains"]
     interesting_columns = ["ensembl_gene_id", "biodomain", "go_terms"]
     genes_biodomains = genes_biodomains[interesting_columns].dropna().drop_duplicates()

--- a/src/agoradatatools/etl/transform/model_details.py
+++ b/src/agoradatatools/etl/transform/model_details.py
@@ -8,7 +8,11 @@ from typing import Any, Dict, List
 import pandas as pd
 
 from agoradatatools.etl.transform.immunohisto_transform import immunohisto_transform
-from agoradatatools.etl.utils import check_required_datasets_and_columns
+from agoradatatools.etl.utils import (
+    ColumnRule,
+    check_column_rules,
+    check_required_datasets_and_columns,
+)
 from agoradatatools.etl.transform.model_ad_transform_utils import (
     build_transcriptomics_url,
     process_genetic_info,
@@ -78,6 +82,12 @@ REQUIRED_INPUT = {
     ],
 }
 
+COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
+    "model_info": {
+        "name": [ColumnRule(rule="not_empty")],
+    },
+}
+
 
 def transform_model_details(
     datasets: Dict[str, pd.DataFrame],
@@ -111,6 +121,7 @@ def transform_model_details(
         ValueError: If required datasets are missing or if required columns are missing from any dataset.
     """
     check_required_datasets_and_columns(datasets, required_input)
+    check_column_rules(datasets, COLUMN_RULES)
 
     # Load and prepare datasets
     allele_info_df = datasets["allele_info"].fillna("")

--- a/src/agoradatatools/etl/transform/model_overview.py
+++ b/src/agoradatatools/etl/transform/model_overview.py
@@ -7,6 +7,8 @@ import pandas as pd
 from typing import Any, Dict, List
 
 from agoradatatools.etl.utils import (
+    ColumnRule,
+    check_column_rules,
     check_required_datasets_and_columns,
     remove_duplicates_keep_order,
 )
@@ -50,6 +52,12 @@ REQUIRED_INPUT = {
         "gene_symbol",
         "human_ensembl_id",
     ],
+}
+
+COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
+    "model_info": {
+        "name": [ColumnRule(rule="not_empty")],
+    },
 }
 
 
@@ -128,6 +136,7 @@ def transform_model_overview(
     """
 
     check_required_datasets_and_columns(datasets, required_input)
+    check_column_rules(datasets, COLUMN_RULES)
 
     model_info = datasets["model_info"]
     model_results_info = datasets["model_results_info"]

--- a/src/agoradatatools/etl/transform/overall_scores.py
+++ b/src/agoradatatools/etl/transform/overall_scores.py
@@ -1,8 +1,37 @@
+from typing import Dict, List
+
 import numpy as np
 import pandas as pd
 
+from agoradatatools.etl.utils import (
+    ColumnRule,
+    check_column_rules,
+    check_required_datasets_and_columns,
+)
+
+REQUIRED_INPUT: Dict[str, List[str]] = {
+    "overall_scores": [
+        "ensg",
+        "hgnc_gene_id",
+        "overall",
+        "geneticsscore",
+        "omicsscore",
+        "isscored_genetics",
+        "isscored_omics",
+    ],
+}
+
+COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
+    "overall_scores": {
+        "ensg": [ColumnRule(rule="not_empty")],
+    },
+}
+
 
 def transform_overall_scores(df: pd.DataFrame) -> pd.DataFrame:
+    check_required_datasets_and_columns({"overall_scores": df}, REQUIRED_INPUT)
+    check_column_rules({"overall_scores": df}, COLUMN_RULES)
+
     interesting_columns = [
         "ensg",
         "hgnc_gene_id",

--- a/src/agoradatatools/etl/transform/proteomics_distribution.py
+++ b/src/agoradatatools/etl/transform/proteomics_distribution.py
@@ -1,6 +1,13 @@
+from typing import List
+
 import pandas as pd
 
 from agoradatatools.etl import utils, transform
+from agoradatatools.etl.utils import check_required_datasets_and_columns
+
+SUPPORTED_PROTEOMICS_TYPES = {"proteomics", "proteomics_tmt", "proteomics_srm"}
+
+_PROTEOMICS_REQUIRED_COLUMNS: List[str] = ["tissue", "log2_fc", "uniqid"]
 
 
 def transform_proteomics_distribution_data(datasets: dict) -> pd.DataFrame:
@@ -16,6 +23,10 @@ def transform_proteomics_distribution_data(datasets: dict) -> pd.DataFrame:
                       containing columns "tissue", "min", "max", "first_quartile",
                       "median", "third_quartile", and "type", where "type" is LFQ or TMT.
     """
+    present = {name for name in datasets if name in SUPPORTED_PROTEOMICS_TYPES}
+    required_input = dict.fromkeys(present, _PROTEOMICS_REQUIRED_COLUMNS)
+    check_required_datasets_and_columns(datasets, required_input)
+
     transformed = []
     for name, dataset in datasets.items():
         # Remove contaminant ("CON__") entries and rows with NA uniqids before calculating distribution

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -39,7 +39,12 @@ from typing import Dict, List, Any
 import logging
 import gc
 
-from agoradatatools.etl.utils import check_required_datasets_and_columns, normalize_zero
+from agoradatatools.etl.utils import (
+    ColumnRule,
+    check_column_rules,
+    check_required_datasets_and_columns,
+    normalize_zero,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -58,6 +63,15 @@ REQUIRED_INPUT = {
         "symbol",
         "ensembl_id",
     ],
+}
+
+COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
+    "rnaseq_genotype_label_map": {
+        "model": [ColumnRule(rule="not_empty")],
+    },
+    "mouse_gene_metadata": {
+        "ensembl_gene_id": [ColumnRule(rule="starts_with", value="ENSMUSG")],
+    },
 }
 
 
@@ -523,6 +537,7 @@ def transform_rna_de_aggregate(
         genes (ENSG*) to ensure only mouse (Mus musculus) data is included in the output.
     """
     check_required_datasets_and_columns(datasets, required_input)
+    check_column_rules(datasets, COLUMN_RULES)
 
     # Pre-compute lookup dictionaries for efficient lookups
     rnaseq_genotype_label_map_df = datasets["rnaseq_genotype_label_map"].fillna("")

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -70,7 +70,7 @@ COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
         "model": [ColumnRule(rule="not_empty")],
     },
     "mouse_gene_metadata": {
-        "ensembl_gene_id": [ColumnRule(rule="starts_with", value="ENSMUSG")],
+        "ensembl_gene_id": [ColumnRule(rule="matches_regex", value="^ENSMUSG")],
     },
 }
 

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -77,7 +77,7 @@ COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
         "display_label": [ColumnRule(rule="not_empty")],
     },
     "mouse_gene_metadata": {
-        "ensembl_gene_id": [ColumnRule(rule="starts_with", value="ENSMUSG")],
+        "ensembl_gene_id": [ColumnRule(rule="matches_regex", value="^ENSMUSG")],
     },
 }
 

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -43,7 +43,12 @@ from typing import Any, Dict, List
 
 import pandas as pd
 
-from agoradatatools.etl.utils import check_required_datasets_and_columns, nest_fields
+from agoradatatools.etl.utils import (
+    ColumnRule,
+    check_column_rules,
+    check_required_datasets_and_columns,
+    nest_fields,
+)
 from agoradatatools.etl.transform.rna_de_individual_utils import (
     validate_model_group_consistency,
     create_gene_metadata_dict,
@@ -63,6 +68,17 @@ REQUIRED_INPUT = {
         "result_order",
     ],
     "mouse_gene_metadata": ["ensembl_gene_id", "gene_symbol"],
+}
+
+COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
+    "rnaseq_genotype_label_map": {
+        "model": [ColumnRule(rule="not_empty")],
+        "model_group": [ColumnRule(rule="not_empty")],
+        "display_label": [ColumnRule(rule="not_empty")],
+    },
+    "mouse_gene_metadata": {
+        "ensembl_gene_id": [ColumnRule(rule="starts_with", value="ENSMUSG")],
+    },
 }
 
 DATA_FILE_REQUIRED_COLUMNS = [
@@ -326,6 +342,7 @@ def transform_rna_de_individual(
     """
     # Step 1: Validate inputs
     check_required_datasets_and_columns(datasets, required_input)
+    check_column_rules(datasets, COLUMN_RULES)
 
     # Step 2: Prepare metadata DataFrames
     # Normalizes genotype label map (NaN/"" → None for model_group, result_order → int)

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -100,8 +100,8 @@ def _determine_result_order(data_file: pd.DataFrame) -> List[str]:
     Operates on a data_file that has already been merged with the genotype label map
     and filtered to a single model_group, so every display_label present is guaranteed
     to exist in the actual data. Empty display_label values are guaranteed not to be
-    present — prepare_genotype_label_map_df raises a ValueError if any are found in
-    the mapping file.
+    present — check_column_rules() raises a ValueError if any are found in the mapping
+    file before this function is called.
 
     Args:
         data_file: DataFrame already merged with the genotype label map and filtered to
@@ -165,12 +165,6 @@ def _process_individual_data_file_core(
         raise ValueError(
             "No rows remained after filtering to mapped genotypes — "
             "all genotypes in this file were absent from the label map."
-        )
-
-    if data_file["model"].isna().any() or data_file["model_group"].isna().any():
-        raise ValueError(
-            "model or model_group is None for some rows. Every model must have a "
-            "non-empty model_group in the rnaseq_genotype_label_map."
         )
 
     # Step 3: Pre-calculate result_order list and matched_control.

--- a/src/agoradatatools/etl/transform/rna_de_individual_utils.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual_utils.py
@@ -91,9 +91,9 @@ def prepare_genotype_label_map_df(df: pd.DataFrame) -> pd.DataFrame:
     """
     Normalize the genotype label map DataFrame.
 
-    Validates that display_label is non-empty for every row (it is a required field).
-    Validates that model_group is non-empty for every row (it is a required field).
-    Casts result_order to int.
+    Casts result_order to int. Content validation (non-empty model, model_group,
+    display_label) is performed upstream by check_column_rules() before this
+    function is called.
 
     Args:
         df: Raw rnaseq_genotype_label_map DataFrame with columns: model, genotype,
@@ -101,9 +101,6 @@ def prepare_genotype_label_map_df(df: pd.DataFrame) -> pd.DataFrame:
 
     Returns:
         Normalized DataFrame with result_order cast to int.
-
-    Raises:
-        ValueError: If any row has an empty or missing display_label or model_group.
 
     Examples:
         >>> df = pd.DataFrame({
@@ -118,16 +115,6 @@ def prepare_genotype_label_map_df(df: pd.DataFrame) -> pd.DataFrame:
         ['GroupA', 'GroupX']
     """
     df = df.copy()
-
-    if df["display_label"].isna().any() or (df["display_label"] == "").any():
-        raise ValueError(
-            "display_label is a required field in rnaseq_genotype_label_map and must not be empty."
-        )
-
-    if df["model_group"].isna().any() or (df["model_group"] == "").any():
-        raise ValueError(
-            "model_group is a required field in rnaseq_genotype_label_map and must not be empty."
-        )
     df["result_order"] = df["result_order"].astype(int)
     return df
 

--- a/src/agoradatatools/etl/transform/rna_de_individual_utils.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual_utils.py
@@ -49,9 +49,9 @@ def validate_model_group_consistency(
 
     None/NaN values are counted as a single distinct value (i.e. "no group assigned")
     rather than being excluded from the uniqueness check. When called after
-    prepare_genotype_label_map_df, None/NaN will not be present since that function
-    rejects empty model_group values; this handles the case where the function is
-    called independently.
+    check_column_rules(), None/NaN will not be present since check_column_rules()
+    rejects empty model_group values upstream; this handles the case where the function
+    is called independently.
 
     Args:
         genotype_label_map_df: DataFrame with 'model' and 'model_group' columns

--- a/src/agoradatatools/etl/transform/rna_distribution.py
+++ b/src/agoradatatools/etl/transform/rna_distribution.py
@@ -1,7 +1,38 @@
+from typing import Dict, List
+
 from agoradatatools.etl import transform, utils
+from agoradatatools.etl.utils import (
+    ColumnRule,
+    check_column_rules,
+    check_required_datasets_and_columns,
+)
+
+REQUIRED_INPUT: Dict[str, List[str]] = {
+    "diff_exp_data": [
+        "ensembl_gene_id",
+        "hgnc_symbol",
+        "logfc",
+        "ci_l",
+        "ci_r",
+        "adj_p_val",
+        "tissue",
+        "study",
+        "model",
+        "sex",
+    ],
+}
+
+COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
+    "diff_exp_data": {
+        "ensembl_gene_id": [ColumnRule(rule="not_empty")],
+    },
+}
 
 
 def transform_rna_distribution_data(datasets: dict):
+    check_required_datasets_and_columns(datasets, REQUIRED_INPUT)
+    check_column_rules(datasets, COLUMN_RULES)
+
     # "datasets" contains the unprocessed RNA-seq data, which needs to go
     # through the same processing as before in order to use it here.
     rna_df = transform.transform_rnaseq_differential_expression(datasets)

--- a/src/agoradatatools/etl/transform/rnaseq_differential_expression.py
+++ b/src/agoradatatools/etl/transform/rnaseq_differential_expression.py
@@ -1,4 +1,37 @@
+from typing import Dict, List
+
+from agoradatatools.etl.utils import (
+    ColumnRule,
+    check_column_rules,
+    check_required_datasets_and_columns,
+)
+
+REQUIRED_INPUT: Dict[str, List[str]] = {
+    "diff_exp_data": [
+        "ensembl_gene_id",
+        "hgnc_symbol",
+        "logfc",
+        "ci_l",
+        "ci_r",
+        "adj_p_val",
+        "tissue",
+        "study",
+        "model",
+        "sex",
+    ],
+}
+
+COLUMN_RULES: Dict[str, Dict[str, List[ColumnRule]]] = {
+    "diff_exp_data": {
+        "ensembl_gene_id": [ColumnRule(rule="not_empty")],
+    },
+}
+
+
 def transform_rnaseq_differential_expression(datasets: dict):
+    check_required_datasets_and_columns(datasets, REQUIRED_INPUT)
+    check_column_rules(datasets, COLUMN_RULES)
+
     diff_exp_data = datasets["diff_exp_data"]
 
     diff_exp_data["study"].replace(

--- a/src/agoradatatools/etl/transform/team_info.py
+++ b/src/agoradatatools/etl/transform/team_info.py
@@ -1,7 +1,18 @@
+from typing import Dict, List
+
 import pandas as pd
+
+from agoradatatools.etl.utils import check_required_datasets_and_columns
+
+REQUIRED_INPUT: Dict[str, List[str]] = {
+    "team_info": ["team"],
+    "team_member_info": ["team"],
+}
 
 
 def transform_team_info(datasets: dict):
+    check_required_datasets_and_columns(datasets, REQUIRED_INPUT)
+
     team_info = datasets["team_info"]
     team_member_info = datasets["team_member_info"]
 

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -1,10 +1,29 @@
-from typing import Union, Dict, Any, List
+from dataclasses import dataclass
+from typing import Union, Dict, Any, List, Literal, Optional
 import re
 
 import numpy as np
 import pandas as pd
 import synapseclient
 import yaml
+
+
+@dataclass
+class ColumnRule:
+    """Describes a single content rule for a DataFrame column.
+
+    Attributes:
+        rule: The type of rule to apply. One of:
+            - "not_empty": every value must be non-null and non-empty string
+            - "starts_with": every value must start with `value`
+            - "contains": every value must contain `value` as a substring
+            - "one_of": every value must be a member of the collection `value`
+        value: The expected prefix, substring, or allowed set, depending on `rule`.
+               Not required for "not_empty".
+    """
+
+    rule: Literal["not_empty", "starts_with", "contains", "one_of"]
+    value: Optional[Any] = None
 
 
 # TODO remove "_" - these utils functions are not only used internally
@@ -304,6 +323,98 @@ def check_required_datasets_and_columns(
                 f"Missing required columns in {dataset_name} dataset: {', '.join(missing_columns)}. "
                 f"Please ensure the {dataset_name} dataset contains all required columns. Columns found: {', '.join(dataset_columns)}."
             )
+
+
+def check_column_rules(
+    datasets: Dict[str, pd.DataFrame],
+    column_rules: Dict[str, Dict[str, List[ColumnRule]]],
+) -> None:
+    """Validate per-column content rules across one or more datasets.
+
+    Iterates over every (dataset, column, rule) triple in `column_rules` and
+    checks that every value in that column satisfies the rule. All violations
+    are collected before raising so callers see every problem in a single error.
+
+    Args:
+        datasets: Dictionary mapping dataset names to their DataFrames.
+        column_rules: Nested mapping of
+            dataset_name -> column_name -> list of ColumnRule objects.
+            Only datasets and columns present in this mapping are checked.
+
+    Raises:
+        ValueError: If any rule is violated. The message lists all violations,
+            each naming the dataset, column, rule, and number of offending rows.
+
+    Example::
+
+        COLUMN_RULES = {
+            "mouse_gene_metadata": {
+                "ensembl_gene_id": [ColumnRule(rule="starts_with", value="ENSMUSG")],
+            },
+            "rnaseq_genotype_label_map": {
+                "model": [ColumnRule(rule="not_empty")],
+                "model_group": [ColumnRule(rule="not_empty")],
+            },
+        }
+        check_column_rules(datasets, COLUMN_RULES)
+    """
+    violations: List[str] = []
+
+    for dataset_name, col_rules in column_rules.items():
+        if dataset_name not in datasets:
+            continue
+        df = datasets[dataset_name]
+
+        for col_name, rules in col_rules.items():
+            if col_name not in df.columns:
+                violations.append(
+                    f"In dataset '{dataset_name}', column '{col_name}' does not exist."
+                )
+                continue
+
+            for rule in rules:
+                if rule.rule == "not_empty":
+                    null_mask = df[col_name].isna()
+                    empty_mask = df[col_name].astype(str).str.strip() == ""
+                    bad_count = (null_mask | empty_mask).sum()
+                    if bad_count > 0:
+                        violations.append(
+                            f"In dataset '{dataset_name}', column '{col_name}': "
+                            f"{bad_count} row(s) violate rule 'not_empty'."
+                        )
+
+                elif rule.rule == "starts_with":
+                    bad_mask = ~df[col_name].str.startswith(rule.value, na=False)
+                    bad_count = bad_mask.sum()
+                    if bad_count > 0:
+                        violations.append(
+                            f"In dataset '{dataset_name}', column '{col_name}': "
+                            f"{bad_count} row(s) violate rule 'starts_with' "
+                            f"(value={rule.value!r})."
+                        )
+
+                elif rule.rule == "contains":
+                    bad_mask = ~df[col_name].str.contains(rule.value, na=False)
+                    bad_count = bad_mask.sum()
+                    if bad_count > 0:
+                        violations.append(
+                            f"In dataset '{dataset_name}', column '{col_name}': "
+                            f"{bad_count} row(s) violate rule 'contains' "
+                            f"(value={rule.value!r})."
+                        )
+
+                elif rule.rule == "one_of":
+                    bad_mask = ~df[col_name].isin(rule.value)
+                    bad_count = bad_mask.sum()
+                    if bad_count > 0:
+                        violations.append(
+                            f"In dataset '{dataset_name}', column '{col_name}': "
+                            f"{bad_count} row(s) violate rule 'one_of' "
+                            f"(value={rule.value!r})."
+                        )
+
+    if violations:
+        raise ValueError("\n".join(violations))
 
 
 def flatten_list(lst: List[Any]) -> List[Any]:

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -325,6 +325,56 @@ def check_required_datasets_and_columns(
             )
 
 
+def _check_single_rule(
+    df: pd.DataFrame,
+    dataset_name: str,
+    col_name: str,
+    rule: ColumnRule,
+) -> List[str]:
+    """Check a single ColumnRule against one column and return any violation messages.
+
+    Args:
+        df: The DataFrame containing the column to check.
+        dataset_name: Name of the dataset (used in violation messages).
+        col_name: Name of the column to validate.
+        rule: The ColumnRule to apply.
+
+    Returns:
+        A list containing a violation message if the rule is broken, or an empty list.
+    """
+    prefix = f"In dataset '{dataset_name}', column '{col_name}': "
+
+    if rule.rule == "not_empty":
+        bad_count = (
+            df[col_name].isna() | (df[col_name].astype(str).str.strip() == "")
+        ).sum()
+        if bad_count > 0:
+            return [f"{prefix}{bad_count} row(s) violate rule 'not_empty'."]
+
+    elif rule.rule == "starts_with":
+        bad_count = (~df[col_name].str.startswith(rule.value, na=False)).sum()
+        if bad_count > 0:
+            return [
+                f"{prefix}{bad_count} row(s) violate rule 'starts_with' (value={rule.value!r})."
+            ]
+
+    elif rule.rule == "contains":
+        bad_count = (~df[col_name].str.contains(rule.value, na=False)).sum()
+        if bad_count > 0:
+            return [
+                f"{prefix}{bad_count} row(s) violate rule 'contains' (value={rule.value!r})."
+            ]
+
+    elif rule.rule == "one_of":
+        bad_count = (~df[col_name].isin(rule.value)).sum()
+        if bad_count > 0:
+            return [
+                f"{prefix}{bad_count} row(s) violate rule 'one_of' (value={rule.value!r})."
+            ]
+
+    return []
+
+
 def check_column_rules(
     datasets: Dict[str, pd.DataFrame],
     column_rules: Dict[str, Dict[str, List[ColumnRule]]],
@@ -373,45 +423,7 @@ def check_column_rules(
                 continue
 
             for rule in rules:
-                if rule.rule == "not_empty":
-                    null_mask = df[col_name].isna()
-                    empty_mask = df[col_name].astype(str).str.strip() == ""
-                    bad_count = (null_mask | empty_mask).sum()
-                    if bad_count > 0:
-                        violations.append(
-                            f"In dataset '{dataset_name}', column '{col_name}': "
-                            f"{bad_count} row(s) violate rule 'not_empty'."
-                        )
-
-                elif rule.rule == "starts_with":
-                    bad_mask = ~df[col_name].str.startswith(rule.value, na=False)
-                    bad_count = bad_mask.sum()
-                    if bad_count > 0:
-                        violations.append(
-                            f"In dataset '{dataset_name}', column '{col_name}': "
-                            f"{bad_count} row(s) violate rule 'starts_with' "
-                            f"(value={rule.value!r})."
-                        )
-
-                elif rule.rule == "contains":
-                    bad_mask = ~df[col_name].str.contains(rule.value, na=False)
-                    bad_count = bad_mask.sum()
-                    if bad_count > 0:
-                        violations.append(
-                            f"In dataset '{dataset_name}', column '{col_name}': "
-                            f"{bad_count} row(s) violate rule 'contains' "
-                            f"(value={rule.value!r})."
-                        )
-
-                elif rule.rule == "one_of":
-                    bad_mask = ~df[col_name].isin(rule.value)
-                    bad_count = bad_mask.sum()
-                    if bad_count > 0:
-                        violations.append(
-                            f"In dataset '{dataset_name}', column '{col_name}': "
-                            f"{bad_count} row(s) violate rule 'one_of' "
-                            f"(value={rule.value!r})."
-                        )
+                violations.extend(_check_single_rule(df, dataset_name, col_name, rule))
 
     if violations:
         raise ValueError("\n".join(violations))

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -15,14 +15,15 @@ class ColumnRule:
     Attributes:
         rule: The type of rule to apply. One of:
             - "not_empty": every value must be non-null and non-empty string
-            - "starts_with": every value must start with `value`
+            - "matches_regex": every value must fully match the regex pattern in `value`
+              (e.g. ``value="^ENSMUSG"`` to enforce a prefix)
             - "contains": every value must contain `value` as a substring
             - "one_of": every value must be a member of the collection `value`
-        value: The expected prefix, substring, or allowed set, depending on `rule`.
+        value: The expected regex pattern, substring, or allowed set, depending on `rule`.
                Not required for "not_empty".
     """
 
-    rule: Literal["not_empty", "starts_with", "contains", "one_of"]
+    rule: Literal["not_empty", "matches_regex", "contains", "one_of"]
     value: Optional[Any] = None
 
 
@@ -351,11 +352,11 @@ def _check_single_rule(
         if bad_count > 0:
             return [f"{prefix}{bad_count} row(s) violate rule 'not_empty'."]
 
-    elif rule.rule == "starts_with":
-        bad_count = (~df[col_name].str.startswith(rule.value, na=False)).sum()
+    elif rule.rule == "matches_regex":
+        bad_count = (~df[col_name].astype(str).str.match(rule.value, na=False)).sum()
         if bad_count > 0:
             return [
-                f"{prefix}{bad_count} row(s) violate rule 'starts_with' (value={rule.value!r})."
+                f"{prefix}{bad_count} row(s) violate rule 'matches_regex' (pattern={rule.value!r})."
             ]
 
     elif rule.rule == "contains":
@@ -399,7 +400,7 @@ def check_column_rules(
 
         COLUMN_RULES = {
             "mouse_gene_metadata": {
-                "ensembl_gene_id": [ColumnRule(rule="starts_with", value="ENSMUSG")],
+                "ensembl_gene_id": [ColumnRule(rule="matches_regex", value="^ENSMUSG")],
             },
             "rnaseq_genotype_label_map": {
                 "model": [ColumnRule(rule="not_empty")],

--- a/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
+++ b/tests/test_assets/rna_de_aggregate/README_synthetic_datasets.md
@@ -239,6 +239,9 @@ When testing, verify:
 15. **Negative padj validation**: Negative adjusted p-values raise ValueError with informative error message
 16. **Log2foldchange normalization**: Negative zero (-0.0) log2foldchange values are normalized to positive zero (0.0) via normalize_zero function
 17. **NaN padj coercion**: NaN adjusted p-values are coerced to 0.0 in output
+18. **Input column rules** (enforced by `check_column_rules()` before processing):
+    - `rnaseq_genotype_label_map.model`: must be non-empty (raises ValueError if null or empty string)
+    - `mouse_gene_metadata.ensembl_gene_id`: must start with `ENSMUSG` (raises ValueError if not)
 
 ## File Structure
 ```

--- a/tests/test_assets/rna_de_individual/README_synthetic_datasets.md
+++ b/tests/test_assets/rna_de_individual/README_synthetic_datasets.md
@@ -146,7 +146,7 @@ Each output JSON file contains the expected transformed data structure:
 3. **TestPreprocessDataFileTypeCasting**: Tests numeric type casting during preprocessing
 4. **TestValidateModelGroupConsistency**: Tests model_group consistency validation
 5. **TestCreateGeneMetadataDict**: Tests gene metadata dictionary creation
-6. **TestPrepareGenotypeLabelMapDf**: Tests label map normalization (None/empty model_group handling)
+6. **TestPrepareGenotypeLabelMapDf**: Tests label map normalization (result_order casting to int). Content validation — non-empty model, model_group, and display_label — is performed upstream by `check_column_rules()` in `transform_rna_de_individual()`.
 7. **TestLogFileProcessingInfo**: Tests file processing log output
 8. **TestValidateDataFileNotEmpty**: Tests empty file error handling
 
@@ -162,6 +162,10 @@ Each output JSON file contains the expected transformed data structure:
 8. **test_synthetic_rounding_precision**: Numeric precision rounding
 9. **test_synthetic_multi_model_data**: Multi-model group (split-file UCI models combined into one output entry)
 10. **test_inconsistent_model_group_values**: Inconsistent model_group error handling
+11. **test_raises_on_empty_model_in_label_map**: `check_column_rules()` rejects empty `model` in label map
+12. **test_raises_on_empty_model_group_in_label_map**: `check_column_rules()` rejects empty `model_group` in label map
+13. **test_raises_on_empty_display_label_in_label_map**: `check_column_rules()` rejects empty `display_label` in label map
+14. **test_raises_on_non_ensmusg_ensembl_gene_id**: `check_column_rules()` rejects non-ENSMUSG IDs in mouse_gene_metadata
 
 ## Notes
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -673,6 +673,159 @@ class TestCheckRequiredDatasetsAndColumns:
             utils.check_required_datasets_and_columns(datasets, self.required_input)
 
 
+class TestCheckColumnRules:
+    def _make_datasets(self, col_data: dict) -> dict:
+        return {"ds": pd.DataFrame(col_data)}
+
+    # ── not_empty ────────────────────────────────────────────────────────────
+
+    def test_not_empty_passes_for_all_non_empty_values(self):
+        datasets = self._make_datasets({"col": ["a", "b", "c"]})
+        utils.check_column_rules(
+            datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
+        )
+
+    def test_not_empty_raises_on_null(self):
+        datasets = self._make_datasets({"col": ["a", None, "c"]})
+        with pytest.raises(ValueError, match="col.*not_empty"):
+            utils.check_column_rules(
+                datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
+            )
+
+    def test_not_empty_raises_on_empty_string(self):
+        datasets = self._make_datasets({"col": ["a", "", "c"]})
+        with pytest.raises(ValueError, match="col.*not_empty"):
+            utils.check_column_rules(
+                datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
+            )
+
+    def test_not_empty_raises_on_whitespace_only_string(self):
+        datasets = self._make_datasets({"col": ["a", "   ", "c"]})
+        with pytest.raises(ValueError, match="col.*not_empty"):
+            utils.check_column_rules(
+                datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
+            )
+
+    # ── starts_with ──────────────────────────────────────────────────────────
+
+    def test_starts_with_passes_for_all_matching_values(self):
+        datasets = self._make_datasets({"col": ["ENSMUSG001", "ENSMUSG002"]})
+        utils.check_column_rules(
+            datasets,
+            {"ds": {"col": [utils.ColumnRule(rule="starts_with", value="ENSMUSG")]}},
+        )
+
+    def test_starts_with_raises_with_correct_count(self):
+        datasets = self._make_datasets({"col": ["ENSMUSG001", "ENSG002", "ENSG003"]})
+        with pytest.raises(ValueError, match="2 row\\(s\\).*starts_with.*ENSMUSG"):
+            utils.check_column_rules(
+                datasets,
+                {
+                    "ds": {
+                        "col": [utils.ColumnRule(rule="starts_with", value="ENSMUSG")]
+                    }
+                },
+            )
+
+    def test_starts_with_treats_null_as_violation(self):
+        datasets = self._make_datasets({"col": ["ENSMUSG001", None]})
+        with pytest.raises(ValueError, match="starts_with"):
+            utils.check_column_rules(
+                datasets,
+                {
+                    "ds": {
+                        "col": [utils.ColumnRule(rule="starts_with", value="ENSMUSG")]
+                    }
+                },
+            )
+
+    # ── contains ─────────────────────────────────────────────────────────────
+
+    def test_contains_passes_for_all_matching_values(self):
+        datasets = self._make_datasets({"col": ["hello world", "world cup"]})
+        utils.check_column_rules(
+            datasets,
+            {"ds": {"col": [utils.ColumnRule(rule="contains", value="world")]}},
+        )
+
+    def test_contains_raises_with_correct_count(self):
+        datasets = self._make_datasets({"col": ["hello world", "goodbye", "adieu"]})
+        with pytest.raises(ValueError, match="2 row\\(s\\).*contains.*world"):
+            utils.check_column_rules(
+                datasets,
+                {"ds": {"col": [utils.ColumnRule(rule="contains", value="world")]}},
+            )
+
+    def test_contains_treats_null_as_violation(self):
+        datasets = self._make_datasets({"col": ["hello world", None]})
+        with pytest.raises(ValueError, match="contains"):
+            utils.check_column_rules(
+                datasets,
+                {"ds": {"col": [utils.ColumnRule(rule="contains", value="world")]}},
+            )
+
+    # ── one_of ───────────────────────────────────────────────────────────────
+
+    def test_one_of_passes_for_all_allowed_values(self):
+        datasets = self._make_datasets({"col": ["male", "female", "male"]})
+        utils.check_column_rules(
+            datasets,
+            {
+                "ds": {
+                    "col": [utils.ColumnRule(rule="one_of", value={"male", "female"})]
+                }
+            },
+        )
+
+    def test_one_of_raises_with_correct_count(self):
+        datasets = self._make_datasets({"col": ["male", "unknown", "other"]})
+        with pytest.raises(ValueError, match="2 row\\(s\\).*one_of"):
+            utils.check_column_rules(
+                datasets,
+                {
+                    "ds": {
+                        "col": [
+                            utils.ColumnRule(rule="one_of", value={"male", "female"})
+                        ]
+                    }
+                },
+            )
+
+    # ── multi-violation collection ────────────────────────────────────────────
+
+    def test_all_violations_collected_in_single_error(self):
+        datasets = {
+            "ds1": pd.DataFrame({"col_a": ["a", None]}),
+            "ds2": pd.DataFrame({"col_b": ["ENSG001", "ENSG002"]}),
+        }
+        column_rules = {
+            "ds1": {"col_a": [utils.ColumnRule(rule="not_empty")]},
+            "ds2": {"col_b": [utils.ColumnRule(rule="starts_with", value="ENSMUSG")]},
+        }
+        with pytest.raises(ValueError) as exc_info:
+            utils.check_column_rules(datasets, column_rules)
+        message = str(exc_info.value)
+        assert "ds1" in message
+        assert "ds2" in message
+
+    # ── missing dataset / column graceful skip ────────────────────────────────
+
+    def test_missing_dataset_in_rules_is_skipped(self):
+        datasets = {"ds": pd.DataFrame({"col": ["a"]})}
+        utils.check_column_rules(
+            datasets,
+            {"nonexistent_ds": {"col": [utils.ColumnRule(rule="not_empty")]}},
+        )
+
+    def test_missing_column_in_rules_reports_violation(self):
+        datasets = {"ds": pd.DataFrame({"other_col": ["a"]})}
+        with pytest.raises(ValueError, match="does not exist"):
+            utils.check_column_rules(
+                datasets,
+                {"ds": {"missing_col": [utils.ColumnRule(rule="not_empty")]}},
+            )
+
+
 class TestFlattenList:
     def test_flatten_list_empty(self):
         assert utils.flatten_list([]) == []

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -706,35 +706,39 @@ class TestCheckColumnRules:
                 datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
             )
 
-    # ── starts_with ──────────────────────────────────────────────────────────
+    # ── matches_regex ─────────────────────────────────────────────────────────
 
-    def test_starts_with_passes_for_all_matching_values(self):
+    def test_matches_regex_passes_for_all_matching_values(self):
         datasets = self._make_datasets({"col": ["ENSMUSG001", "ENSMUSG002"]})
         utils.check_column_rules(
             datasets,
-            {"ds": {"col": [utils.ColumnRule(rule="starts_with", value="ENSMUSG")]}},
+            {"ds": {"col": [utils.ColumnRule(rule="matches_regex", value="^ENSMUSG")]}},
         )
 
-    def test_starts_with_raises_with_correct_count(self):
+    def test_matches_regex_raises_with_correct_count(self):
         datasets = self._make_datasets({"col": ["ENSMUSG001", "ENSG002", "ENSG003"]})
-        with pytest.raises(ValueError, match="2 row\\(s\\).*starts_with.*ENSMUSG"):
+        with pytest.raises(ValueError, match="2 row\\(s\\).*matches_regex.*\\^ENSMUSG"):
             utils.check_column_rules(
                 datasets,
                 {
                     "ds": {
-                        "col": [utils.ColumnRule(rule="starts_with", value="ENSMUSG")]
+                        "col": [
+                            utils.ColumnRule(rule="matches_regex", value="^ENSMUSG")
+                        ]
                     }
                 },
             )
 
-    def test_starts_with_treats_null_as_violation(self):
+    def test_matches_regex_treats_null_as_violation(self):
         datasets = self._make_datasets({"col": ["ENSMUSG001", None]})
-        with pytest.raises(ValueError, match="starts_with"):
+        with pytest.raises(ValueError, match="matches_regex"):
             utils.check_column_rules(
                 datasets,
                 {
                     "ds": {
-                        "col": [utils.ColumnRule(rule="starts_with", value="ENSMUSG")]
+                        "col": [
+                            utils.ColumnRule(rule="matches_regex", value="^ENSMUSG")
+                        ]
                     }
                 },
             )
@@ -800,7 +804,9 @@ class TestCheckColumnRules:
         }
         column_rules = {
             "ds1": {"col_a": [utils.ColumnRule(rule="not_empty")]},
-            "ds2": {"col_b": [utils.ColumnRule(rule="starts_with", value="ENSMUSG")]},
+            "ds2": {
+                "col_b": [utils.ColumnRule(rule="matches_regex", value="^ENSMUSG")]
+            },
         }
         with pytest.raises(ValueError) as exc_info:
             utils.check_column_rules(datasets, column_rules)

--- a/tests/transform/test_disease_correlation.py
+++ b/tests/transform/test_disease_correlation.py
@@ -459,6 +459,45 @@ class TestTransformDiseaseCorrelation:
         with pytest.raises(error_type, match=error_msg):
             transform_disease_correlation(datasets)
 
+    def test_raises_on_empty_mouse_model(self):
+        """Test that an empty mouse_model raises ValueError from check_column_rules."""
+        datasets = {
+            "disease_correlation_results": pd.DataFrame(
+                [
+                    {
+                        "cluster": "Cluster A",
+                        "module": "IFGyellow",
+                        "mouse_model": None,
+                        "sex": "Female",
+                        "age": "4 months",
+                        "correlation": "0.5",
+                        "adjusted_p_value": "0.01",
+                    }
+                ]
+            ),
+            "model_info": pd.DataFrame(
+                [
+                    {
+                        "name": "LOAD1",
+                        "matched_controls": "C57BL6J",
+                        "model_type": "Late Onset AD",
+                    }
+                ]
+            ),
+            "allele_info": pd.DataFrame(
+                [{"name": "LOAD1", "gene": "APOE4", "mgi_allele_id": 5810209}]
+            ),
+            "human_transgene_allele_map": pd.DataFrame(
+                {
+                    "mgi_allele_id": pd.Series(dtype="object"),
+                    "gene_symbol": pd.Series(dtype="object"),
+                    "human_ensembl_id": pd.Series(dtype="object"),
+                }
+            ),
+        }
+        with pytest.raises(ValueError, match="mouse_model.*not_empty"):
+            transform_disease_correlation(datasets)
+
 
 class TestCreateLookup:
     """

--- a/tests/transform/test_model_details.py
+++ b/tests/transform/test_model_details.py
@@ -383,3 +383,66 @@ class TestTransformModelDetails:
         assert (
             model_info_df["jax_id"].iloc[0] == 123
         ), "Original DataFrame should not be modified"
+
+    def test_raises_on_empty_name_in_model_info(self):
+        """Test that an empty name in model_info raises ValueError from check_column_rules."""
+        datasets = {}
+        for dataset_name, file_name in {
+            "model_info": "model_details_model_info_good_test_input.csv",
+        }.items():
+            datasets[dataset_name] = pd.read_csv(
+                os.path.join(self.data_files_path, "input", file_name)
+            )
+        # Add minimal required datasets to pass check_required_datasets_and_columns
+        datasets["allele_info"] = pd.DataFrame(
+            columns=[
+                "name",
+                "modified_gene",
+                "gene_ensembl_id",
+                "allele",
+                "allele_type",
+                "mgi_allele_id",
+            ]
+        )
+        datasets["model_results_info"] = pd.DataFrame(
+            columns=[
+                "name",
+                "transcriptomics",
+                "disease_correlation",
+                "pathology",
+                "biomarkers",
+            ]
+        )
+        datasets["human_transgene_allele_map"] = pd.DataFrame(
+            columns=["mgi_allele_id", "gene_symbol", "human_ensembl_id"]
+        )
+        datasets["immunohisto_measure_order"] = _load_test_measure_order_config()
+        datasets["biomarkers"] = pd.DataFrame(
+            columns=[
+                "name",
+                "evidence_type",
+                "value",
+                "units",
+                "age",
+                "tissue",
+                "sex",
+                "genotype",
+                "individual_id",
+            ]
+        )
+        datasets["pathology"] = pd.DataFrame(
+            columns=[
+                "name",
+                "evidence_type",
+                "value",
+                "units",
+                "age",
+                "tissue",
+                "sex",
+                "genotype",
+                "individual_id",
+            ]
+        )
+        datasets["model_info"].loc[0, "name"] = None
+        with pytest.raises(ValueError, match="name.*not_empty"):
+            transform_model_details(datasets=datasets)

--- a/tests/transform/test_model_overview.py
+++ b/tests/transform/test_model_overview.py
@@ -503,6 +503,27 @@ class TestTransformModelOverview:
         # Compare output with expected
         assert output_data == expected_output
 
+    def test_raises_on_empty_name_in_model_info(self):
+        """Test that an empty name in model_info raises ValueError from check_column_rules."""
+        datasets = {
+            dataset_name: pd.read_csv(
+                os.path.join(
+                    self.data_files_path,
+                    "input",
+                    file_name,
+                )
+            )
+            for dataset_name, file_name in {
+                "model_info": "model_overview_model_info_good_test_input.csv",
+                "model_results_info": "model_overview_model_results_info_good_test_input.csv",
+                "allele_info": "model_overview_allele_info_good_test_input.csv",
+                "human_transgene_allele_map": "model_overview_human_transgene_allele_map_good_test_input.csv",
+            }.items()
+        }
+        datasets["model_info"].loc[0, "name"] = None
+        with pytest.raises(ValueError, match="name.*not_empty"):
+            transform_model_overview(datasets=datasets)
+
 
 class TestGetListOfAvailableData:
     def test_all_data_present(self):

--- a/tests/transform/test_overall_scores.py
+++ b/tests/transform/test_overall_scores.py
@@ -64,3 +64,14 @@ class TestTransformOverallScores:
             scores_df = pd.read_csv(os.path.join(self.data_files_path, "input", input_file), index_col=0)
             overall_scores.transform_overall_scores(df=scores_df)
     """
+
+    def test_raises_on_empty_ensg(self):
+        scores_df = pd.read_csv(
+            os.path.join(
+                self.data_files_path, "input", "test_overall_scores_good_input.csv"
+            ),
+            index_col=0,
+        )
+        scores_df.loc[scores_df.index[0], "ensg"] = None
+        with pytest.raises(ValueError, match="ensg.*not_empty"):
+            overall_scores.transform_overall_scores(df=scores_df)

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -1724,5 +1724,5 @@ class TestTransformRnaDeAggregate:
             ]
         )
         datasets["mouse_gene_metadata"].loc[0, "ensembl_gene_id"] = "ENSG00000000001"
-        with pytest.raises(ValueError, match="ensembl_gene_id.*starts_with.*ENSMUSG"):
+        with pytest.raises(ValueError, match="ensembl_gene_id.*matches_regex.*ENSMUSG"):
             transform_rna_de_aggregate(datasets=datasets)

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -1696,3 +1696,33 @@ class TestTransformRnaDeAggregate:
         assert "Model_A" in error_message
         # Model_B should not be in the error since it's consistent
         assert "Model_B" not in error_message
+
+    def test_raises_on_empty_model_in_label_map(self) -> None:
+        """Test that an empty model value in the label map raises ValueError from check_column_rules."""
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_basic_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+                "synthetic_model_info.csv",
+                "synthetic_biodom_genes_mm.csv",
+            ]
+        )
+        datasets["rnaseq_genotype_label_map"].loc[0, "model"] = None
+        with pytest.raises(ValueError, match="model.*not_empty"):
+            transform_rna_de_aggregate(datasets=datasets)
+
+    def test_raises_on_non_ensmusg_gene_id_in_metadata(self) -> None:
+        """Test that a non-ENSMUSG ensembl_gene_id in mouse_gene_metadata raises ValueError."""
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_basic_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+                "synthetic_model_info.csv",
+                "synthetic_biodom_genes_mm.csv",
+            ]
+        )
+        datasets["mouse_gene_metadata"].loc[0, "ensembl_gene_id"] = "ENSG00000000001"
+        with pytest.raises(ValueError, match="ensembl_gene_id.*starts_with.*ENSMUSG"):
+            transform_rna_de_aggregate(datasets=datasets)

--- a/tests/transform/test_rna_de_individual.py
+++ b/tests/transform/test_rna_de_individual.py
@@ -121,8 +121,6 @@ class TestProcessIndividualDataFileCore:
           message lists every offending age value.
         - test_multiple_tissues_produce_separate_output_entries: Tests that different tissues
           produce one output entry each.
-        - test_none_model_group_raises_value_error: Verifies that None model_group raises a
-          clear ValueError.
         - test_name_equals_model_for_single_model_group: Verifies that name is set to model
           (not model_group) for single-model groups.
     """
@@ -529,44 +527,6 @@ class TestProcessIndividualDataFileCore:
         for entry in result:
             assert entry["ensembl_gene_id"] == "ENSMUSG00000000001"
             assert len(entry["data"]) == 2  # 2 individuals per tissue
-
-    def test_none_model_group_raises_value_error(self) -> None:
-        """Test that None model_group raises a ValueError in _process_individual_data_file_core.
-
-        In normal usage, prepare_genotype_label_map_df rejects None/empty model_group
-        values before this function is called. This test exercises the safety-net check
-        inside _process_individual_data_file_core for callers that bypass that validation.
-        """
-        data_file = pd.DataFrame(
-            {
-                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000001"],
-                "individualid": ["Ind001", "Ind002"],
-                "expression": [5.0, 6.0],
-                "tissue": ["Cortex", "Cortex"],
-                "sex": ["Male", "Female"],
-                "age": ["6 months", "6 months"],
-                "genotype": ["Tg", "Tg"],
-                "model": ["3xTg-AD", "3xTg-AD"],
-            }
-        )
-
-        gene_metadata_dict = {"ENSMUSG00000000001": "Gene1"}
-        genotype_label_map_df = pd.DataFrame(
-            {
-                "model": ["3xTg-AD"],
-                "genotype": ["Tg"],
-                "display_label": ["3xTg-AD"],
-                "result_order": [1],
-                "model_group": [None],
-            }
-        )
-
-        with pytest.raises(
-            ValueError, match="model or model_group is None for some rows"
-        ):
-            _process_individual_data_file_core(
-                data_file, gene_metadata_dict, genotype_label_map_df
-            )
 
     def test_name_equals_model_for_single_model_group(self) -> None:
         """Test that name is set to model (not model_group) for single-model groups.

--- a/tests/transform/test_rna_de_individual.py
+++ b/tests/transform/test_rna_de_individual.py
@@ -1194,3 +1194,55 @@ class TestTransformRnaDeIndividual:
         assert "Each model must have a consistent model_group value" in error_message
         assert "rnaseq_genotype_label_map" in error_message
         assert "APOE4" in error_message
+
+    def test_raises_on_empty_model_in_label_map(self) -> None:
+        """Test that an empty model value in the label map raises ValueError from check_column_rules."""
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_basic_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+            ]
+        )
+        datasets["rnaseq_genotype_label_map"].loc[0, "model"] = None
+        with pytest.raises(ValueError, match="model.*not_empty"):
+            transform_rna_de_individual(datasets=datasets)
+
+    def test_raises_on_empty_model_group_in_label_map(self) -> None:
+        """Test that an empty model_group value in the label map raises ValueError from check_column_rules."""
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_basic_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+            ]
+        )
+        datasets["rnaseq_genotype_label_map"].loc[0, "model_group"] = None
+        with pytest.raises(ValueError, match="model_group.*not_empty"):
+            transform_rna_de_individual(datasets=datasets)
+
+    def test_raises_on_empty_display_label_in_label_map(self) -> None:
+        """Test that an empty display_label value in the label map raises ValueError from check_column_rules."""
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_basic_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+            ]
+        )
+        datasets["rnaseq_genotype_label_map"].loc[0, "display_label"] = None
+        with pytest.raises(ValueError, match="display_label.*not_empty"):
+            transform_rna_de_individual(datasets=datasets)
+
+    def test_raises_on_non_ensmusg_gene_id_in_metadata(self) -> None:
+        """Test that a non-ENSMUSG ensembl_gene_id in mouse_gene_metadata raises ValueError."""
+        datasets = self._load_synthetic_test_data(
+            [
+                "synthetic_basic_data.csv",
+                "synthetic_rnaseq_genotype_label_map.csv",
+                "synthetic_mouse_gene_metadata.csv",
+            ]
+        )
+        datasets["mouse_gene_metadata"].loc[0, "ensembl_gene_id"] = "ENSG00000000001"
+        with pytest.raises(ValueError, match="ensembl_gene_id.*starts_with.*ENSMUSG"):
+            transform_rna_de_individual(datasets=datasets)

--- a/tests/transform/test_rna_de_individual.py
+++ b/tests/transform/test_rna_de_individual.py
@@ -1204,5 +1204,5 @@ class TestTransformRnaDeIndividual:
             ]
         )
         datasets["mouse_gene_metadata"].loc[0, "ensembl_gene_id"] = "ENSG00000000001"
-        with pytest.raises(ValueError, match="ensembl_gene_id.*starts_with.*ENSMUSG"):
+        with pytest.raises(ValueError, match="ensembl_gene_id.*matches_regex.*ENSMUSG"):
             transform_rna_de_individual(datasets=datasets)

--- a/tests/transform/test_rna_de_individual_utils.py
+++ b/tests/transform/test_rna_de_individual_utils.py
@@ -311,36 +311,6 @@ class TestCreateGeneMetadataDict:
 class TestPrepareGenotypeLabelMapDf:
     """Tests for prepare_genotype_label_map_df function."""
 
-    def test_raises_error_for_nan_model_group(self) -> None:
-        """Test that a NaN model_group raises ValueError."""
-        df = pd.DataFrame(
-            {
-                "model": ["Model_A"],
-                "genotype": ["Tg"],
-                "display_label": ["Transgenic"],
-                "model_group": [None],
-                "result_order": [1],
-            }
-        )
-
-        with pytest.raises(ValueError, match="model_group is a required field"):
-            prepare_genotype_label_map_df(df)
-
-    def test_raises_error_for_empty_string_model_group(self) -> None:
-        """Test that an empty string model_group raises ValueError."""
-        df = pd.DataFrame(
-            {
-                "model": ["Model_A"],
-                "genotype": ["Tg"],
-                "display_label": ["Transgenic"],
-                "model_group": [""],
-                "result_order": [1],
-            }
-        )
-
-        with pytest.raises(ValueError, match="model_group is a required field"):
-            prepare_genotype_label_map_df(df)
-
     def test_converts_result_order_to_int(self) -> None:
         """Test that result_order is cast to int."""
         df = pd.DataFrame(
@@ -390,51 +360,6 @@ class TestPrepareGenotypeLabelMapDf:
         result = prepare_genotype_label_map_df(df)
 
         pd.testing.assert_frame_equal(result, df)
-
-    def test_raises_error_for_empty_string_display_label(self) -> None:
-        """Test that an empty string display_label raises ValueError."""
-        df = pd.DataFrame(
-            {
-                "model": ["Model_A"],
-                "genotype": ["Tg"],
-                "display_label": [""],
-                "model_group": ["GroupA"],
-                "result_order": [1],
-            }
-        )
-
-        with pytest.raises(ValueError, match="display_label is a required field"):
-            prepare_genotype_label_map_df(df)
-
-    def test_raises_error_for_nan_display_label(self) -> None:
-        """Test that a NaN display_label raises ValueError."""
-        df = pd.DataFrame(
-            {
-                "model": ["Model_A"],
-                "genotype": ["Tg"],
-                "display_label": [None],
-                "model_group": ["GroupA"],
-                "result_order": [1],
-            }
-        )
-
-        with pytest.raises(ValueError, match="display_label is a required field"):
-            prepare_genotype_label_map_df(df)
-
-    def test_raises_error_for_empty_display_label_in_mixed_rows(self) -> None:
-        """Test that a ValueError is raised when any row has an empty display_label."""
-        df = pd.DataFrame(
-            {
-                "model": ["Model_A", "Model_B"],
-                "genotype": ["Tg", "Carrier"],
-                "display_label": ["Valid Label", ""],
-                "model_group": ["GroupA", "GroupB"],
-                "result_order": [1, 2],
-            }
-        )
-
-        with pytest.raises(ValueError, match="display_label is a required field"):
-            prepare_genotype_label_map_df(df)
 
     def test_valid_display_labels_do_not_raise(self) -> None:
         """Test that non-empty display_labels pass validation without error."""

--- a/tests/transform/test_rna_distribution_data.py
+++ b/tests/transform/test_rna_distribution_data.py
@@ -63,3 +63,17 @@ class TestTransformRnaDistributionData:
             rna_distribution.transform_rna_distribution_data(
                 datasets={"diff_exp_data": input_df}
             )
+
+    def test_raises_on_empty_ensembl_gene_id(self):
+        input_df = pd.read_csv(
+            os.path.join(
+                self.data_files_path,
+                "input",
+                "test_rna_distribution_data_good_input.csv",
+            )
+        )
+        input_df.loc[0, "ensembl_gene_id"] = None
+        with pytest.raises(ValueError, match="ensembl_gene_id.*not_empty"):
+            rna_distribution.transform_rna_distribution_data(
+                datasets={"diff_exp_data": input_df}
+            )

--- a/tests/transform/test_rnaseq_differential_expression.py
+++ b/tests/transform/test_rnaseq_differential_expression.py
@@ -55,3 +55,17 @@ class TestTransformRnaseqDifferentialExpression:
             rnaseq_differential_expression.transform_rnaseq_differential_expression(
                 datasets={"diff_exp_data": input_df}
             )
+
+    def test_raises_on_empty_ensembl_gene_id(self):
+        input_df = pd.read_csv(
+            os.path.join(
+                self.data_files_path,
+                "input",
+                "test_rnaseq_differential_expression_good_input.csv",
+            )
+        )
+        input_df.loc[0, "ensembl_gene_id"] = None
+        with pytest.raises(ValueError, match="ensembl_gene_id.*not_empty"):
+            rnaseq_differential_expression.transform_rnaseq_differential_expression(
+                datasets={"diff_exp_data": input_df}
+            )


### PR DESCRIPTION
# DO NOT REVIEW, THIS PR IS BEING SPLIT INTO SMALLER CHUNKS

## Motivation

`check_required_datasets_and_columns()` in `utils.py` validates that required datasets and their columns are present before a transform runs — but it only checks for *presence*, not *content*. Several transforms had already grown one-off content checks (e.g. `ensembl_gene_id.str.startswith("ENSMUSG")` guards, null checks on `model_group` and `display_label` in `rna_de_individual_utils.py`), but there was no shared, reusable mechanism to express rules like:

- A column value must not be null or empty
- A column value must match a given prefix or substring (e.g. `"ENSMUSG"`)
- A column value must belong to an allowed set of values

Additionally, 9 transforms (`gene_info`, `rnaseq_differential_expression`, `overall_scores`, `proteomics`, `biodomain_info`, `team_info`, `rna_distribution`, `proteomics_distribution`, `genes_biodomains`) were not calling `check_required_datasets_and_columns()` at all, meaning bad input could propagate silently and produce confusing errors deep in the transform logic.

## What Changed

### New utility (`src/agoradatatools/etl/utils.py`)
- Adds a `ColumnRule` dataclass with a `rule` field (`not_empty`, `starts_with`, `contains`, `one_of`) and an optional `value` field for the prefix, substring, or allowed set
- Adds `check_column_rules(datasets, column_rules)` which applies all rules declaratively, collects every violation, and raises a single descriptive `ValueError` naming the dataset, column, rule, and number of offending rows

### Applied to all transforms
- `check_required_datasets_and_columns()` added to the 9 transforms that were missing it
- `check_column_rules()` added to all 15 transforms with a `COLUMN_RULES` constant expressing the meaningful per-column rules for each transform
- Transforms whose existing logic already gracefully handles "imperfect" values (e.g. `dropna()`, `fillna("")`, `na=True` in string filters) do not have redundant `not_empty` rules — those were intentionally excluded to preserve existing behavior

### One-off checks removed
- The `display_label` and `model_group` null/empty guards inside `prepare_genotype_label_map_df` in `rna_de_individual_utils.py` are removed; those rules are now declared in `rna_de_individual.py`'s `COLUMN_RULES` and enforced by `check_column_rules()` at the transform entry point
- A redundant `model`/`model_group` null check inside `_process_individual_data_file_core` is removed, as it was already guaranteed by `check_column_rules()` upstream and by the `dropna(subset=["result_order"])` that precedes it

## Test Plan

- [ ] `TestCheckColumnRules` added to `tests/test_utils.py` — covers all four rule types, happy paths, null/empty violations, mismatched values, and incorrect counts
- [ ] Per-transform `ValueError` tests added to each affected transform test file, verifying that column rule violations are caught at the transform boundary
- [ ] Tests that previously validated the now-removed one-off checks in `prepare_genotype_label_map_df` have been deleted; equivalent coverage is provided by new tests in `test_rna_de_individual.py` via `check_column_rules`
- [ ] Docstrings and README files updated to reflect the new validation location
- [ ] All 478 tests pass