### PR TITLE
[AG-1904] Added an option to filter datasets in CLI

### DIFF
--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -404,6 +404,8 @@ def process_all_files(
         table_id=gx_table,
     )
     if filter_datasets:
+        # Each entry in datasets is a single-key dict where the key is the dataset name (e.g. {"gene_info": {...}}).
+        # Keep only the datasets whose name appears in filter_datasets.
         datasets = [d for d in datasets if list(d.keys())[0] in filter_datasets]
         if not datasets:
             raise ValueError(

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -370,6 +370,7 @@ def process_all_files(
     platform: Platform = Platform.LOCAL,
     run_id: str = None,
     upload: bool = True,
+    filter_datasets: Optional[List[str]] = None,
 ):
     """This function will read through the entire configuration and process each file listed.
 
@@ -379,6 +380,7 @@ def process_all_files(
         platform (Platform, optional): Platform where the process is being run. One of LOCAL, GITHUB, NEXTFLOW. Defaults to LOCAL.
         run_id (str, optional): Unique identifier for the processing run. Defaults to None.
         upload (bool, optional): Whether or not to upload the data to Synapse. Defaults to True.
+        filter_datasets (List[str], optional): List of dataset names to process. If None, all datasets in the config will be processed. Defaults to None.
     """
     if platform == Platform.LOCAL and upload is True:
         logger.warning(
@@ -401,6 +403,14 @@ def process_all_files(
         run_id=run_id,
         table_id=gx_table,
     )
+
+    if filter_datasets:
+        datasets = [d for d in datasets if list(d.keys())[0] in filter_datasets]
+        if not datasets:
+            raise ValueError(
+                f"No datasets found matching: {filter_datasets}. "
+                f"Check that the dataset names match those in the config."
+            )
 
     error_list = []
     for dataset in datasets:
@@ -500,6 +510,14 @@ synapse_auth_opt = Option(
     "https://python-docs.synapse.org/reference/client/?h=syn.login#synapseclient.Synapse.login)",
     show_default=False,
 )
+datasets_opt = Option(
+    None,
+    "--dataset",
+    "-d",
+    help="Name of a dataset to process. Can be specified multiple times to process multiple datasets. "
+    "If omitted, all datasets in the config are processed. (Optional, defaults to None)",
+    show_default=True,
+)
 
 
 @app.command()
@@ -509,6 +527,7 @@ def process(
     run_id: str = run_id_opt,
     upload: bool = upload_opt,
     auth_token: str = synapse_auth_opt,
+    dataset: Optional[List[str]] = datasets_opt,
 ) -> None:
     """Process the configuration file and execute the data processing pipeline based on options.
 
@@ -518,6 +537,8 @@ def process(
         run_id (str): Run ID of the process. Used to identify the run in the GX table.
         upload (bool): Boolean value to toggle whether files will be uploaded to Synapse.
         auth_token (str): Synapse authentication token. Defaults to environment variable SYNAPSE_AUTH_TOKEN.
+        dataset (Optional[List[str]]): Name of a dataset to process. Can be specified multiple times to process multiple datasets.
+            If omitted, all datasets in the config are processed. (Optional, defaults to None)
     """
     syn = utils._login_to_synapse(token=auth_token)
     platform_enum = Platform(platform)
@@ -527,6 +548,7 @@ def process(
         platform=platform_enum,
         run_id=run_id,
         upload=upload,
+        filter_datasets=dataset,
     )
 
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -403,7 +403,6 @@ def process_all_files(
         run_id=run_id,
         table_id=gx_table,
     )
-
     if filter_datasets:
         datasets = [d for d in datasets if list(d.keys())[0] in filter_datasets]
         if not datasets:
@@ -514,7 +513,7 @@ datasets_opt = Option(
     None,
     "--dataset",
     "-d",
-    help="Name of a dataset to process. Can be specified multiple times to process multiple datasets. "
+    help="Name of a dataset to process. Can be specified multiple times or as a comma-separated list to process multiple datasets. "
     "If omitted, all datasets in the config are processed. (Optional, defaults to None)",
     show_default=True,
 )
@@ -537,18 +536,26 @@ def process(
         run_id (str): Run ID of the process. Used to identify the run in the GX table.
         upload (bool): Boolean value to toggle whether files will be uploaded to Synapse.
         auth_token (str): Synapse authentication token. Defaults to environment variable SYNAPSE_AUTH_TOKEN.
-        dataset (Optional[List[str]]): Name of a dataset to process. Can be specified multiple times to process multiple datasets.
+        dataset (Optional[List[str]]): Name of a dataset to process. Can be specified multiple times or as a
+            comma-separated list to process multiple datasets.
             If omitted, all datasets in the config are processed. (Optional, defaults to None)
     """
     syn = utils._login_to_synapse(token=auth_token)
     platform_enum = Platform(platform)
+
+    filter_datasets = (
+        [name.strip() for entry in dataset for name in entry.split(",")]
+        if dataset
+        else None
+    )
+
     process_all_files(
         syn=syn,
         config_path=config_path,
         platform=platform_enum,
         run_id=run_id,
         upload=upload,
-        filter_datasets=dataset,
+        filter_datasets=filter_datasets,
     )
 
 

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -408,7 +408,8 @@ def process_all_files(
         if not datasets:
             raise ValueError(
                 f"No datasets found matching: {filter_datasets}. "
-                f"Check that the dataset names match those in the config."
+                "Check that the dataset names match those in the config. "
+                "To specify multiple datasets, use commas separated list"
             )
 
     error_list = []
@@ -548,7 +549,6 @@ def process(
         if dataset
         else None
     )
-
     process_all_files(
         syn=syn,
         config_path=config_path,

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -409,7 +409,7 @@ def process_all_files(
             raise ValueError(
                 f"No datasets found matching: {filter_datasets}. "
                 "Check that the dataset names match those in the config. "
-                "To specify multiple datasets, use commas separated list"
+                "To specify multiple datasets, use a comma-separated list"
             )
 
     error_list = []

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -15,6 +15,7 @@ from agoradatatools.etl import load, utils, extract
 from agoradatatools.reporter import DatasetReport, ADTGXReporter
 from agoradatatools.constants import Platform
 from agoradatatools.gx import GreatExpectationsRunner
+import synapseclient
 
 
 STAGING_PATH = "./staging"
@@ -1394,7 +1395,9 @@ class TestProcessAllFiles:
             self.patch_format_link.assert_not_called()
             self.patch_update_table.assert_called_once()
 
-    def test_process_all_files_filter_datasets(self, syn: Any):
+    def test_process_all_files_filter_datasets(
+        self, syn: synapseclient.Synapse
+    ) -> None:
         process.process_all_files(
             syn=syn,
             config_path=self.config_path,
@@ -1422,7 +1425,9 @@ class TestProcessAllFiles:
             upload=True,
         )
 
-    def test_process_all_files_filter_datasets_no_match(self, syn: Any):
+    def test_process_all_files_filter_datasets_no_match(
+        self, syn: synapseclient.Synapse
+    ) -> None:
         with pytest.raises(
             ValueError, match="No datasets found matching: \\['non_existent_dataset'\\]"
         ):
@@ -1434,7 +1439,9 @@ class TestProcessAllFiles:
                 run_id="123",
             )
 
-    def test_process_multiple_files_filter_datasets(self, syn: Any):
+    def test_process_multiple_files_filter_datasets(
+        self, syn: synapseclient.Synapse
+    ) -> None:
         process.process_all_files(
             syn=syn,
             config_path=self.config_path,
@@ -1484,7 +1491,7 @@ class TestProcessCLI:
             self.mock_process_all_files = mock_process_all_files
             yield
 
-    def test_process_cli_no_dataset_flag(self):
+    def test_process_cli_no_dataset_flag(self) -> None:
         """When --dataset is omitted, filter_datasets should be None (process all)."""
         result = self.runner.invoke(process.app, ["path/to/config"])
 
@@ -1492,7 +1499,7 @@ class TestProcessCLI:
         self.mock_process_all_files.assert_called_once()
         assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] is None
 
-    def test_process_cli_single_dataset(self):
+    def test_process_cli_single_dataset(self) -> None:
         """A single --dataset flag passes a one-element list to process_all_files."""
         result = self.runner.invoke(
             process.app, ["path/to/config", "--dataset", "gene_info"]
@@ -1503,7 +1510,7 @@ class TestProcessCLI:
             "gene_info"
         ]
 
-    def test_process_cli_repeated_dataset_flags(self):
+    def test_process_cli_repeated_dataset_flags(self) -> None:
         """Repeated --dataset flags are combined into a list."""
         result = self.runner.invoke(
             process.app,
@@ -1516,7 +1523,7 @@ class TestProcessCLI:
             "team_info",
         ]
 
-    def test_process_cli_comma_separated_datasets(self):
+    def test_process_cli_comma_separated_datasets(self) -> None:
         """A comma-separated value in --dataset is split into individual names."""
         result = self.runner.invoke(
             process.app, ["path/to/config", "--dataset", "gene_info,team_info"]
@@ -1528,7 +1535,7 @@ class TestProcessCLI:
             "team_info",
         ]
 
-    def test_process_cli_comma_separated_with_spaces(self):
+    def test_process_cli_comma_separated_with_spaces(self) -> None:
         """Whitespace around comma-separated names is stripped."""
         result = self.runner.invoke(
             process.app, ["path/to/config", "--dataset", "gene_info, team_info"]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1424,7 +1424,7 @@ class TestProcessAllFiles:
 
     def test_process_all_files_filter_datasets_no_match(self, syn: Any):
         with pytest.raises(
-            ValueError, match="No datasets found matching: \['non_existent_dataset'\]"
+            ValueError, match="No datasets found matching: \\['non_existent_dataset'\\]"
         ):
             process.process_all_files(
                 syn=syn,
@@ -1482,6 +1482,7 @@ class TestProcessCLI:
             patch.object(process, "process_all_files") as mock_process_all_files,
         ):
             self.mock_process_all_files = mock_process_all_files
+            yield
 
     def test_process_cli_no_dataset_flag(self):
         """When --dataset is omitted, filter_datasets should be None (process all)."""

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 
 from synapseclient import File
+from typer.testing import CliRunner
 
 from agoradatatools import process
 from agoradatatools.errors import ADTDataProcessingError
@@ -1467,3 +1468,73 @@ class TestProcessAllFiles:
             syn=syn,
             upload=True,
         )
+
+
+class TestProcessCLI:
+    """Tests for the `process` CLI command"""
+
+    runner = CliRunner()
+
+    @pytest.fixture(autouse=True)
+    def patch_dependencies(self):
+        with (
+            patch.object(utils, "_login_to_synapse", return_value=None),
+            patch.object(process, "process_all_files") as mock_process_all_files,
+        ):
+            self.mock_process_all_files = mock_process_all_files
+
+    def test_process_cli_no_dataset_flag(self):
+        """When --dataset is omitted, filter_datasets should be None (process all)."""
+        result = self.runner.invoke(process.app, ["path/to/config"])
+
+        assert result.exit_code == 0
+        self.mock_process_all_files.assert_called_once()
+        assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] is None
+
+    def test_process_cli_single_dataset(self):
+        """A single --dataset flag passes a one-element list to process_all_files."""
+        result = self.runner.invoke(
+            process.app, ["path/to/config", "--dataset", "gene_info"]
+        )
+
+        assert result.exit_code == 0
+        assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] == [
+            "gene_info"
+        ]
+
+    def test_process_cli_repeated_dataset_flags(self):
+        """Repeated --dataset flags are combined into a list."""
+        result = self.runner.invoke(
+            process.app,
+            ["path/to/config", "--dataset", "gene_info", "--dataset", "team_info"],
+        )
+
+        assert result.exit_code == 0
+        assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] == [
+            "gene_info",
+            "team_info",
+        ]
+
+    def test_process_cli_comma_separated_datasets(self):
+        """A comma-separated value in --dataset is split into individual names."""
+        result = self.runner.invoke(
+            process.app, ["path/to/config", "--dataset", "gene_info,team_info"]
+        )
+
+        assert result.exit_code == 0
+        assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] == [
+            "gene_info",
+            "team_info",
+        ]
+
+    def test_process_cli_comma_separated_with_spaces(self):
+        """Whitespace around comma-separated names is stripped."""
+        result = self.runner.invoke(
+            process.app, ["path/to/config", "--dataset", "gene_info, team_info"]
+        )
+
+        assert result.exit_code == 0
+        assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] == [
+            "gene_info",
+            "team_info",
+        ]

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1135,20 +1135,20 @@ class TestCreateDataManifest:
 
 class TestProcessAllFiles:
     config_path = "./path/to/config"
-    test_reporter = DatasetReport(
-        data_set="test_dataset",
-        gx_report_file="syn123",
-        gx_report_version=1,
-        gx_report_link="test_link",
-        gx_failures=False,
-        gx_failure_message="test_message",
-        adt_output_file="syn456",
-        adt_output_version=1,
-        adt_output_link="test_link",
-    )
 
     @pytest.fixture(scope="function", autouse=True)
     def setup_method(self):
+        self.test_reporter = DatasetReport(
+            data_set="test_dataset",
+            gx_report_file="syn123",
+            gx_report_version=1,
+            gx_report_link="test_link",
+            gx_failures=False,
+            gx_failure_message="test_message",
+            adt_output_file="syn456",
+            adt_output_version=1,
+            adt_output_link="test_link",
+        )
         self.patch_get_config = patch.object(
             utils,
             "_get_config",
@@ -1392,3 +1392,78 @@ class TestProcessAllFiles:
             self.patch_load.assert_not_called()
             self.patch_format_link.assert_not_called()
             self.patch_update_table.assert_called_once()
+
+    def test_process_all_files_filter_datasets(self, syn: Any):
+        process.process_all_files(
+            syn=syn,
+            config_path=self.config_path,
+            platform=Platform.LOCAL,
+            filter_datasets=["a"],
+            run_id="123",
+        )
+
+        self.patch_get_config.assert_called_once_with(config_path=self.config_path)
+        self.patch_create_temp_location.assert_called_once_with(
+            staging_path=STAGING_PATH
+        )
+
+        called_dataset = [
+            list(call.kwargs["dataset_obj"].keys())[0]
+            for call in self.patch_process_dataset.call_args_list
+        ]
+        assert called_dataset == ["a"]
+        assert self.patch_process_dataset.call_count == 1
+        self.patch_process_dataset.assert_called_once_with(
+            dataset_obj={"a": {"b": "c"}},
+            staging_path=STAGING_PATH,
+            gx_folder=GX_FOLDER,
+            syn=syn,
+            upload=True,
+        )
+
+    def test_process_all_files_filter_datasets_no_match(self, syn: Any):
+        with pytest.raises(
+            ValueError, match="No datasets found matching: \['non_existent_dataset'\]"
+        ):
+            process.process_all_files(
+                syn=syn,
+                config_path=self.config_path,
+                platform=Platform.LOCAL,
+                filter_datasets=["non_existent_dataset"],
+                run_id="123",
+            )
+
+    def test_process_multiple_files_filter_datasets(self, syn: Any):
+        process.process_all_files(
+            syn=syn,
+            config_path=self.config_path,
+            platform=Platform.LOCAL,
+            filter_datasets=["a", "d"],
+            run_id="123",
+        )
+
+        self.patch_get_config.assert_called_once_with(config_path=self.config_path)
+        self.patch_create_temp_location.assert_called_once_with(
+            staging_path=STAGING_PATH
+        )
+
+        called_dataset = [
+            list(call.kwargs["dataset_obj"].keys())[0]
+            for call in self.patch_process_dataset.call_args_list
+        ]
+        assert called_dataset == ["a", "d"]
+        assert self.patch_process_dataset.call_count == 2
+        self.patch_process_dataset.assert_any_call(
+            dataset_obj={"a": {"b": "c"}},
+            staging_path=STAGING_PATH,
+            gx_folder=GX_FOLDER,
+            syn=syn,
+            upload=True,
+        )
+        self.patch_process_dataset.assert_any_call(
+            dataset_obj={"d": {"e": "f"}},
+            staging_path=STAGING_PATH,
+            gx_folder=GX_FOLDER,
+            syn=syn,
+            upload=True,
+        )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1398,6 +1398,10 @@ class TestProcessAllFiles:
     def test_process_all_files_filter_datasets(
         self, syn: synapseclient.Synapse
     ) -> None:
+        """Verify that only the specified dataset is processed when filter_datasets is set to a single name.
+        The config contains three datasets ("a", "d", "g"), but only "a" should be processed.
+        """
+        # WHEN process_all_files is called with filter_datasets=["a"]
         process.process_all_files(
             syn=syn,
             config_path=self.config_path,
@@ -1406,11 +1410,13 @@ class TestProcessAllFiles:
             run_id="123",
         )
 
+        # THEN the config is loaded and the staging location is created as normal
         self.patch_get_config.assert_called_once_with(config_path=self.config_path)
         self.patch_create_temp_location.assert_called_once_with(
             staging_path=STAGING_PATH
         )
 
+        # AND only dataset "a" is processed — "d" and "g" are skipped
         called_dataset = [
             list(call.kwargs["dataset_obj"].keys())[0]
             for call in self.patch_process_dataset.call_args_list
@@ -1428,6 +1434,9 @@ class TestProcessAllFiles:
     def test_process_all_files_filter_datasets_no_match(
         self, syn: synapseclient.Synapse
     ) -> None:
+        """Verify that a ValueError is raised when filter_datasets contains names not present in the config."""
+        # WHEN process_all_files is called with a dataset name that does not exist in the config
+        # THEN a ValueError is raised with a message identifying the unmatched names
         with pytest.raises(
             ValueError, match="No datasets found matching: \\['non_existent_dataset'\\]"
         ):
@@ -1442,6 +1451,10 @@ class TestProcessAllFiles:
     def test_process_multiple_files_filter_datasets(
         self, syn: synapseclient.Synapse
     ) -> None:
+        """Verify that multiple datasets are processed when filter_datasets contains more than one name.
+        The config contains three datasets ("a", "d", "g"), and only "a" and "d" should be processed.
+        """
+        # WHEN process_all_files is called with filter_datasets=["a", "d"]
         process.process_all_files(
             syn=syn,
             config_path=self.config_path,
@@ -1450,11 +1463,13 @@ class TestProcessAllFiles:
             run_id="123",
         )
 
+        # THEN the config is loaded and the staging location is created as normal
         self.patch_get_config.assert_called_once_with(config_path=self.config_path)
         self.patch_create_temp_location.assert_called_once_with(
             staging_path=STAGING_PATH
         )
 
+        # AND exactly "a" and "d" are processed in config order — "g" is skipped
         called_dataset = [
             list(call.kwargs["dataset_obj"].keys())[0]
             for call in self.patch_process_dataset.call_args_list
@@ -1470,6 +1485,42 @@ class TestProcessAllFiles:
         )
         self.patch_process_dataset.assert_any_call(
             dataset_obj={"d": {"e": "f"}},
+            staging_path=STAGING_PATH,
+            gx_folder=GX_FOLDER,
+            syn=syn,
+            upload=True,
+        )
+
+    def test_process_duplicated_dataset_names_filter_datasets(
+        self, syn: synapseclient.Synapse
+    ) -> None:
+        """Verify that a dataset is not processed more than once when its name appears multiple times in filter_datasets.
+        This guards against double-processing when a user passes --dataset a --dataset a or --dataset a,a.
+        """
+        # WHEN process_all_files is called with a duplicated dataset name in filter_datasets
+        process.process_all_files(
+            syn=syn,
+            config_path=self.config_path,
+            platform=Platform.LOCAL,
+            filter_datasets=["a", "a"],
+            run_id="123",
+        )
+
+        # THEN the config is loaded and the staging location is created as normal
+        self.patch_get_config.assert_called_once_with(config_path=self.config_path)
+        self.patch_create_temp_location.assert_called_once_with(
+            staging_path=STAGING_PATH
+        )
+
+        # AND dataset "a" is processed exactly once despite appearing twice in the filter
+        called_dataset = [
+            list(call.kwargs["dataset_obj"].keys())[0]
+            for call in self.patch_process_dataset.call_args_list
+        ]
+        assert called_dataset == ["a"]
+        assert self.patch_process_dataset.call_count == 1
+        self.patch_process_dataset.assert_called_once_with(
+            dataset_obj={"a": {"b": "c"}},
             staging_path=STAGING_PATH,
             gx_folder=GX_FOLDER,
             syn=syn,
@@ -1493,18 +1544,22 @@ class TestProcessCLI:
 
     def test_process_cli_no_dataset_flag(self) -> None:
         """When --dataset is omitted, filter_datasets should be None (process all)."""
+        # WHEN the CLI is invoked without a --dataset flag
         result = self.runner.invoke(process.app, ["path/to/config"])
 
+        # THEN the command succeeds and filter_datasets is None, meaning all datasets are processed
         assert result.exit_code == 0
         self.mock_process_all_files.assert_called_once()
         assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] is None
 
     def test_process_cli_single_dataset(self) -> None:
         """A single --dataset flag passes a one-element list to process_all_files."""
+        # WHEN the CLI is invoked with a single --dataset flag
         result = self.runner.invoke(
             process.app, ["path/to/config", "--dataset", "gene_info"]
         )
 
+        # THEN the command succeeds and filter_datasets contains exactly the specified dataset name
         assert result.exit_code == 0
         assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] == [
             "gene_info"
@@ -1512,11 +1567,13 @@ class TestProcessCLI:
 
     def test_process_cli_repeated_dataset_flags(self) -> None:
         """Repeated --dataset flags are combined into a list."""
+        # WHEN the CLI is invoked with --dataset specified multiple times
         result = self.runner.invoke(
             process.app,
             ["path/to/config", "--dataset", "gene_info", "--dataset", "team_info"],
         )
 
+        # THEN the command succeeds and filter_datasets contains all specified dataset names
         assert result.exit_code == 0
         assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] == [
             "gene_info",
@@ -1525,10 +1582,12 @@ class TestProcessCLI:
 
     def test_process_cli_comma_separated_datasets(self) -> None:
         """A comma-separated value in --dataset is split into individual names."""
+        # WHEN the CLI is invoked with a comma-separated list of dataset names in a single --dataset flag
         result = self.runner.invoke(
             process.app, ["path/to/config", "--dataset", "gene_info,team_info"]
         )
 
+        # THEN the command succeeds and filter_datasets contains each name as a separate entry
         assert result.exit_code == 0
         assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] == [
             "gene_info",
@@ -1537,10 +1596,12 @@ class TestProcessCLI:
 
     def test_process_cli_comma_separated_with_spaces(self) -> None:
         """Whitespace around comma-separated names is stripped."""
+        # WHEN the CLI is invoked with a comma-separated list that includes surrounding whitespace
         result = self.runner.invoke(
             process.app, ["path/to/config", "--dataset", "gene_info, team_info"]
         )
 
+        # THEN the command succeeds and dataset names are trimmed before being passed to process_all_files
         assert result.exit_code == 0
         assert self.mock_process_all_files.call_args.kwargs["filter_datasets"] == [
             "gene_info",


### PR DESCRIPTION
# Problem

When testing or troubleshooting a specific dataset, there is no way to target it without modifying or copying the config file. These workarounds are error-prone — modified configs can be accidentally committed, introducing version errors in production configs.

# Solution
## Process a single dataset
```
adt configs/agora_preprod.yaml --dataset gene_info
```
## Process multiple datasets
```
adt configs/agora_preprod.yaml --dataset gene_info, team_info
```

# Test
* The command listed above are working as expected
* If you pass in: 
```
adt configs/agora_preprod.yaml --dataset "gene_info;team_info"
```
You would get an error: 
```
ValueError: No datasets found matching: ['gene_info;team_info']. Check that the dataset names match those in the config. To specify multiple datasets, use commas separated list
```
