### PR TITLE
MG-187: Bump pathology source version to pick up MG-848/MG-850 fixes

### DIFF
--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -16,7 +16,7 @@ datasets:
           id: syn64618791.6
           format: csv
         - name: pathology
-          id: syn61357279.16
+          id: syn61357279.17
           format: csv
         - name: biomarkers
           id: syn61250724.12

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -16,7 +16,7 @@ datasets:
           id: syn64618791.6
           format: csv
         - name: pathology
-          id: syn61357279.16
+          id: syn61357279.17
           format: csv
         - name: biomarkers
           id: syn61250724.12

--- a/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
+++ b/data_analysis/model_ad/notebooks/MG-264: Update_disease_correlation_source_file.Rmd
@@ -1,7 +1,8 @@
 
 # Modify Disease Correlation source (MG-264)
 
-This notebook downloads the correlation data that was exported from the legacy explorer (syn65467849.1) and aligns the model_name values with our other data.
+This notebook downloads the correlation data that was exported from the legacy explorer (syn65467849.1),
+ aligns the model_name values with our other data, then writes the updated file back to the same synID.
 
 
 ## Library setup

--- a/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-40_Create_harmonized_pathology_source_file.rmd
@@ -300,7 +300,7 @@ Note that each file's synId and version is added to the data_sources vector via 
 The populated data_sources vector is used to populate Synapse provenance when the harmonized csv is uploaded.
 ```{r}
 # Genotype -> Display label map
-genotype_label_map <- download_csv('syn69014401.14') %>%
+genotype_label_map <- download_csv('syn69014401.17') %>%
   # Model name fix, plus change "5xFAD (UCI)" -> "5xFAD"
   mutate(model = model_group,
          display_label = str_replace(display_label, " \\(UCI\\)", ""))

--- a/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-88_Create_harmonized_biomarkers_source_file.rmd
@@ -242,7 +242,7 @@ Note that each file's synId and version is added to the data_sources vector via 
 The populated data_sources vector is used to populate Synapse provenance when the harmonized csv is uploaded.
 ```{r}
 # Genotype -> Display label map
-genotype_label_map <- download_csv('syn69014401.14') %>%
+genotype_label_map <- download_csv('syn69014401.17') %>%
   # Model name fix, plus change "5xFAD (UCI)" -> "5xFAD"
   mutate(model = model_group,
          display_label = str_replace(display_label, " \\(UCI\\)", ""))


### PR DESCRIPTION
## Problem

We need to finalize our production data release. This PR makes a few changes the fix issues detected during validation:
* I forgot to bump the pathology source file version when I addressed MG-848 / MG-850
* I forgot that the disease correlation notebook uses v1 of the source file, then writes a modified version of the source file back to the same synID, and almost had a panic attack about v1 vs v6
* The pathology and biomarker notebooks were using an older version of the genotype label map. Note that the only difference between v14 and v17 is the addition of the modelType column, which isn't used by the notebooks and thus won't impact the output files.


## Solution

Fix all the things:
* Bump the pathology source file version 
* Add information to the disease correlation notebook to avert future panic attacks
* Updated the version of the genotype label map in the biomarker and pathology notebooks