### PR TITLE
AG-2150: Write to GX records table when uploading GX reports, always and only

### DIFF
--- a/src/agoradatatools/process.py
+++ b/src/agoradatatools/process.py
@@ -402,6 +402,7 @@ def process_all_files(
         platform=platform,
         run_id=run_id,
         table_id=gx_table,
+        upload=upload,
     )
     if filter_datasets:
         # Each entry in datasets is a single-key dict where the key is the dataset name (e.g. {"gene_info": {...}}).

--- a/src/agoradatatools/reporter.py
+++ b/src/agoradatatools/reporter.py
@@ -124,13 +124,10 @@ class ADTGXReporter:
             )
 
     def update_table(self) -> None:
-        """Updates the Synapse table adding one new row for each DatasetReport object.
-
-        The table is updated for non-LOCAL platforms, or for LOCAL runs that uploaded
-        their outputs to Synapse (i.e. the `--upload` flag was set), as long as there
-        is at least one report to add.
+        """Updates the Synapse GX report table, adding one new row for each DatasetReport object that is
+        uploaded to Synapse.
         """
-        if (self.platform != Platform.LOCAL or self.upload) and self.reports:
+        if self.upload and self.reports:
             self._update_reports_before_upload()
             self.syn.store(
                 synapseclient.Table(

--- a/src/agoradatatools/reporter.py
+++ b/src/agoradatatools/reporter.py
@@ -85,7 +85,7 @@ class ADTGXReporter:
         platform: The platform where the processing was run.
         run_id: The id of the processing run. This will be passed from the `process` CLI command.
         table_id: Synapse ID of the Synapse table to be updated.
-        upload: Whether or not the processing run uploaded its outputs to Synapse.
+        upload: Whether upload to Synapse is enabled for the processing run.
         data_manifest_file: Synapse ID of the ADT manifest file.
         data_manifest_version: Version number of the ADT manifest file.
         data_manifest_link: URL of the specific version of the ADT manifest file.

--- a/src/agoradatatools/reporter.py
+++ b/src/agoradatatools/reporter.py
@@ -85,6 +85,7 @@ class ADTGXReporter:
         platform: The platform where the processing was run.
         run_id: The id of the processing run. This will be passed from the `process` CLI command.
         table_id: Synapse ID of the Synapse table to be updated.
+        upload: Whether or not the processing run uploaded its outputs to Synapse.
         data_manifest_file: Synapse ID of the ADT manifest file.
         data_manifest_version: Version number of the ADT manifest file.
         data_manifest_link: URL of the specific version of the ADT manifest file.
@@ -95,6 +96,7 @@ class ADTGXReporter:
     platform: Platform
     run_id: str
     table_id: str
+    upload: bool = field(default=False)
     data_manifest_file: Optional[str] = field(default=None)
     data_manifest_version: Optional[int] = field(default=None)
     data_manifest_link: Optional[str] = field(default=None)
@@ -122,8 +124,13 @@ class ADTGXReporter:
             )
 
     def update_table(self) -> None:
-        """Updates the Synapse table adding one new row for each DatasetReport object if the platform is not LOCAL."""
-        if self.platform != Platform.LOCAL and self.reports:
+        """Updates the Synapse table adding one new row for each DatasetReport object.
+
+        The table is updated for non-LOCAL platforms, or for LOCAL runs that uploaded
+        their outputs to Synapse (i.e. the `--upload` flag was set), as long as there
+        is at least one report to add.
+        """
+        if (self.platform != Platform.LOCAL or self.upload) and self.reports:
             self._update_reports_before_upload()
             self.syn.store(
                 synapseclient.Table(

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -45,6 +45,13 @@ class TestADTGXReporter:
             run_id="test_run_id",
             table_id="syn123",
         )
+        self.test_reporter_local_upload = ADTGXReporter(
+            syn=syn,
+            platform=Platform.LOCAL,
+            run_id="test_run_id",
+            table_id="syn123",
+            upload=True,
+        )
         self.test_report = DatasetReport()
         self.upload_report = DatasetReport(
             timestamp="test_timestamp",
@@ -83,11 +90,33 @@ class TestADTGXReporter:
             mock_store.assert_called_once()
             mock_update_reports_before_upload.assert_called_once()
 
-    def test_update_table_when_platform_is_local(self, syn):
+    def test_update_table_when_platform_is_local_and_upload_is_false(self, syn):
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
+            self.test_reporter_local.reports = [self.test_report]
             self.test_reporter_local.update_table()
+
+            mock_store.assert_not_called()
+            mock_update_reports_before_upload.assert_not_called()
+
+    def test_update_table_when_platform_is_local_and_upload_is_true(self, syn):
+        with patch.object(syn, "store") as mock_store, patch.object(
+            self.test_reporter_local_upload, "_update_reports_before_upload"
+        ) as mock_update_reports_before_upload:
+            self.test_reporter_local_upload.reports = [self.test_report]
+            self.test_reporter_local_upload.update_table()
+
+            mock_store.assert_called_once()
+            mock_update_reports_before_upload.assert_called_once()
+
+    def test_update_table_when_platform_is_local_and_upload_is_true_but_reports_empty(
+        self, syn
+    ):
+        with patch.object(syn, "store") as mock_store, patch.object(
+            self.test_reporter_local_upload, "_update_reports_before_upload"
+        ) as mock_update_reports_before_upload:
+            self.test_reporter_local_upload.update_table()
 
             mock_store.assert_not_called()
             mock_update_reports_before_upload.assert_not_called()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -3,9 +3,8 @@ import datetime
 
 from unittest.mock import patch, Mock
 
-from typing import Any
-
 import agoradatatools.reporter
+import synapseclient
 
 from agoradatatools.reporter import ADTGXReporter, DatasetReport
 from agoradatatools.constants import Platform
@@ -91,7 +90,7 @@ class TestADTGXReporter:
         assert self.test_reporter.reports[0] == self.upload_report
 
     def test_update_table_platform_not_local_and_reports_not_empty(
-        self, syn: Any
+        self, syn: synapseclient.Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter, "_update_reports_before_upload"
@@ -103,7 +102,7 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_called_once()
 
     def test_update_table_when_platform_is_local_and_upload_is_false(
-        self, syn: Any
+        self, syn: synapseclient.Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local, "_update_reports_before_upload"
@@ -115,7 +114,7 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_not_called()
 
     def test_update_table_when_platform_is_local_and_upload_is_true(
-        self, syn: Any
+        self, syn: synapseclient.Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local_upload, "_update_reports_before_upload"
@@ -127,7 +126,7 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_called_once()
 
     def test_update_table_when_platform_is_local_and_upload_is_true_but_reports_empty(
-        self, syn: Any
+        self, syn: synapseclient.Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local_upload, "_update_reports_before_upload"
@@ -137,7 +136,9 @@ class TestADTGXReporter:
             mock_store.assert_not_called()
             mock_update_reports_before_upload.assert_not_called()
 
-    def test_update_table_platform_not_local_and_reports_empty(self, syn: Any) -> None:
+    def test_update_table_platform_not_local_and_reports_empty(
+        self, syn: synapseclient.Synapse
+    ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
@@ -147,7 +148,7 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_not_called()
 
     def test_update_table_platform_not_local_and_upload_is_false(
-        self, syn: Any
+        self, syn: synapseclient.Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_no_upload, "_update_reports_before_upload"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -3,6 +3,8 @@ import datetime
 
 from unittest.mock import patch, Mock
 
+from typing import Any
+
 import agoradatatools.reporter
 
 from agoradatatools.reporter import ADTGXReporter, DatasetReport
@@ -88,7 +90,9 @@ class TestADTGXReporter:
         mock_datetime.datetime.now.return_value.strftime.assert_called_once()
         assert self.test_reporter.reports[0] == self.upload_report
 
-    def test_update_table_platform_not_local_and_reports_not_empty(self, syn):
+    def test_update_table_platform_not_local_and_reports_not_empty(
+        self, syn: Any
+    ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
@@ -98,7 +102,9 @@ class TestADTGXReporter:
             mock_store.assert_called_once()
             mock_update_reports_before_upload.assert_called_once()
 
-    def test_update_table_when_platform_is_local_and_upload_is_false(self, syn):
+    def test_update_table_when_platform_is_local_and_upload_is_false(
+        self, syn: Any
+    ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
@@ -108,7 +114,9 @@ class TestADTGXReporter:
             mock_store.assert_not_called()
             mock_update_reports_before_upload.assert_not_called()
 
-    def test_update_table_when_platform_is_local_and_upload_is_true(self, syn):
+    def test_update_table_when_platform_is_local_and_upload_is_true(
+        self, syn: Any
+    ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local_upload, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
@@ -119,8 +127,8 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_called_once()
 
     def test_update_table_when_platform_is_local_and_upload_is_true_but_reports_empty(
-        self, syn
-    ):
+        self, syn: Any
+    ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local_upload, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
@@ -129,7 +137,7 @@ class TestADTGXReporter:
             mock_store.assert_not_called()
             mock_update_reports_before_upload.assert_not_called()
 
-    def test_update_table_platform_not_local_and_reports_empty(self, syn):
+    def test_update_table_platform_not_local_and_reports_empty(self, syn: Any) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
@@ -138,7 +146,9 @@ class TestADTGXReporter:
             mock_store.assert_not_called()
             mock_update_reports_before_upload.assert_not_called()
 
-    def test_update_table_platform_not_local_and_upload_is_false(self, syn):
+    def test_update_table_platform_not_local_and_upload_is_false(
+        self, syn: Any
+    ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_no_upload, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -3,11 +3,13 @@ import datetime
 
 from unittest.mock import patch, Mock
 
+from synapseclient import Synapse
+
 import agoradatatools.reporter
-import synapseclient
 
 from agoradatatools.reporter import ADTGXReporter, DatasetReport
 from agoradatatools.constants import Platform
+
 
 
 class TestDatasetReport:
@@ -90,7 +92,7 @@ class TestADTGXReporter:
         assert self.test_reporter.reports[0] == self.upload_report
 
     def test_update_table_platform_not_local_and_reports_not_empty(
-        self, syn: synapseclient.Synapse
+        self, syn: Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter, "_update_reports_before_upload"
@@ -102,7 +104,7 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_called_once()
 
     def test_update_table_when_platform_is_local_and_upload_is_false(
-        self, syn: synapseclient.Synapse
+        self, syn: Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local, "_update_reports_before_upload"
@@ -114,7 +116,7 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_not_called()
 
     def test_update_table_when_platform_is_local_and_upload_is_true(
-        self, syn: synapseclient.Synapse
+        self, syn: Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local_upload, "_update_reports_before_upload"
@@ -126,7 +128,7 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_called_once()
 
     def test_update_table_when_platform_is_local_and_upload_is_true_but_reports_empty(
-        self, syn: synapseclient.Synapse
+        self, syn: Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_local_upload, "_update_reports_before_upload"
@@ -137,7 +139,7 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_not_called()
 
     def test_update_table_platform_not_local_and_reports_empty(
-        self, syn: synapseclient.Synapse
+        self, syn: Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter, "_update_reports_before_upload"
@@ -148,7 +150,7 @@ class TestADTGXReporter:
             mock_update_reports_before_upload.assert_not_called()
 
     def test_update_table_platform_not_local_and_upload_is_false(
-        self, syn: synapseclient.Synapse
+        self, syn: Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_no_upload, "_update_reports_before_upload"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -35,9 +35,17 @@ class TestADTGXReporter:
             platform=Platform.GITHUB,
             run_id="test_run_id",
             table_id="syn123",
+            upload=True,
             data_manifest_file="syn456",
             data_manifest_version=1,
             data_manifest_link="test_link",
+        )
+        self.test_reporter_no_upload = ADTGXReporter(
+            syn=syn,
+            platform=Platform.GITHUB,
+            run_id="test_run_id",
+            table_id="syn123",
+            upload=False,
         )
         self.test_reporter_local = ADTGXReporter(
             syn=syn,
@@ -126,6 +134,16 @@ class TestADTGXReporter:
             self.test_reporter, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
             self.test_reporter.update_table()
+
+            mock_store.assert_not_called()
+            mock_update_reports_before_upload.assert_not_called()
+
+    def test_update_table_platform_not_local_and_upload_is_false(self, syn):
+        with patch.object(syn, "store") as mock_store, patch.object(
+            self.test_reporter_no_upload, "_update_reports_before_upload"
+        ) as mock_update_reports_before_upload:
+            self.test_reporter_no_upload.reports = [self.test_report]
+            self.test_reporter_no_upload.update_table()
 
             mock_store.assert_not_called()
             mock_update_reports_before_upload.assert_not_called()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -11,7 +11,6 @@ from agoradatatools.reporter import ADTGXReporter, DatasetReport
 from agoradatatools.constants import Platform
 
 
-
 class TestDatasetReport:
     @pytest.fixture(scope="function", autouse=True)
     def setup_method(self, syn):
@@ -50,19 +49,6 @@ class TestADTGXReporter:
             table_id="syn123",
             upload=False,
         )
-        self.test_reporter_local = ADTGXReporter(
-            syn=syn,
-            platform=Platform.LOCAL,
-            run_id="test_run_id",
-            table_id="syn123",
-        )
-        self.test_reporter_local_upload = ADTGXReporter(
-            syn=syn,
-            platform=Platform.LOCAL,
-            run_id="test_run_id",
-            table_id="syn123",
-            upload=True,
-        )
         self.test_report = DatasetReport()
         self.upload_report = DatasetReport(
             timestamp="test_timestamp",
@@ -91,7 +77,7 @@ class TestADTGXReporter:
         mock_datetime.datetime.now.return_value.strftime.assert_called_once()
         assert self.test_reporter.reports[0] == self.upload_report
 
-    def test_update_table_platform_not_local_and_reports_not_empty(
+    def test_update_table_when_upload_is_true_and_reports_not_empty(
         self, syn: Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
@@ -103,42 +89,7 @@ class TestADTGXReporter:
             mock_store.assert_called_once()
             mock_update_reports_before_upload.assert_called_once()
 
-    def test_update_table_when_platform_is_local_and_upload_is_false(
-        self, syn: Synapse
-    ) -> None:
-        with patch.object(syn, "store") as mock_store, patch.object(
-            self.test_reporter_local, "_update_reports_before_upload"
-        ) as mock_update_reports_before_upload:
-            self.test_reporter_local.reports = [self.test_report]
-            self.test_reporter_local.update_table()
-
-            mock_store.assert_not_called()
-            mock_update_reports_before_upload.assert_not_called()
-
-    def test_update_table_when_platform_is_local_and_upload_is_true(
-        self, syn: Synapse
-    ) -> None:
-        with patch.object(syn, "store") as mock_store, patch.object(
-            self.test_reporter_local_upload, "_update_reports_before_upload"
-        ) as mock_update_reports_before_upload:
-            self.test_reporter_local_upload.reports = [self.test_report]
-            self.test_reporter_local_upload.update_table()
-
-            mock_store.assert_called_once()
-            mock_update_reports_before_upload.assert_called_once()
-
-    def test_update_table_when_platform_is_local_and_upload_is_true_but_reports_empty(
-        self, syn: Synapse
-    ) -> None:
-        with patch.object(syn, "store") as mock_store, patch.object(
-            self.test_reporter_local_upload, "_update_reports_before_upload"
-        ) as mock_update_reports_before_upload:
-            self.test_reporter_local_upload.update_table()
-
-            mock_store.assert_not_called()
-            mock_update_reports_before_upload.assert_not_called()
-
-    def test_update_table_platform_not_local_and_reports_empty(
+    def test_update_table_when_upload_is_true_and_reports_empty(
         self, syn: Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
@@ -149,13 +100,24 @@ class TestADTGXReporter:
             mock_store.assert_not_called()
             mock_update_reports_before_upload.assert_not_called()
 
-    def test_update_table_platform_not_local_and_upload_is_false(
+    def test_update_table_when_upload_is_false_and_reports_not_empty(
         self, syn: Synapse
     ) -> None:
         with patch.object(syn, "store") as mock_store, patch.object(
             self.test_reporter_no_upload, "_update_reports_before_upload"
         ) as mock_update_reports_before_upload:
             self.test_reporter_no_upload.reports = [self.test_report]
+            self.test_reporter_no_upload.update_table()
+
+            mock_store.assert_not_called()
+            mock_update_reports_before_upload.assert_not_called()
+
+    def test_update_table_when_upload_is_false_and_reports_empty(
+        self, syn: Synapse
+    ) -> None:
+        with patch.object(syn, "store") as mock_store, patch.object(
+            self.test_reporter_no_upload, "_update_reports_before_upload"
+        ) as mock_update_reports_before_upload:
             self.test_reporter_no_upload.update_table()
 
             mock_store.assert_not_called()


### PR DESCRIPTION
# Problem

For each GX report that's uploaded to Synapse, a row is supposed to be added to the `gx_table` specified in config. That row captures information that links each archived version of the report to a specific processing run.

The current implementation has two issues:
- When processing on the LOCAL platform with upload=TRUE, GX reports are uploaded but no table rows are written
- When processing on other platforms with upload=FALSE, table rows are written but no GX reports are uploaded


You can see that this is happening for the model_ad_preprod CI jobs that run with upload=FALSE; the corresponding [GX table](https://www.synapse.org/Synapse:syn71888382/tables/) is full of GITHUB rows with bogus report links: 
https://www.synapse.org/Synapse:None.None


# Solution

Propagate `upload` to ADTGXReporter so we can have conditional logic that aligns table row creation with GX report upload, rather than with processing platform.

AI disclosure:
Code authored by Claude