### PR TITLE
MG-894: Update model_info version, removes LOAD1.Plcg2M28L

### DIFF
--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -6,7 +6,7 @@ sources:
   - model_info:
     model_info_file: &model_info_file
       - name: model_info
-        id: syn61378590.12
+        id: syn61378590.13
         format: csv
 datasets:
   - model_details:

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -6,7 +6,7 @@ sources:
   - model_info:
     model_info_file: &model_info_file
       - name: model_info
-        id: syn61378590.12
+        id: syn61378590.13
         format: csv
 datasets:
   - model_details:


### PR DESCRIPTION
# Problem

The application indicates that we have Disease Correlation data for this model, but we don't. 

We also have no other result types for this model, so there's no reason for it to be included in the explorer.

# Solution

Delete the model's row from model_info source file, so that it will no longer be included in model_overview or model_details collections. 

This PR adjusts the pinned model_info version number to target the updated source file, https://www.synapse.org/Synapse:syn61378590.13