### PR TITLE
AG-2162: Update ui_config notebook to add missing FunGen filter

### DIFF
--- a/configs/agora_preprod.yaml
+++ b/configs/agora_preprod.yaml
@@ -12,7 +12,7 @@ files:
   - &gene_metadata                { name: gene_metadata               , format: feather, id: syn25953363.17  }
   - &igap                         { name: igap                        , format: csv    , id: syn12514826.5   }
   - &pharos_classes               { name: pharos_classes              , format: csv    , id: syn64123611.3   }
-  - &ui_config                    { name: ui_config                   , format: json   , id: syn73677126     }
+  - &ui_config                    { name: ui_config                   , format: json   , id: syn73677126.15     }
   # Results
   - &diff_exp_data                { name: diff_exp_data               , format: tsv    , id: syn27211942.1   }
   - &genes_biodomains             { name: genes_biodomains            , format: csv    , id: syn44151254.5   }

--- a/configs/agora_prod.yaml
+++ b/configs/agora_prod.yaml
@@ -12,7 +12,7 @@ files:
   - &gene_metadata                { name: gene_metadata               , format: feather, id: syn25953363.17  }
   - &igap                         { name: igap                        , format: csv    , id: syn12514826.5   }
   - &pharos_classes               { name: pharos_classes              , format: csv    , id: syn64123611.3   }
-  - &ui_config                    { name: ui_config                   , format: json   , id: syn73677126     }
+  - &ui_config                    { name: ui_config                   , format: json   , id: syn73677126.15     }
   # Results
   - &diff_exp_data                { name: diff_exp_data               , format: tsv    , id: syn27211942.1   }
   - &genes_biodomains             { name: genes_biodomains            , format: csv    , id: syn44151254.5   }

--- a/data_analysis/agora/notebooks/preprocessing/AG-2005_ui_config.rmd
+++ b/data_analysis/agora/notebooks/preprocessing/AG-2005_ui_config.rmd
@@ -188,7 +188,7 @@ targets_data_filter_values <- c("Behavior", "Clinical", "Genetics", "Metabolomic
 targets_first_nom_filter_values <- c(2018:2025)
 targets_team_filter_values <- c("ASU", "Chang Lab", "Columbia-Rush", "Duke", "Duke BARU", "Emory", "Emory-Sage-SGC", "Harvard-MIT", "IUSM-Purdue", "JAX-VUMC-UW Resilience", "Longo Lab", "Mayo", "Mayo-UFL-ISB", "MSSM - Roussos Lab", "MSSM - Zhang Lab")
 targets_pharos_filter_values <- c('Tbio', 'Tchem', 'Tclin', 'Tdark')
-targets_program_filter_values <- c("AMP-AD", "Community", "Resilience-AD", "TREAT-AD")
+targets_program_filter_values <- c("AMP-AD", "Community", "FunGen-AD", "Resilience-AD", "TREAT-AD")
 targets_total_nom_filter_values <- c(1:5)
 
 target_filter_values <- list(


### PR DESCRIPTION
# Problem

Our upcoming Agora release incorporates the very first nomination from the FunGen-AD consortium, but I forget to add FunGen-AD to the Program filter list.

We also need to pin the final version of ui_config.


# Solution

Update the ui_config notebook to populate the filter list with the missing FunGen-AD value

A new version of ui_config is in synapse here: https://www.synapse.org/Synapse:syn73677126.15

I also pinned that `ui_config` version for Agora's 4.3.0 release in this PR.