### PR TITLE
Replace np.NaN with np.nan repo-wide

### DIFF
--- a/data_analysis/agora/notebooks/preprocessing/AG-896_Preprocess_Gene_Annotations.ipynb
+++ b/data_analysis/agora/notebooks/preprocessing/AG-896_Preprocess_Gene_Annotations.ipynb
@@ -580,7 +580,7 @@
    "source": [
     "gene_table_merged[\"possible_replacement\"] = gene_table_merged[\n",
     "    \"possible_replacement\"\n",
-    "].apply(lambda pr: pr if pr is np.NaN or len(pr) == 0 else [x[\"stable_id\"] for x in pr])\n",
+    "].apply(lambda pr: pr if pr is np.nan or len(pr) == 0 else [x[\"stable_id\"] for x in pr])\n",
     "\n",
     "gene_table_merged[\"possible_replacement\"] = gene_table_merged[\n",
     "    \"possible_replacement\"\n",
@@ -629,7 +629,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "agora-data-tools-asv3WV1c",
+   "display_name": "agora-data-tools-ywFp1Gf9",
    "language": "python",
    "name": "python3"
   },

--- a/data_analysis/agora/notebooks/preprocessing/preprocessing_utils.py
+++ b/data_analysis/agora/notebooks/preprocessing/preprocessing_utils.py
@@ -323,14 +323,14 @@ def _extract_ensembl_ids(
         print(entity["name"] + " has an n/A Ensembl ID")
         file_ensembl_ids.remove("n/A")
 
-    if np.NaN in file_ensembl_ids:
+    if np.nan in file_ensembl_ids:
         print(
             entity["name"]
             + " has "
-            + str(file_ensembl_ids.count(np.NaN))
+            + str(file_ensembl_ids.count(np.nan))
             + " NaN Ensembl IDs"
         )
-        file_ensembl_ids = [x for x in file_ensembl_ids if x is not np.NaN]
+        file_ensembl_ids = [x for x in file_ensembl_ids if x is not np.nan]
 
     # Remove duplicate values
     return list(set(file_ensembl_ids))
@@ -381,13 +381,13 @@ def standardize_list_item(item: Union[str, List[str]]) -> List[str]:
     column.
 
     Args:
-        item: either a string, a list of strings, or np.NaN
+        item: either a string, a list of strings, or np.nan
 
     Returns:
         A list of strings or an empty list. The list is sorted alphabetically.
     """
     # Convert NaN to an empty list
-    if item is np.NaN:
+    if item is np.nan:
         return []
 
     # Convert plain strings to a list of one string

--- a/src/agoradatatools/etl/transform/gene_info.py
+++ b/src/agoradatatools/etl/transform/gene_info.py
@@ -162,7 +162,7 @@ def transform_gene_info(
         lambda row: (
             RESOURCE_URL_PREFIX + row["hgnc_symbol"] + RESOURCE_URL_SUFFIX
             if row["is_adi"] is True or row["is_tep"] is True
-            else np.NaN
+            else np.nan
         ),
         axis=1,
     )
@@ -263,7 +263,7 @@ def transform_gene_info(
         lambda row: (
             len(row["target_nominations"])
             if isinstance(row["target_nominations"], list)
-            else np.NaN
+            else np.nan
         ),
         axis=1,
     )

--- a/tests/transform/test_model_ad_transform_utils.py
+++ b/tests/transform/test_model_ad_transform_utils.py
@@ -329,10 +329,10 @@ class TestZeroPadJaxIds:
                 pd.Series(["123", "123456", "0"]),
                 pd.Series(["000123", "123456", "000000"]),
             ),
-            # Should handle both None and np.NaN. The Series with None is cast to dtype=object because otherwise the
+            # Should handle both None and np.nan. The Series with None is cast to dtype=object because otherwise the
             # None is converted to NaN by pandas. Using dtype=object also matches the output of replacing NaN values
             # with None, which is what happens in the transforms.
-            (pd.Series([1234, np.NaN]), pd.Series(["001234", ""])),
+            (pd.Series([1234, np.nan]), pd.Series(["001234", ""])),
             (pd.Series([1234, None], dtype="object"), pd.Series(["001234", ""])),
             # Empty series should return an empty series
             (pd.Series(), pd.Series()),
@@ -347,11 +347,11 @@ class TestZeroPadJaxIds:
             # Mixed floats and integers all become integers before padding
             (pd.Series([123.0, 12345]), pd.Series(["000123", "012345"])),
             # Floats are converted to integers and padded even when some values are NaN or None
-            (pd.Series([1234.0, np.NaN]), pd.Series(["001234", ""])),
+            (pd.Series([1234.0, np.nan]), pd.Series(["001234", ""])),
             (pd.Series([1234.0, None], dtype="object"), pd.Series(["001234", ""])),
             # Mixed None and NaN values -- None and NaN should both be converted to empty strings
             (
-                pd.Series(["123", None, np.NaN], dtype="object"),
+                pd.Series(["123", None, np.nan], dtype="object"),
                 pd.Series(["000123", "", ""]),
             ),
         ],
@@ -377,7 +377,7 @@ class TestZeroPadJaxIds:
     ) -> None:
         """
         Tests that the function works with multiple different kinds of input. It should work on integers or strings, and
-        both np.NaN and None should be converted to empty strings.
+        both np.nan and None should be converted to empty strings.
         """
         output = zero_pad_jax_ids(input_ids)
 
@@ -459,7 +459,7 @@ class TestValidateJaxIds:
             pd.Series(["-12345"]),
             pd.Series(["123 456"]),
             pd.Series([None]),
-            pd.Series([np.NaN]),
+            pd.Series([np.nan]),
             pd.Series(["\n"]),
         ],
         ids=[


### PR DESCRIPTION
Lingling noted in another PR that np.NaN will be deprecated in numpy 2.0. While changing out np.NaNs in the files in that PR, I noticed a few other areas that had it, so I've handled those in this PR.

I did a repo-wide search for "np.NaN" and replaced it with "np.nan".

All tests pass.