### PR TITLE
[Bug fix] Added boolean type check to normalize_null_values

### DIFF
--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -691,6 +691,10 @@ def normalize_null_values(
     columns listed in `empty_string_columns` will have NaN/None values replaced with "". After that, all columns left
     over will have their NaN values replaced with None, regardless of column type.
 
+    To avoid unexpected behavior when casting to `bool`, this function verifies that all values in the columns specified
+    in `boolean_columns` are of type `bool` or missing (None or NaN) before filling NAs and casting to `bool`. A
+    TypeError will be raised if any non-boolean values are found in these columns.
+
     All *_columns arguments are optional and default to empty lists. Values in these arguments must not overlap with
     each other and must contain only columns that appear in the data frame.
 
@@ -707,6 +711,7 @@ def normalize_null_values(
     Raises:
         TypeError: If the input df is not a pandas DataFrame.
         TypeError: If any of the *_columns arguments are not lists.
+        TypeError: If any of the values in the boolean_columns columns are not of type `bool` or missing.
         ValueError: If there are overlaps between the boolean_columns and empty_string_columns lists.
         ValueError: If any column specified in the boolean_columns or empty_string_columns lists does not exist in the
         DataFrame.
@@ -744,6 +749,16 @@ def normalize_null_values(
 
     df = df.copy()
 
+    # Verify that all values in boolean columns are boolean or NaN
+    invalid_cols = [
+        col
+        for col in boolean_columns
+        if not df[col].dropna().apply(isinstance, args=[bool]).all()
+    ]
+    if len(invalid_cols) > 0:
+        raise TypeError(f"Columns {invalid_cols} contain non-boolean values")
+
+    # Fill NAs
     for col in boolean_columns:
         df[col] = df[col].fillna(False).astype(bool)
 

--- a/src/agoradatatools/etl/utils.py
+++ b/src/agoradatatools/etl/utils.py
@@ -692,8 +692,8 @@ def normalize_null_values(
     over will have their NaN values replaced with None, regardless of column type.
 
     To avoid unexpected behavior when casting to `bool`, this function verifies that all values in the columns specified
-    in `boolean_columns` are of type `bool` or missing (None or NaN) before filling NAs and casting to `bool`. A
-    TypeError will be raised if any non-boolean values are found in these columns.
+    in `boolean_columns` are of type `bool`, `np.bool_`, or missing (None or NaN), before filling NAs and casting to
+    `bool`. A TypeError will be raised if any non-boolean values are found in these columns.
 
     All *_columns arguments are optional and default to empty lists. Values in these arguments must not overlap with
     each other and must contain only columns that appear in the data frame.
@@ -711,7 +711,7 @@ def normalize_null_values(
     Raises:
         TypeError: If the input df is not a pandas DataFrame.
         TypeError: If any of the *_columns arguments are not lists.
-        TypeError: If any of the values in the boolean_columns columns are not of type `bool` or missing.
+        TypeError: If any of the values in the boolean_columns columns are not of type `bool`, `np.bool_`, or missing.
         ValueError: If there are overlaps between the boolean_columns and empty_string_columns lists.
         ValueError: If any column specified in the boolean_columns or empty_string_columns lists does not exist in the
         DataFrame.
@@ -753,10 +753,10 @@ def normalize_null_values(
     invalid_cols = [
         col
         for col in boolean_columns
-        if not df[col].dropna().apply(isinstance, args=[bool]).all()
+        if not df[col].dropna().apply(isinstance, args=[bool | np.bool_]).all()
     ]
-    if len(invalid_cols) > 0:
-        raise TypeError(f"Columns {invalid_cols} contain non-boolean values")
+    if invalid_cols:
+        raise TypeError(f"Column(s) {sorted(invalid_cols)} contain non-boolean values")
 
     # Fill NAs
     for col in boolean_columns:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1497,9 +1497,21 @@ class TestNormalizeNullValues:
             {"bool1": [True, False, np.nan, np.bool_(True), np.bool_(False)]}
         )
 
+        # Ensure that pandas has not converted the np.bool_ values to bool, so that we are actually testing the
+        # intended scenario
+        assert input_df["bool1"].dtype == "O"
+        assert isinstance(input_df.loc[3, "bool1"], np.bool_) and not isinstance(
+            input_df.loc[3, "bool1"], bool
+        )
+        assert isinstance(input_df.loc[4, "bool1"], np.bool_) and not isinstance(
+            input_df.loc[4, "bool1"], bool
+        )
+
         output = utils.normalize_null_values(input_df, boolean_columns=["bool1"])
 
-        expected_output = pd.DataFrame({"bool1": [True, False, False, True, False]})
+        expected_output = pd.DataFrame(
+            {"bool1": [True, False, False, True, False]}, dtype="bool"
+        )
 
         pd.testing.assert_frame_equal(output, expected_output)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1583,6 +1583,41 @@ class TestNormalizeNullValues:
                 empty_string_columns=column_value,
             )
 
+    def test_normalize_null_values_fails_with_non_boolean_values_in_boolean_columns(
+        self,
+    ) -> None:
+        """
+        Test that normalize_null_values raises a TypeError when boolean_columns contains non-boolean values. All columns
+        in the input data frame except "bool_col" should fail and be included in the raised error message. As an added
+        check, columns "string2" and "numeric2" have values that look like booleans but aren't. These should both fail
+        the check because casting to `bool` might produce unexpected behavior. For example, bool("False") = True.
+        Although 1 and 0 from numeric2 would be converted to booleans as expected, we still want all numeric values to
+        fail the check to avoid ambiguity.
+        """
+        input_df = pd.DataFrame(
+            {
+                "bool_col": [True, False, None, np.nan, pd.NA],
+                "string1": ["abc", None, "", np.nan, pd.NA],
+                "string2": ["True", "False", None, np.nan, pd.NA],
+                "numeric1": [123, 456, np.nan, np.nan, np.nan],
+                "numeric2": [1, 0, None, np.nan, pd.NA],
+                "mixed": [True, "abc", 123, None, np.nan],
+            }
+        )
+
+        bad_columns = ["string1", "string2", "numeric1", "numeric2", "mixed"]
+
+        with pytest.raises(
+            TypeError, match="Columns .* contain non-boolean values"
+        ) as exc_info:
+            utils.normalize_null_values(
+                input_df, boolean_columns=input_df.columns.to_list()
+            )
+
+        assert "bool_col" not in str(exc_info.value)
+        for col in bad_columns:
+            assert col in str(exc_info.value)
+
 
 class TestDelimStringToList:
     """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1487,6 +1487,22 @@ class TestNormalizeNullValues:
 
         pd.testing.assert_frame_equal(output, expected_output)
 
+    def test_normalize_null_values_works_with_np_bool(self) -> None:
+        """
+        Test that normalize_null_values correctly normalizes null values in boolean columns even when they are of type
+        np.bool_. We don't expect to see np.bool_ in the data, but we want to make sure our function can handle this
+        in case of future changes to the data or transforms.
+        """
+        input_df = pd.DataFrame(
+            {"bool1": [True, False, np.nan, np.bool_(True), np.bool_(False)]}
+        )
+
+        output = utils.normalize_null_values(input_df, boolean_columns=["bool1"])
+
+        expected_output = pd.DataFrame({"bool1": [True, False, False, True, False]})
+
+        pd.testing.assert_frame_equal(output, expected_output)
+
     def test_normalize_null_values_with_empty_data_frame(self) -> None:
         """
         Test that normalize_null_values correctly handles an empty data frame without errors.
@@ -1608,7 +1624,7 @@ class TestNormalizeNullValues:
         bad_columns = ["string1", "string2", "numeric1", "numeric2", "mixed"]
 
         with pytest.raises(
-            TypeError, match="Columns .* contain non-boolean values"
+            TypeError, match="Column\\(s\\) .* contain non-boolean values"
         ) as exc_info:
             utils.normalize_null_values(
                 input_df, boolean_columns=input_df.columns.to_list()


### PR DESCRIPTION
# Bug fix

I discovered a bug in `normalize_null_values` while adding it to some of the transforms. If you put a column in the `boolean_columns` argument that contains non-boolean values, they would silently get cast to `bool` with unexpected results. 

For example, a column containing the string values `["True", "False"]` converts to `[True, True]`.

To fix this, I added a check to `normalize_null_values` which verifies that all values in the columns specified by `boolean_values` are in fact booleans, or missing. A `TypeError` is raised if there are non-boolean values. We can't directly check the column dtype as it might be `object` instead of `bool`, so we have to check individual values inside the columns.

I added a test to make sure the error is raised, which fails (doesn't raise) on the original code but passes (raises the error) with the fixed code.