### PR TITLE
MG-851: Add check_column_rules() and _check_single_rule() utilities

### DIFF
--- a/agoradatatools/etl/utils.py
+++ b/agoradatatools/etl/utils.py
@@ -28,6 +28,16 @@ class ColumnRule:
     value: Optional[Any] = None
 
 
+_RULE_VIOLATION_COUNTERS: Dict[
+    str, Any
+] = {
+    "not_empty": lambda s, v: (s.isna() | (s.astype(str).str.strip() == "")).sum(),
+    "matches_regex": lambda s, v: (~s.astype(str).str.match(v, na=False)).sum(),
+    "contains": lambda s, v: (~s.str.contains(v, na=False)).sum(),
+    "one_of": lambda s, v: (~s.isin(v)).sum(),
+}
+
+
 def _check_single_rule(
     df: pd.DataFrame,
     dataset_name: str,
@@ -45,36 +55,14 @@ def _check_single_rule(
     Returns:
         A list containing a violation message if the rule is broken, or an empty list.
     """
+    counter = _RULE_VIOLATION_COUNTERS.get(rule.rule)
+    if counter is None:
+        return []
     prefix = f"In dataset '{dataset_name}', column '{col_name}': "
-
-    if rule.rule == "not_empty":
-        bad_count = (
-            df[col_name].isna() | (df[col_name].astype(str).str.strip() == "")
-        ).sum()
-        if bad_count > 0:
-            return [f"{prefix}{bad_count} row(s) violate rule 'not_empty'."]
-
-    elif rule.rule == "matches_regex":
-        bad_count = (~df[col_name].astype(str).str.match(rule.value, na=False)).sum()
-        if bad_count > 0:
-            return [
-                f"{prefix}{bad_count} row(s) violate rule 'matches_regex' (pattern={rule.value!r})."
-            ]
-
-    elif rule.rule == "contains":
-        bad_count = (~df[col_name].str.contains(rule.value, na=False)).sum()
-        if bad_count > 0:
-            return [
-                f"{prefix}{bad_count} row(s) violate rule 'contains' (value={rule.value!r})."
-            ]
-
-    elif rule.rule == "one_of":
-        bad_count = (~df[col_name].isin(rule.value)).sum()
-        if bad_count > 0:
-            return [
-                f"{prefix}{bad_count} row(s) violate rule 'one_of' (value={rule.value!r})."
-            ]
-
+    bad_count = counter(df[col_name], rule.value)
+    value_detail = "" if rule.value is None else f" (value={rule.value!r})"
+    if bad_count > 0:
+        return [f"{prefix}{bad_count} row(s) violate rule '{rule.rule}'{value_detail}."]
     return []
 
 

--- a/agoradatatools/etl/utils.py
+++ b/agoradatatools/etl/utils.py
@@ -1,7 +1,135 @@
+from dataclasses import dataclass
+from typing import Any, Dict, List, Literal, Optional
+import re
+
+import pandas as pd
 import synapseclient
 import yaml
 import errno
 import sys
+
+
+@dataclass
+class ColumnRule:
+    """Describes a single content rule for a DataFrame column.
+
+    Attributes:
+        rule: The type of rule to apply. One of:
+            - "not_empty": every value must be non-null and non-empty string
+            - "matches_regex": every value must fully match the regex pattern in `value`
+              (e.g. ``value="^ENSMUSG"`` to enforce a prefix)
+            - "contains": every value must contain `value` as a substring
+            - "one_of": every value must be a member of the collection `value`
+        value: The expected regex pattern, substring, or allowed set, depending on `rule`.
+               Not required for "not_empty".
+    """
+
+    rule: Literal["not_empty", "matches_regex", "contains", "one_of"]
+    value: Optional[Any] = None
+
+
+def _check_single_rule(
+    df: pd.DataFrame,
+    dataset_name: str,
+    col_name: str,
+    rule: ColumnRule,
+) -> List[str]:
+    """Check a single ColumnRule against one column and return any violation messages.
+
+    Args:
+        df: The DataFrame containing the column to check.
+        dataset_name: Name of the dataset (used in violation messages).
+        col_name: Name of the column to validate.
+        rule: The ColumnRule to apply.
+
+    Returns:
+        A list containing a violation message if the rule is broken, or an empty list.
+    """
+    prefix = f"In dataset '{dataset_name}', column '{col_name}': "
+
+    if rule.rule == "not_empty":
+        bad_count = (
+            df[col_name].isna() | (df[col_name].astype(str).str.strip() == "")
+        ).sum()
+        if bad_count > 0:
+            return [f"{prefix}{bad_count} row(s) violate rule 'not_empty'."]
+
+    elif rule.rule == "matches_regex":
+        bad_count = (~df[col_name].astype(str).str.match(rule.value, na=False)).sum()
+        if bad_count > 0:
+            return [
+                f"{prefix}{bad_count} row(s) violate rule 'matches_regex' (pattern={rule.value!r})."
+            ]
+
+    elif rule.rule == "contains":
+        bad_count = (~df[col_name].str.contains(rule.value, na=False)).sum()
+        if bad_count > 0:
+            return [
+                f"{prefix}{bad_count} row(s) violate rule 'contains' (value={rule.value!r})."
+            ]
+
+    elif rule.rule == "one_of":
+        bad_count = (~df[col_name].isin(rule.value)).sum()
+        if bad_count > 0:
+            return [
+                f"{prefix}{bad_count} row(s) violate rule 'one_of' (value={rule.value!r})."
+            ]
+
+    return []
+
+
+def check_column_rules(
+    datasets: Dict[str, pd.DataFrame],
+    column_rules: Dict[str, Dict[str, List[ColumnRule]]],
+) -> None:
+    """Validate per-column content rules across one or more datasets.
+
+    Iterates over every (dataset, column, rule) triple in `column_rules` and
+    checks that every value in that column satisfies the rule. All violations
+    are collected before raising so callers see every problem in a single error.
+
+    Args:
+        datasets: Dictionary mapping dataset names to their DataFrames.
+        column_rules: Nested mapping of
+            dataset_name -> column_name -> list of ColumnRule objects.
+            Only datasets and columns present in this mapping are checked.
+
+    Raises:
+        ValueError: If any rule is violated. The message lists all violations,
+            each naming the dataset, column, rule, and number of offending rows.
+
+    Example::
+
+        COLUMN_RULES = {
+            "mouse_gene_metadata": {
+                "ensembl_gene_id": [ColumnRule(rule="matches_regex", value="^ENSMUSG")],
+            },
+            "rnaseq_genotype_label_map": {
+                "model": [ColumnRule(rule="not_empty")],
+                "model_group": [ColumnRule(rule="not_empty")],
+            },
+        }
+        check_column_rules(datasets, COLUMN_RULES)
+    """
+    violations: List[str] = []
+
+    for dataset_name, col_rules in column_rules.items():
+        if dataset_name not in datasets:
+            continue
+        df = datasets[dataset_name]
+
+        for col_name, rules in col_rules.items():
+            if col_name not in df.columns:
+                violations.append(
+                    f"In dataset '{dataset_name}', column '{col_name}' does not exist."
+                )
+                continue
+
+            for rule in rules:
+                violations.extend(_check_single_rule(df, dataset_name, col_name, rule))
+
+    if violations:
+        raise ValueError("\n".join(violations))
 
 
 def _login_to_synapse(authtoken: str = None) -> object:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import pytest
+import pandas as pd
 from agoradatatools.etl import utils
 from synapseclient import Synapse
 
@@ -29,6 +30,165 @@ def test_yaml():
         utils._get_config(config_path="./tests/test_assets/bad_config.yam")
     assert err.type == SystemExit
     assert err.value.code == 2
+
+
+class TestCheckColumnRules:
+    def _make_datasets(self, col_data: dict) -> dict:
+        return {"ds": pd.DataFrame(col_data)}
+
+    # ── not_empty ────────────────────────────────────────────────────────────
+
+    def test_not_empty_passes_for_all_non_empty_values(self):
+        datasets = self._make_datasets({"col": ["a", "b", "c"]})
+        utils.check_column_rules(
+            datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
+        )
+
+    def test_not_empty_raises_on_null(self):
+        datasets = self._make_datasets({"col": ["a", None, "c"]})
+        with pytest.raises(ValueError, match="col.*not_empty"):
+            utils.check_column_rules(
+                datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
+            )
+
+    def test_not_empty_raises_on_empty_string(self):
+        datasets = self._make_datasets({"col": ["a", "", "c"]})
+        with pytest.raises(ValueError, match="col.*not_empty"):
+            utils.check_column_rules(
+                datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
+            )
+
+    def test_not_empty_raises_on_whitespace_only_string(self):
+        datasets = self._make_datasets({"col": ["a", "   ", "c"]})
+        with pytest.raises(ValueError, match="col.*not_empty"):
+            utils.check_column_rules(
+                datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
+            )
+
+    # ── matches_regex ─────────────────────────────────────────────────────────
+
+    def test_matches_regex_passes_for_all_matching_values(self):
+        datasets = self._make_datasets({"col": ["ENSMUSG001", "ENSMUSG002"]})
+        utils.check_column_rules(
+            datasets,
+            {"ds": {"col": [utils.ColumnRule(rule="matches_regex", value="^ENSMUSG")]}},
+        )
+
+    def test_matches_regex_raises_with_correct_count(self):
+        datasets = self._make_datasets({"col": ["ENSMUSG001", "ENSG002", "ENSG003"]})
+        with pytest.raises(ValueError, match="2 row\\(s\\).*matches_regex.*\\^ENSMUSG"):
+            utils.check_column_rules(
+                datasets,
+                {
+                    "ds": {
+                        "col": [
+                            utils.ColumnRule(rule="matches_regex", value="^ENSMUSG")
+                        ]
+                    }
+                },
+            )
+
+    def test_matches_regex_treats_null_as_violation(self):
+        datasets = self._make_datasets({"col": ["ENSMUSG001", None]})
+        with pytest.raises(ValueError, match="matches_regex"):
+            utils.check_column_rules(
+                datasets,
+                {
+                    "ds": {
+                        "col": [
+                            utils.ColumnRule(rule="matches_regex", value="^ENSMUSG")
+                        ]
+                    }
+                },
+            )
+
+    # ── contains ─────────────────────────────────────────────────────────────
+
+    def test_contains_passes_for_all_matching_values(self):
+        datasets = self._make_datasets({"col": ["hello world", "world cup"]})
+        utils.check_column_rules(
+            datasets,
+            {"ds": {"col": [utils.ColumnRule(rule="contains", value="world")]}},
+        )
+
+    def test_contains_raises_with_correct_count(self):
+        datasets = self._make_datasets({"col": ["hello world", "goodbye", "adieu"]})
+        with pytest.raises(ValueError, match="2 row\\(s\\).*contains.*world"):
+            utils.check_column_rules(
+                datasets,
+                {"ds": {"col": [utils.ColumnRule(rule="contains", value="world")]}},
+            )
+
+    def test_contains_treats_null_as_violation(self):
+        datasets = self._make_datasets({"col": ["hello world", None]})
+        with pytest.raises(ValueError, match="contains"):
+            utils.check_column_rules(
+                datasets,
+                {"ds": {"col": [utils.ColumnRule(rule="contains", value="world")]}},
+            )
+
+    # ── one_of ───────────────────────────────────────────────────────────────
+
+    def test_one_of_passes_for_all_allowed_values(self):
+        datasets = self._make_datasets({"col": ["male", "female", "male"]})
+        utils.check_column_rules(
+            datasets,
+            {
+                "ds": {
+                    "col": [utils.ColumnRule(rule="one_of", value={"male", "female"})]
+                }
+            },
+        )
+
+    def test_one_of_raises_with_correct_count(self):
+        datasets = self._make_datasets({"col": ["male", "unknown", "other"]})
+        with pytest.raises(ValueError, match="2 row\\(s\\).*one_of"):
+            utils.check_column_rules(
+                datasets,
+                {
+                    "ds": {
+                        "col": [
+                            utils.ColumnRule(rule="one_of", value={"male", "female"})
+                        ]
+                    }
+                },
+            )
+
+    # ── multi-violation collection ────────────────────────────────────────────
+
+    def test_all_violations_collected_in_single_error(self):
+        datasets = {
+            "ds1": pd.DataFrame({"col_a": ["a", None]}),
+            "ds2": pd.DataFrame({"col_b": ["ENSG001", "ENSG002"]}),
+        }
+        column_rules = {
+            "ds1": {"col_a": [utils.ColumnRule(rule="not_empty")]},
+            "ds2": {
+                "col_b": [utils.ColumnRule(rule="matches_regex", value="^ENSMUSG")]
+            },
+        }
+        with pytest.raises(ValueError) as exc_info:
+            utils.check_column_rules(datasets, column_rules)
+        message = str(exc_info.value)
+        assert "ds1" in message
+        assert "ds2" in message
+
+    # ── missing dataset / column graceful skip ────────────────────────────────
+
+    def test_missing_dataset_in_rules_is_skipped(self):
+        datasets = {"ds": pd.DataFrame({"col": ["a"]})}
+        utils.check_column_rules(
+            datasets,
+            {"nonexistent_ds": {"col": [utils.ColumnRule(rule="not_empty")]}},
+        )
+
+    def test_missing_column_in_rules_reports_violation(self):
+        datasets = {"ds": pd.DataFrame({"other_col": ["a"]})}
+        with pytest.raises(ValueError, match="does not exist"):
+            utils.check_column_rules(
+                datasets,
+                {"ds": {"missing_col": [utils.ColumnRule(rule="not_empty")]}},
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,5 @@
+from typing import Any, Dict
+
 import pytest
 import pandas as pd
 from agoradatatools.etl import utils
@@ -33,32 +35,34 @@ def test_yaml():
 
 
 class TestCheckColumnRules:
-    def _make_datasets(self, col_data: dict) -> dict:
+    """Tests for check_column_rules() and its supporting _check_single_rule() helper."""
+
+    def _make_datasets(self, col_data: Dict[str, Any]) -> Dict[str, pd.DataFrame]:
         return {"ds": pd.DataFrame(col_data)}
 
     # ── not_empty ────────────────────────────────────────────────────────────
 
-    def test_not_empty_passes_for_all_non_empty_values(self):
+    def test_not_empty_passes_for_all_non_empty_values(self) -> None:
         datasets = self._make_datasets({"col": ["a", "b", "c"]})
         utils.check_column_rules(
             datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
         )
 
-    def test_not_empty_raises_on_null(self):
+    def test_not_empty_raises_on_null(self) -> None:
         datasets = self._make_datasets({"col": ["a", None, "c"]})
         with pytest.raises(ValueError, match="col.*not_empty"):
             utils.check_column_rules(
                 datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
             )
 
-    def test_not_empty_raises_on_empty_string(self):
+    def test_not_empty_raises_on_empty_string(self) -> None:
         datasets = self._make_datasets({"col": ["a", "", "c"]})
         with pytest.raises(ValueError, match="col.*not_empty"):
             utils.check_column_rules(
                 datasets, {"ds": {"col": [utils.ColumnRule(rule="not_empty")]}}
             )
 
-    def test_not_empty_raises_on_whitespace_only_string(self):
+    def test_not_empty_raises_on_whitespace_only_string(self) -> None:
         datasets = self._make_datasets({"col": ["a", "   ", "c"]})
         with pytest.raises(ValueError, match="col.*not_empty"):
             utils.check_column_rules(
@@ -67,14 +71,14 @@ class TestCheckColumnRules:
 
     # ── matches_regex ─────────────────────────────────────────────────────────
 
-    def test_matches_regex_passes_for_all_matching_values(self):
+    def test_matches_regex_passes_for_all_matching_values(self) -> None:
         datasets = self._make_datasets({"col": ["ENSMUSG001", "ENSMUSG002"]})
         utils.check_column_rules(
             datasets,
             {"ds": {"col": [utils.ColumnRule(rule="matches_regex", value="^ENSMUSG")]}},
         )
 
-    def test_matches_regex_raises_with_correct_count(self):
+    def test_matches_regex_raises_with_correct_count(self) -> None:
         datasets = self._make_datasets({"col": ["ENSMUSG001", "ENSG002", "ENSG003"]})
         with pytest.raises(ValueError, match="2 row\\(s\\).*matches_regex.*\\^ENSMUSG"):
             utils.check_column_rules(
@@ -88,7 +92,7 @@ class TestCheckColumnRules:
                 },
             )
 
-    def test_matches_regex_treats_null_as_violation(self):
+    def test_matches_regex_treats_null_as_violation(self) -> None:
         datasets = self._make_datasets({"col": ["ENSMUSG001", None]})
         with pytest.raises(ValueError, match="matches_regex"):
             utils.check_column_rules(
@@ -104,14 +108,14 @@ class TestCheckColumnRules:
 
     # ── contains ─────────────────────────────────────────────────────────────
 
-    def test_contains_passes_for_all_matching_values(self):
+    def test_contains_passes_for_all_matching_values(self) -> None:
         datasets = self._make_datasets({"col": ["hello world", "world cup"]})
         utils.check_column_rules(
             datasets,
             {"ds": {"col": [utils.ColumnRule(rule="contains", value="world")]}},
         )
 
-    def test_contains_raises_with_correct_count(self):
+    def test_contains_raises_with_correct_count(self) -> None:
         datasets = self._make_datasets({"col": ["hello world", "goodbye", "adieu"]})
         with pytest.raises(ValueError, match="2 row\\(s\\).*contains.*world"):
             utils.check_column_rules(
@@ -119,7 +123,7 @@ class TestCheckColumnRules:
                 {"ds": {"col": [utils.ColumnRule(rule="contains", value="world")]}},
             )
 
-    def test_contains_treats_null_as_violation(self):
+    def test_contains_treats_null_as_violation(self) -> None:
         datasets = self._make_datasets({"col": ["hello world", None]})
         with pytest.raises(ValueError, match="contains"):
             utils.check_column_rules(
@@ -129,7 +133,7 @@ class TestCheckColumnRules:
 
     # ── one_of ───────────────────────────────────────────────────────────────
 
-    def test_one_of_passes_for_all_allowed_values(self):
+    def test_one_of_passes_for_all_allowed_values(self) -> None:
         datasets = self._make_datasets({"col": ["male", "female", "male"]})
         utils.check_column_rules(
             datasets,
@@ -140,7 +144,7 @@ class TestCheckColumnRules:
             },
         )
 
-    def test_one_of_raises_with_correct_count(self):
+    def test_one_of_raises_with_correct_count(self) -> None:
         datasets = self._make_datasets({"col": ["male", "unknown", "other"]})
         with pytest.raises(ValueError, match="2 row\\(s\\).*one_of"):
             utils.check_column_rules(
@@ -156,7 +160,7 @@ class TestCheckColumnRules:
 
     # ── multi-violation collection ────────────────────────────────────────────
 
-    def test_all_violations_collected_in_single_error(self):
+    def test_all_violations_collected_in_single_error(self) -> None:
         datasets = {
             "ds1": pd.DataFrame({"col_a": ["a", None]}),
             "ds2": pd.DataFrame({"col_b": ["ENSG001", "ENSG002"]}),
@@ -175,14 +179,14 @@ class TestCheckColumnRules:
 
     # ── missing dataset / column graceful skip ────────────────────────────────
 
-    def test_missing_dataset_in_rules_is_skipped(self):
+    def test_missing_dataset_in_rules_is_skipped(self) -> None:
         datasets = {"ds": pd.DataFrame({"col": ["a"]})}
         utils.check_column_rules(
             datasets,
             {"nonexistent_ds": {"col": [utils.ColumnRule(rule="not_empty")]}},
         )
 
-    def test_missing_column_in_rules_reports_violation(self):
+    def test_missing_column_in_rules_reports_violation(self) -> None:
         datasets = {"ds": pd.DataFrame({"other_col": ["a"]})}
         with pytest.raises(ValueError, match="does not exist"):
             utils.check_column_rules(


### PR DESCRIPTION
## Background

`check_required_datasets_and_columns()` in `agoradatatools/etl/utils.py` validates that required datasets and their columns are present before a transform runs — but it only checks for *presence*, not *content*.

Several transforms already implement one-off content checks (e.g. `validate_data_file_not_empty()` in `rna_de_individual_utils.py`, `ensembl_gene_id.str.startswith("ENSMUSG")` guards, etc.), but there is no shared, reusable mechanism for expressing rules like:

- A column value must not be null/empty
- A column value must match a given regex pattern (e.g. `"^ENSMUSG"`)
- A column value must contain a given substring
- A column value must belong to an allowed set of values

Additionally, several transforms do not currently call `check_required_datasets_and_columns()` at all.

## Goal

Implement a universal `check_column_rules()` function in `agoradatatools/etl/utils.py` that allows any transform to declaratively express per-column content rules, then apply it (along with `check_required_datasets_and_columns()` where still missing) to every transform.

## PR Structure

This ticket is being delivered as a series of focused PRs:

1. **This PR** — adds `ColumnRule`, `_check_single_rule()`, and `check_column_rules()` to `utils.py`, with full test coverage. No transform changes yet.
2. Subsequent PRs — each updates one transform to call `check_column_rules()` (and `check_required_datasets_and_columns()` where missing), along with its tests.

## Changes in This PR

- **`agoradatatools/etl/utils.py`** — adds:
  - `ColumnRule` dataclass supporting `not_empty`, `matches_regex`, `contains`, and `one_of` rule types
  - `_check_single_rule()` — evaluates one `ColumnRule` against one column
  - `check_column_rules()` — orchestrates rules across multiple datasets/columns, collects all violations, and raises a single descriptive `ValueError`
- **`tests/test_utils.py`** — adds `TestCheckColumnRules` with 14 tests covering all rule types, multi-violation collection, and graceful handling of missing datasets/columns

## Test plan

- [ ] Run `pytest tests/test_utils.py -k TestCheckColumnRules` to verify all new tests pass
- [ ] Confirm no regressions in the existing `test_login` / `test_yaml` tests