### PR TITLE
AG-2066/AG-2070/AG-2071: Update ui_config to address multiple issues

### DIFF
--- a/data_analysis/agora/notebooks/preprocessing/AG-2005_ui_config.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-2005_ui_config.rmd
@@ -223,11 +223,11 @@ drug_columns <- data.frame(
            "Programs", "Modality", "First Approved",
            "Max Clinical Trial Phase"),
   type = c("primary", "text", "numeric",
-           "link_internal", "numeric", "text",
+           "text", "numeric", "text",
            "text", "text", "numeric",
            "text"),
   data_key = c("common_name", "chembl_id", "total_nominations",
-               "combined_with", "year_first_nominated", "principal_investigators",
+               "combined_with", "initial_nomination", "principal_investigators",
                "programs", "modality", "year_of_first_approval",
                "maximum_clinical_trial_phase"),
   tooltip = rep(NA, times = 10),
@@ -256,7 +256,7 @@ drug_filters <- data.frame(
 # Nominated Drug Filter Values
 # ----------------------------
 drug_modality_filter_values <- c(
-  "Small Molecule", "Protein"
+  "Small molecule", "Protein"
 )
 
 # These are in alpha order by last name


### PR DESCRIPTION
## Problem

Some integration issues were identified with the ui_config object for the Nominated Drugs CT:
1. Incorrect `data_key` value for "Year first nominated" column prevents data population
2. Incorrect casing of "Small Molecule" filter option prevents matching "Small molecule" in the data collection
3. Proposed link_internal type for "Combined with" field is not actually going to be compatible with future extension to support nominations of combination therapies with >2 components; we don't want to shove a list of links into a table cell.

## Solution

Update Agora's ui_config notebook to:
1. Specify the correct `initial_nomination ` data field, which actually exists in the `nominated_drugs` collection
2. Update the casing in ui_config to align with the casing in the data collection
3. Convert the "Combined with" column back to a simple text field in ui_config.

Update 3 relies on a parallel update to the prototype data transformation (this lives in the unmerged branch jbritton/;AG-2061). An updated version of the `nominated_drugs` data collection was processed locally:  [syn73695286.4 ](https://www.synapse.org/Synapse:syn73695286.4)

The updated `ui_config` source file: [syn73677126.10](https://www.synapse.org/Synapse:syn73677126.10)