### PR TITLE
MG-187: Bump model_results_info version to omit abca7 pathology results from model_overview

### DIFF
--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -25,7 +25,7 @@ datasets:
           id: syn64846805.2
           format: csv
         - name: model_results_info
-          id: syn68377668.5
+          id: syn68377668.6
           format: csv
         - name: immunohisto_measure_order
           id: syn71305327.2
@@ -83,7 +83,7 @@ datasets:
       files:
         - <<: *model_info_file
         - name: model_results_info
-          id: syn68377668.5
+          id: syn68377668.6
           format: csv
         - name: allele_info
           id: syn64618791.6

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -25,7 +25,7 @@ datasets:
           id: syn64846805.2
           format: csv
         - name: model_results_info
-          id: syn68377668.5
+          id: syn68377668.6
           format: csv
         - name: immunohisto_measure_order
           id: syn71305327.2
@@ -83,7 +83,7 @@ datasets:
       files:
         - <<: *model_info_file
         - name: model_results_info
-          id: syn68377668.5
+          id: syn68377668.6
           format: csv
         - name: allele_info
           id: syn64618791.6


### PR DESCRIPTION
# Problem

We removed the Abca7 pathology results from the model_details data collection, but we also need to remove the link to those results from model_overview.

# Solution

The model_results_info source file was updated to indicate that abca7 does not have pathology results.

This PR bumps the model_results_info version in the ADT configs.