### PR TITLE
AG-2151: Save GX reports to staging folder

### DIFF
--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -42,7 +42,7 @@ class GreatExpectationsRunner:
         syn: Synapse,
         dataset_path: str,
         dataset_name: str,
-        staging_path: str = None,
+        staging_path: str,
         upload_folder: str = None,
         nested_columns: typing.List[str] = None,
     ):

--- a/src/agoradatatools/gx.py
+++ b/src/agoradatatools/gx.py
@@ -42,6 +42,7 @@ class GreatExpectationsRunner:
         syn: Synapse,
         dataset_path: str,
         dataset_name: str,
+        staging_path: str = None,
         upload_folder: str = None,
         nested_columns: typing.List[str] = None,
     ):
@@ -49,6 +50,7 @@ class GreatExpectationsRunner:
         self.syn = syn
         self.dataset_path = dataset_path
         self.expectation_suite_name = dataset_name
+        self.staging_path = staging_path
         self.upload_folder = upload_folder
         self.nested_columns = nested_columns
         self.gx_project_dir = self._get_data_context_location()
@@ -126,6 +128,25 @@ class GreatExpectationsRunner:
 
         shutil.copy(original_results_path, new_results_path)
         return new_results_path
+
+    def write_report_to_staging(self, results_path: str) -> str:
+        """Copies the GX HTML report into a `gx_reports` subdirectory of the staging
+        directory so it can be viewed locally regardless of whether results are
+        uploaded to Synapse.
+
+        Args:
+            results_path (str): Path to the GX report file.
+
+        Returns:
+            str: Path to the report copied into the staging directory.
+        """
+        gx_reports_dir = os.path.join(self.staging_path, "gx_reports")
+        os.makedirs(gx_reports_dir, exist_ok=True)
+        staging_report_path = os.path.join(
+            gx_reports_dir, os.path.basename(results_path)
+        )
+        shutil.copy(results_path, staging_report_path)
+        return staging_report_path
 
     def upload_results_file_to_synapse(self, results_path: str) -> None:
         """Uploads a results file to Synapse. Assigns class attributes associated
@@ -278,8 +299,11 @@ class GreatExpectationsRunner:
         logger.info(
             f"Data validation complete for {self.expectation_suite_name}. Uploading results to Synapse."
         )
-        latest_reults_path = self.get_results_path(checkpoint_result)
+        latest_results_path = self.get_results_path(checkpoint_result)
         self.set_warnings_and_failures(checkpoint_result)
 
+        # Always write the report locally so it can be viewed without uploading.
+        self.write_report_to_staging(latest_results_path)
+
         if self.upload_folder:
-            self.upload_results_file_to_synapse(latest_reults_path)
+            self.upload_results_file_to_synapse(latest_results_path)

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -280,6 +280,7 @@ def process_dataset(
             syn=syn,
             dataset_path=json_path,
             dataset_name=dataset_name,
+            staging_path=staging_path,
             upload_folder=gx_folder if upload else None,
             nested_columns=(
                 dataset_obj[dataset_name]["gx_nested_columns"]

--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -395,8 +395,8 @@ def process_all_files(
     destination = config["destination"]
     gx_table = config["gx_table"]
 
-    staging_path = config.get("staging_path", None)
-    load.create_temp_location(staging_path=staging_path or "./staging")
+    staging_path = config.get("staging_path") or "./staging"
+    load.create_temp_location(staging_path=staging_path)
 
     reporter = ADTGXReporter(
         syn=syn,

--- a/tests/test_gx.py
+++ b/tests/test_gx.py
@@ -27,6 +27,7 @@ class TestGreatExpectationsRunner:
             syn=syn,
             dataset_path="./tests/test_assets/gx/metabolomics.json",
             dataset_name="metabolomics",
+            staging_path="./test_staging",
             upload_folder="test_folder",
             nested_columns=None,
         )
@@ -34,6 +35,7 @@ class TestGreatExpectationsRunner:
             syn=syn,
             dataset_path="./tests/test_assets/gx/not_supported_dataset.json",
             dataset_name="not_supported_dataset",
+            staging_path="./test_staging",
             upload_folder="test_folder",
             nested_columns=None,
         )
@@ -58,6 +60,7 @@ class TestGreatExpectationsRunner:
             self.good_runner.dataset_path == "./tests/test_assets/gx/metabolomics.json"
         )
         assert self.good_runner.expectation_suite_name == "metabolomics"
+        assert self.good_runner.staging_path == "./test_staging"
         assert self.good_runner.upload_folder == "test_folder"
         assert self.good_runner.nested_columns is None
         assert (
@@ -119,6 +122,29 @@ class TestGreatExpectationsRunner:
                 + f"/test/path/to/{self.good_runner.expectation_suite_name}.html",
             )
             assert result == expected
+
+    def test_write_report_to_staging(self):
+        results_path = "/path/to/validations/metabolomics.html"
+        expected_dir = os.path.join(self.good_runner.staging_path, "gx_reports")
+        expected_path = os.path.join(expected_dir, "metabolomics.html")
+        with patch.object(os, "makedirs") as patch_makedirs, patch.object(
+            shutil, "copy"
+        ) as patch_copy:
+            result = self.good_runner.write_report_to_staging(results_path)
+            patch_makedirs.assert_called_once_with(expected_dir, exist_ok=True)
+            patch_copy.assert_called_once_with(results_path, expected_path)
+            assert result == expected_path
+
+    def test_write_report_to_staging_is_called_even_without_upload_folder(self):
+        self.good_runner.upload_folder = None
+        results_path = "/path/to/validations/metabolomics.html"
+        expected_path = os.path.join(
+            self.good_runner.staging_path, "gx_reports", "metabolomics.html"
+        )
+        with patch.object(os, "makedirs"), patch.object(shutil, "copy") as patch_copy:
+            result = self.good_runner.write_report_to_staging(results_path)
+            patch_copy.assert_called_once_with(results_path, expected_path)
+            assert result == expected_path
 
     def test_upload_results_file_to_synapse(self):
         with patch.object(
@@ -237,6 +263,8 @@ class TestGreatExpectationsRunner:
         ) as patch_convert_nested_columns_to_json, patch.object(
             self.good_runner, "get_results_path", return_value="test_path"
         ) as patch_get_results_path, patch.object(
+            self.good_runner, "write_report_to_staging", return_value=None
+        ) as patch_write_report_to_staging, patch.object(
             self.good_runner, "upload_results_file_to_synapse", return_value=None
         ) as patch_upload_results_file_to_synapse, patch.object(
             Checkpoint,
@@ -254,6 +282,7 @@ class TestGreatExpectationsRunner:
             patch_convert_nested_columns_to_json.assert_called_once()
             patch_checkpoint_run.assert_called_once()
             patch_get_results_path.assert_called_once()
+            patch_write_report_to_staging.assert_called_once_with("test_path")
             patch_upload_results_file_to_synapse.assert_called_once_with("test_path")
             patch_set_warnings_and_failures.assert_called_once_with(
                 patch_checkpoint_run.return_value
@@ -273,6 +302,8 @@ class TestGreatExpectationsRunner:
         ) as patch_convert_nested_columns_to_json, patch.object(
             self.good_runner, "get_results_path", return_value="test_path"
         ) as patch_get_results_path, patch.object(
+            self.good_runner, "write_report_to_staging", return_value=None
+        ) as patch_write_report_to_staging, patch.object(
             self.good_runner, "upload_results_file_to_synapse", return_value=None
         ) as patch_upload_results_file_to_synapse, patch.object(
             Checkpoint,
@@ -289,6 +320,7 @@ class TestGreatExpectationsRunner:
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_checkpoint_run.assert_called_once()
             patch_get_results_path.assert_called_once()
+            patch_write_report_to_staging.assert_called_once_with("test_path")
             patch_upload_results_file_to_synapse.assert_called_once_with("test_path")
             patch_set_warnings_and_failures.assert_called_once_with(
                 self.passed_checkpoint_result
@@ -308,6 +340,8 @@ class TestGreatExpectationsRunner:
         ) as patch_convert_nested_columns_to_json, patch.object(
             self.good_runner, "get_results_path", return_value="test_path"
         ) as patch_get_results_path, patch.object(
+            self.good_runner, "write_report_to_staging", return_value=None
+        ) as patch_write_report_to_staging, patch.object(
             self.good_runner, "upload_results_file_to_synapse", return_value=None
         ) as patch_upload_results_file_to_synapse, patch.object(
             Checkpoint,
@@ -321,6 +355,7 @@ class TestGreatExpectationsRunner:
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_checkpoint_run.assert_not_called()
             patch_get_results_path.assert_not_called()
+            patch_write_report_to_staging.assert_not_called()
             patch_upload_results_file_to_synapse.assert_not_called()
             patch_set_warnings_and_failures.assert_not_called()
 
@@ -338,6 +373,8 @@ class TestGreatExpectationsRunner:
         ) as patch_convert_nested_columns_to_json, patch.object(
             self.good_runner, "get_results_path", return_value="test_path"
         ) as patch_get_results_path, patch.object(
+            self.good_runner, "write_report_to_staging", return_value=None
+        ) as patch_write_report_to_staging, patch.object(
             self.good_runner, "upload_results_file_to_synapse", return_value=None
         ) as patch_upload_results_file_to_synapse, patch.object(
             Checkpoint,
@@ -354,6 +391,7 @@ class TestGreatExpectationsRunner:
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_checkpoint_run.assert_called_once()
             patch_get_results_path.assert_called_once()
+            patch_write_report_to_staging.assert_called_once_with("test_path")
             patch_upload_results_file_to_synapse.assert_called_once_with("test_path")
             patch_set_warnings_and_failures.assert_called_once_with(
                 patch_checkpoint_run.return_value
@@ -373,6 +411,8 @@ class TestGreatExpectationsRunner:
         ) as patch_convert_nested_columns_to_json, patch.object(
             self.good_runner, "get_results_path", return_value="test_path"
         ) as patch_get_results_path, patch.object(
+            self.good_runner, "write_report_to_staging", return_value=None
+        ) as patch_write_report_to_staging, patch.object(
             self.good_runner, "upload_results_file_to_synapse", return_value=None
         ) as patch_upload_results_file_to_synapse, patch.object(
             Checkpoint,
@@ -390,6 +430,7 @@ class TestGreatExpectationsRunner:
             patch_convert_nested_columns_to_json.assert_not_called()
             patch_checkpoint_run.assert_called_once()
             patch_get_results_path.assert_called_once()
+            patch_write_report_to_staging.assert_called_once_with("test_path")
             patch_upload_results_file_to_synapse.assert_not_called()
             patch_set_warnings_and_failures.assert_called_once_with(
                 self.passed_checkpoint_result
@@ -411,6 +452,7 @@ class TestCustomJSONSchemaRulesRunner:
             syn=syn,
             dataset_path="./tests/test_assets/gx/test_nested_columns.json",
             dataset_name="test_nested_columns",
+            staging_path="./test_staging",
             upload_folder="test_folder",
             nested_columns=["columns"],
         )
@@ -418,6 +460,7 @@ class TestCustomJSONSchemaRulesRunner:
             syn=syn,
             dataset_path="./tests/test_assets/gx/test_nested_columns.json",
             dataset_name="test_nested_columns",
+            staging_path="./test_staging",
             upload_folder="test_folder",
             nested_columns=["columns"],
         )

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1302,6 +1302,35 @@ class TestProcessAllFiles:
         self.patch_format_link.assert_called_once_with(syn_id="syn123", version=1)
         self.patch_update_table.assert_called_once()
 
+    def test_process_all_files_defaults_staging_path_when_undefined(self, syn: Any):
+        config_without_staging_path = {
+            "destination": "destination",
+            "gx_folder": GX_FOLDER,
+            "gx_table": "syn321",
+            "team_images_id": "syn987",
+            "datasets": [{"a": {"b": "c"}}],
+        }
+        with patch.object(
+            utils, "_get_config", return_value=config_without_staging_path
+        ):
+            process.process_all_files(
+                syn=syn,
+                config_path=self.config_path,
+                platform=Platform.LOCAL,
+                run_id="123",
+                upload=False,
+            )
+        self.patch_create_temp_location.assert_called_once_with(
+            staging_path="./staging"
+        )
+        self.patch_process_dataset.assert_any_call(
+            dataset_obj={"a": {"b": "c"}},
+            staging_path="./staging",
+            gx_folder=GX_FOLDER,
+            syn=syn,
+            upload=False,
+        )
+
     def test_process_all_files_upload_false_gx_failure(self, syn: Any):
         with pytest.raises(
             ADTDataProcessingError,


### PR DESCRIPTION
# Problem

When processing data locally, output dataset files are saved to the `./staging` directory. 

However, GX reports are not saved locally. To view GX reports for local runs, you need to:

1. Process with the `--upload` flag
2. Download the reports from Synapse


# Solution

Extend the GX runner to save GX reports to `./staging/gx_reports` so that they can be more easily viewed during local development.

AI disclosure: 
Code authored by Claude
