### PR TITLE
AD-2079: Added ui_config to Agora preprod and prod configs

### DIFF
--- a/configs/agora_preprod.yaml
+++ b/configs/agora_preprod.yaml
@@ -285,7 +285,7 @@ datasets:
   - ui_config:
       files:
         - name: ui_config
-          id: syn73695287 # TODO pin this once source is finalized
+          id: syn73677126 # TODO pin this once source is finalized
           format: json
       final_format: json
       destination: *dest

--- a/configs/agora_preprod.yaml
+++ b/configs/agora_preprod.yaml
@@ -281,3 +281,12 @@ datasets:
       custom_transformations: transform_proteomics_distribution_data
       destination: *dest
       gx_enabled: true
+
+  - ui_config:
+      files:
+        - name: ui_config
+          id: syn73695287 # TODO pin this once source is finalized
+          format: json
+      final_format: json
+      destination: *dest
+      gx_enabled: false

--- a/configs/agora_prod.yaml
+++ b/configs/agora_prod.yaml
@@ -285,7 +285,7 @@ datasets:
   - ui_config:
       files:
         - name: ui_config
-          id: syn73695287 # TODO pin this once source is finalized
+          id: syn73677126 # TODO pin this once source is finalized
           format: json
       final_format: json
       destination: *dest

--- a/configs/agora_prod.yaml
+++ b/configs/agora_prod.yaml
@@ -281,3 +281,12 @@ datasets:
       custom_transformations: transform_proteomics_distribution_data
       destination: *dest
       gx_enabled: true
+
+  - ui_config:
+      files:
+        - name: ui_config
+          id: syn73695287 # TODO pin this once source is finalized
+          format: json
+      final_format: json
+      destination: *dest
+      gx_enabled: false


### PR DESCRIPTION
- Adds ui_config to the Agora configs
- Uses a pass-through setup: no custom_transformations (per ticket: no Python transform yet). gx_enabled: false so we do not run Great Expectations on this dataset until expectations are validated for Agora output.
- Source file: syn73695287 with a TODO to pin a version once the upstream file is finalized (and verify that this is indeed the ui_config file we want to use, there are a lot in the various agora and model_ad synapse locations)