### PR TITLE
AG-2109: Update Agora ui_config.filters

### DIFF
--- a/data_analysis/agora/notebooks/preprocessing/AG-2005_ui_config.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-2005_ui_config.rmd
@@ -20,8 +20,8 @@ values presented to users on the page.
   Example:
         column.name: ""Pharos Class"
         filter.name: "Pharos Class", <--- the filter's display name in the Filter panel
-        filter.short_name: "Pharos", <-- the filter's short display name in the "applied filter" chiclets
-        filter.query_param_key: "pharosClasses", <-- the filter's query parameter key
+        filter.short_name: "Pharos", <-- the filter's short display name in the "applied filter" chiclet
+        filter.query_param_key: "pharosClasses", <-- the filter's query parameter key is (plural, camelCase)
 
 ## Library setup
 Install required packages:
@@ -152,13 +152,13 @@ target_columns <- data.frame(
 # ----------------------
 target_filters <- data.frame(
   name = c('Cohort', 'Data Used', 'First Nominated', 'Nominating Team',
-           'Pharos Class', 'Program', 'Nominations'),
+           'Nominations', 'Pharos Class', 'Program'),
   data_key = c('cohort_studies', 'input_data', 'initial_nomination', 'nominating_teams',
-               'pharos_class', "programs", "total_nominations"),
+               'total_nominations', 'pharos_class', 'programs'),
   short_name = c('Cohort', 'Data', 'First', 'Team',
-                 'Pharos', "Program", "Nominations"),
+                 'Nominations', 'Pharos', 'Program'),
   query_param_key = c('cohorts', 'data', 'firstNominations', 'teams',
-                      'pharosClasses', 'programs', 'nominations'),
+                      'nominations', 'pharosClasses', 'programs'),
   stringsAsFactors = FALSE
 )
 
@@ -190,9 +190,9 @@ target_filter_values <- list(
   targets_data_filter_values,
   targets_first_nom_filter_values,
   targets_team_filter_values,
+  targets_total_nom_filter_values,
   targets_pharos_filter_values,
-  targets_program_filter_values,
-  targets_total_nom_filter_values
+  targets_program_filter_values
 )
 
 # Build Nominated Targets ui_config
@@ -246,10 +246,10 @@ drug_columns[drug_columns$name == "Chembl ID", "is_hidden"] <- TRUE
 # Nominated Drug Filters
 # ----------------------
 drug_filters <- data.frame(
-  name = c('Modality', 'Nominating PI', 'Nominations'),
-  data_key = c('modality', 'principal_investigators', 'total_nominations'),
-  short_name = c('Modality', 'PI', 'Nominations'),
-  query_param_key = c('modalities', 'nominatingPis', 'nominations'),
+  name = c('Max Clinical Trial Phase', 'Modality', 'Nominating PI', 'Nominations'),
+  data_key = c('maximum_clinical_trial_phase', 'modality', 'principal_investigators', 'total_nominations'),
+  short_name = c('Phase', 'Modality', 'PI', 'Nominations'),
+  query_param_key = c('phase', 'modalities', 'nominatingPis', 'nominations'),
   stringsAsFactors = FALSE
 )
 
@@ -265,8 +265,10 @@ drug_pi_filter_values <- c(
  "Jan Krumsiek", "Marina Sirota", "Lei Xie"
 )
 drug_total_nom_filter_values <- c(1, 2)
+drug_max_clinical_trial_phase_filter_values <- c("Preclinical", "Phase I", "Phase II", "Phase III", "Phase IV", "Unknown")
 
 drug_filter_values <- list(
+  drug_max_clinical_trial_phase_filter_values,
   drug_modality_filter_values,
   drug_pi_filter_values,
   drug_total_nom_filter_values
@@ -377,5 +379,3 @@ json_list <-  list(build_targets_object())
 
 toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)
 ```
-
-


### PR DESCRIPTION
## Problems

1. ui_config did not yet define a filterset targeting the nominated_drugs.max_clinical_trial_phase field
2. Nominated Target filtersets were not defined in alphabetical order

## Solution

This PR updates Agora's ui_config R notebook to:
1. Add a new Max Clinical Trial Phase filterset to the nomiated_drugs CT interface
2. Reorder the Nominated Targets filtersets to reflect the desired alphabetical display order

A new version of the ui_config source file generated via this updated notebook is in Synapse: syn73677126.11