### PR TITLE
MG-948: Add ui_config for Marmoset model overview

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -518,6 +518,8 @@ build_mo_object <- function() {
   filters <- build_filters(mo_filters, mo_filter_values)
 
   # Assemble the ui_config object
+  # note that the page value does not actually control the CT's display title
+  # so this is not updated to 'Mouse Model Overview' even though the display title will be updated
   list(
     page = "Model Overview",
     dropdowns = list(),
@@ -563,9 +565,7 @@ marmo_mo_filters <- data.frame(
 # ----------------------------
 # Include modified_gene filter values for genes modified in any included model
 # Note: like human gene symbols, marmoset gene symbols use all caps
-marmo_mo_modified_gene_filter_vals <- c(
-                               'PSEN1'
-                               )
+marmo_mo_modified_gene_filter_vals <- c('PSEN1')
 
 marmo_mo_filter_values <- list(
   c('Plasma Biomarkers'),

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -444,6 +444,10 @@ build_dc_objects <- function() {
 # **************
 # Model Overview
 # **************
+
+# ********************
+# Mouse Model Overview
+# ********************
 # name, type, data_key, tooltip, sort_tooltip, link_url, link_text, is_exported, is_hidden
 #
 mo_columns <- data.frame(
@@ -483,6 +487,8 @@ mo_filters <- data.frame(
 # Model Overview Filter Values
 # ----------------------------
 # Include modified_gene filter values for genes modified in any included model
+# - Mouse gene symbols use initial caps, e.g. Psen1
+# - For human transgenes introduced into mouse models use all caps, e.g. PSEN1
 mo_modified_gene_filter_vals <- c('Abca7',
                                'APOE',
                                'APP',
@@ -513,7 +519,68 @@ build_mo_object <- function() {
 
   # Assemble the ui_config object
   list(
-    page = "Model Overview",
+    page = "Mouse Model Overview",
+    dropdowns = list(),
+    row_count = model_overview_row_count,
+    columns = columns,
+    filters = filters
+  )
+}
+
+
+# ********************
+# Marmo Model Overview
+# ********************
+
+marmo_ad_adkp_study_url <- "https://adknowledgeportal.synapse.org/Explore/Studies/DetailsPage/StudyDetails?Study=syn61849889"
+
+# name, type, data_key, tooltip, sort_tooltip, link_url, link_text, is_exported, is_hidden
+#
+marmo_mo_columns <- data.frame(
+  name = c("Model", "Model Type", "Plasma Biomarkers", "Study Data", NA, NA),
+  type = c("primary", "text", "link_internal", "link_external", "text", "text"),
+  data_key = c("name", "model_type", "biomarkers", "study_data", "modified_genes", "available_data"),
+  tooltip = c("Marmoset Model",  rep(NA, times = 5)),
+  sort_tooltip = rep(NA, times = 6),
+  link_url = c(NA, NA, NA, marmo_ad_adkp_study_url, NA, NA),
+  link_text = c(NA, NA, "Results", "View Data", NA, NA),
+  is_exported = c(TRUE, TRUE, TRUE, TRUE, TRUE, FALSE),
+  is_hidden = c(FALSE, FALSE, FALSE, FALSE, TRUE, TRUE),
+  stringsAsFactors = FALSE
+)
+
+# Marmo Model Overview Filters
+# ----------------------
+marmo_mo_filters <- data.frame(
+  name = c('Available Data', 'Model Type', 'Modified Gene'),
+  data_key = c('available_data', 'model_type', 'modified_genes'),
+  short_name = c('Data', 'Type', 'Gene'),
+  query_param_key = c('availableData', 'modelTypes', 'modifiedGenes'),
+  stringsAsFactors = FALSE
+)
+
+# Marmo Model Overview Filter Values
+# ----------------------------
+# Include modified_gene filter values for genes modified in any included model
+# Note: like human gene symbols, marmoset gene symbols use all caps
+marmo_mo_modified_gene_filter_vals <- c(
+                               'PSEN1'
+                               )
+
+marmo_mo_filter_values <- list(
+  c('Plasma Biomarkers'),
+  model_type_filter_vals,
+  marmo_mo_modified_gene_filter_vals
+)
+
+# Generates Model Overview ui_config objects
+build_marmo_mo_object <- function() {
+  columns <- build_object(marmo_mo_columns)
+  filters <- build_filters(marmo_mo_filters, marmo_mo_filter_values)
+
+  # Assemble the ui_config object
+  list(
+    page = "Marmoset Model Overview",
     dropdowns = list(),
     row_count = model_overview_row_count,
     columns = columns,
@@ -532,7 +599,8 @@ build_mo_object <- function() {
 json_list <- c(
   build_ge_objects(),
   build_dc_objects(),
-  list(build_mo_object())
+  list(build_mo_object()),
+  list(build_marmo_mo_object())
 )
 
 json_output <- toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -167,7 +167,6 @@ build_filters <- function(filter_defs, filter_values) {
 # ------------------------------
 ge_menu1 <- c("RNA - DIFFERENTIAL EXPRESSION")
 ge_menu2 <- c("Tissue - Hemibrain", "Tissue - Cerebral Cortex", "Tissue - Hippocampus")
-ge_menu3 <- c("Sex - Females & Males", "Sex - Females", "Sex - Males")
 
 # Differential Expression Columns
 # -------------------------
@@ -176,11 +175,11 @@ ge_menu3 <- c("Sex - Females & Males", "Sex - Females", "Sex - Males")
 # Static columns are the same across all views
 ge_primary_column <- list("Gene", "primary", "gene_symbol", "Mouse Gene", NA, NA, NA, TRUE, FALSE)
 ge_model_column <- list("Model", "link_internal", "name", "Mouse Model", "Sort by Model value", NA, NA, TRUE, FALSE)
+ge_sex_column <- list("Sex", "text", "sex_cohort", NA, "Sort by Sex value", NA, NA, TRUE, FALSE)
 ge_matched_control_column <- list("Control", "text", "matched_control", NA, "Sort by Control value", NA, NA, TRUE, FALSE)
 
 # Hidden static columns
 ge_tissue_column <- list(NA, "text", "tissue", NA, NA, NA, NA, TRUE, TRUE)
-ge_sex_cohort_column <- list(NA, "text", "sex_cohort", NA, NA, NA, NA, TRUE, TRUE)
 ge_biodomains_column <- list(NA, "text", "biodomains", NA, NA, NA, NA, TRUE, TRUE)
 ge_model_group_column <- list(NA, "text", "model_group", NA, NA, NA, NA, FALSE, TRUE)
 ge_model_type_column <- list(NA, "text", "model_type", NA, NA, NA, NA, TRUE, TRUE)
@@ -200,10 +199,10 @@ ge_dynamic_names_uci <- c("4 months", "12 months", "18 months")
 # Differential Expression Filters
 # -----------------------
 ge_filters <- data.frame(
-  name = c('Biological Domain', 'Model Type', 'Mouse Model'),
-  data_key = c('biodomains', 'model_type', 'name'),
-  short_name = c('Biodomain', 'Type', 'Model'),
-  query_param_key = c('biodomains', 'modelTypes', 'models'),
+  name = c('Biological Domain', 'Model Type', 'Mouse Model', 'Sex'),
+  data_key = c('biodomains', 'model_type', 'name', 'sex_cohort'),
+  short_name = c('Biodomain', 'Type', 'Model', 'Sex'),
+  query_param_key = c('biodomains', 'modelTypes', 'models', 'sex'),
   stringsAsFactors = FALSE
 )
 
@@ -237,8 +236,8 @@ build_ge_objects <- function() {
   primary <- do.call(build_column, ge_primary_column)
   ensembl_gene_id  <- do.call(build_column, ge_ensembl_gene_id_column)
   tissue <- do.call(build_column, ge_tissue_column)
-  sex_cohort <- do.call(build_column, ge_sex_cohort_column)
   model <- do.call(build_column, ge_model_column)
+  sex <- do.call(build_column, ge_sex_column)
   matched_control <- do.call(build_column, ge_matched_control_column)
   biodomains <- do.call(build_column, ge_biodomains_column)
   model_group <- do.call(build_column, ge_model_group_column)
@@ -246,7 +245,7 @@ build_ge_objects <- function() {
 
 
   # Build a ui_config for each possible combination of dropdown menu options
-  dropdown_combos <- expand.grid(menu1 = ge_menu1, menu2 = ge_menu2, menu3 = ge_menu3, stringsAsFactors = FALSE)
+  dropdown_combos <- expand.grid(menu1 = ge_menu1, menu2 = ge_menu2, stringsAsFactors = FALSE)
   lapply(seq_len(nrow(dropdown_combos)), function(i) {
     combo <- dropdown_combos[i, ]
 
@@ -272,11 +271,12 @@ build_ge_objects <- function() {
     ge_filter_values <- list(
       biodomain_filter_vals,
       model_type_filter_vals,
-      dynamic_model_filters
+      dynamic_model_filters,
+      sex_filter_vals
     )
 
     # The column ordering is mirrored when a CSV is generated
-    columns <- c(list(primary, ensembl_gene_id, tissue, sex_cohort, model, matched_control), dynamic_columns, c(list(biodomains, model_type, model_group)))
+    columns <- c(list(primary, ensembl_gene_id, tissue, model, sex, matched_control), dynamic_columns, c(list(biodomains, model_type, model_group)))
     filters <- build_filters(ge_filters, ge_filter_values)
 
     list(

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -519,7 +519,7 @@ build_mo_object <- function() {
 
   # Assemble the ui_config object
   list(
-    page = "Mouse Model Overview",
+    page = "Model Overview",
     dropdowns = list(),
     row_count = model_overview_row_count,
     columns = columns,


### PR DESCRIPTION
Note: This PR builds on the changes made in the[ MG-942 PR](https://github.com/Sage-Bionetworks/agora-data-tools/pull/336).

# Problem

We want to add a new Marmoset Model Overview CT in our next release, and that requires `ui_config` to define each view supported by the new CT.


# Solution

This PR extends the Model AD ui_config notebook to generate the`ui_config` required to support the new Marmoset Model Overview CT. Like the mouse Model Overview, this CT has ony one view so we need only one new `ui_config` object.

A new version of ui_config is in Synpase: [syn66527739.33](https://www.synapse.org/Synapse:syn66527739.33)

