### PR TITLE
MG-946: Extend ui_config notebook to support mouse proteomics

### DIFF
--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -108,7 +108,10 @@ build_object <- function(page_column_data) {
 #   -- Specify NA for columns with other types
 # - is_exported: Whether this column should be included in CSV data exports
 # - is_hidden: Whether this column should be displayed in the CT table
-build_column <- function(name, type, data_key, tooltip, sort_tooltip, link_url, link_text, is_exported, is_hidden) {
+# - column_width: Optional override that specifies the column's width, in pixels
+#   -- By default, the column width is automatically calculated
+#   -- Specify a numeric value to specify a fixed width for columns with variable content length / auto widths
+build_column <- function(name, type, data_key, tooltip, sort_tooltip, link_url, link_text, is_exported, is_hidden, column_width = NA) {
 
   # Use the default sort_tooltip if one isn't specified, for non-hidden columns only
   if (is_hidden == TRUE) { sort_tooltip = NA }
@@ -123,7 +126,8 @@ build_column <- function(name, type, data_key, tooltip, sort_tooltip, link_url, 
     link_url = link_url ,
     link_text = link_text,
     is_exported = is_exported,
-    is_hidden = is_hidden
+    is_hidden = is_hidden,
+    column_width = column_width
   )
 
   # Omit keys with NA values
@@ -167,7 +171,7 @@ build_filters <- function(filter_defs, filter_values) {
 # Shared - Columns
 # ----------------
 # Static columns are the same across all DE views
-de_model_column <- list("Model", "link_internal", "name", "Mouse Model", "Sort by Model value", NA, NA, TRUE, FALSE)
+de_model_column <- list("Model", "link_internal", "name", "Mouse Model", "Sort by Model value", NA, NA, TRUE, FALSE, 220)
 de_sex_column <- list("Sex", "text", "sex", NA, "Sort by Sex value", NA, NA, TRUE, FALSE)
 de_matched_control_column <- list("Control", "text", "matched_control", NA, "Sort by Control value", NA, NA, TRUE, FALSE)
 
@@ -219,6 +223,7 @@ rna_de_model_name_filter_vals_hemibrain <- c(
                             '5xFAD (IU/Jax/Pitt)',
                             'APOE4',
                             'LOAD1',
+                            "LOAD2",
                             'Trem2R47H')
 
 # Cortex: 5xFAD (UCI); need to wrap single value in a list for JSON serialization
@@ -380,7 +385,7 @@ dc_menu2 <- c(
 #
 # All views have the same static column values
 dc_primary_column <- list("Model", "primary", "name", "Mouse Model", NA, NA, NA, TRUE, FALSE)
-dc_age_column <- list("Age", "text", "age", NA, "Sort by Age value", NA, NA, TRUE, FALSE)
+dc_age_column <- list("Age", "text", "age", NA, "Sort by Age value", NA, NA, TRUE, FALSE, 120)
 dc_sex_column <- list("Sex", "text", "sex", NA, "Sort by Sex value", NA, NA, TRUE, FALSE)
 
 # Hidden static columns
@@ -521,25 +526,28 @@ build_dc_objects <- function() {
 #
 mo_columns <- data.frame(
   name = c("Model", "Model Type", "Matched Controls",
-           "Transcriptomics", "Disease Correlation", "Biomarkers",
-           "Pathology", "Study Data", "JAX Strain",
-           "Center", NA, NA
+           "Transcriptomics", "Proteomics", "Disease Correlation",
+           "Biomarkers", "Pathology", "Study Data",
+           "JAX Strain", "Center", NA,
+           NA
   ),
   type = c("primary", "text", "text",
-    "link_internal", "link_internal", "link_internal",
-    "link_internal","link_external", "link_external",
-    "text", "text", "text"
+           "link_internal", "link_internal", "link_internal",
+           "link_internal", "link_internal", "link_external",
+           "link_external", "text", "text",
+           "text"
   ),
   data_key = c("name", "model_type", "matched_controls",
-               "transcriptomics", "disease_correlation", "biomarkers",
-               "pathology", "study_data", "jax_strain",
-               "center", "modified_genes", "available_data"),
-  tooltip = c("Mouse Model",  rep(NA, times = 11)),
-  sort_tooltip = rep(NA, times = 12),
-  link_url = rep(NA, times = 12),
-  link_text = c(NA, NA, NA, "Results", "Results", "Results", "Results", "View Data", "View Strain", NA, NA, NA),
-  is_exported = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE),
-  is_hidden = c(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE),
+               "transcriptomics", "proteomics", "disease_correlation",
+               "biomarkers", "pathology", "study_data",
+               "jax_strain", "center", "modified_genes",
+               "available_data"),
+  tooltip = c("Mouse Model",  rep(NA, times = 12)),
+  sort_tooltip = rep(NA, times = 13),
+  link_url = rep(NA, times = 13),
+  link_text = c(NA, NA, NA, "Results", "Results", "Results", "Results", "Results", "View Data", "View Strain", NA, NA, NA),
+  is_exported = c(TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, TRUE, FALSE),
+  is_hidden = c(FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, FALSE, TRUE, TRUE, TRUE),
   stringsAsFactors = FALSE
 )
 
@@ -560,7 +568,9 @@ mo_filters <- data.frame(
 # - For human transgenes introduced into mouse models use all caps, e.g. PSEN1
 mo_modified_gene_filter_vals <- c('Abca7',
                                'APOE',
-                               'APP',
+                               'Apoe',
+                               "APP",
+                               "App",
                                'Ceacam1',
                                'Clasp2',
                                'CR1',
@@ -712,7 +722,7 @@ TESTS
 
 ## Test build_column
 ```{r}
-col_def <- build_column("name_value", "type_value", "data_key_value", "tooltip_value", "sort_tooltip_value", "link_url_value", "link_text_value", TRUE, FALSE)
+col_def <- build_column("name_value", "type_value", "data_key_value", "tooltip_value", "sort_tooltip_value", "link_url_value", "link_text_value", TRUE, FALSE, 300)
 
 print(col_def)
 

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -159,48 +159,48 @@ build_filters <- function(filter_defs, filter_values) {
 }
 
 
-# ***************
+# ***********************
 # Differential Expression
-# ***************
+# ***********************
 
 # Differential Expression Dropdown Menus
 # ------------------------------
-ge_menu1 <- c("RNA - DIFFERENTIAL EXPRESSION")
-ge_menu2 <- c("Tissue - Hemibrain", "Tissue - Cerebral Cortex", "Tissue - Hippocampus")
+rna_de_menu1 <- c("RNA - DIFFERENTIAL EXPRESSION")
+rna_de_menu2 <- c("Tissue - Hemibrain", "Tissue - Cerebral Cortex", "Tissue - Hippocampus")
 
 # Differential Expression Columns
 # -------------------------
 # name, type, data_key, tooltip, sort_tooltip, link_url, link_text, is_exported, is_hidden
 #
 # Static columns are the same across all views
-ge_primary_column <- list("Gene", "primary", "gene_symbol", "Mouse Gene", NA, NA, NA, TRUE, FALSE)
-ge_model_column <- list("Model", "link_internal", "name", "Mouse Model", "Sort by Model value", NA, NA, TRUE, FALSE)
-ge_sex_column <- list("Sex", "text", "sex_cohort", NA, "Sort by Sex value", NA, NA, TRUE, FALSE)
-ge_matched_control_column <- list("Control", "text", "matched_control", NA, "Sort by Control value", NA, NA, TRUE, FALSE)
+rna_de_primary_column <- list("Gene", "primary", "gene_symbol", "Mouse Gene", NA, NA, NA, TRUE, FALSE)
+de_model_column <- list("Model", "link_internal", "name", "Mouse Model", "Sort by Model value", NA, NA, TRUE, FALSE)
+de_sex_column <- list("Sex", "text", "sex", NA, "Sort by Sex value", NA, NA, TRUE, FALSE)
+de_matched_control_column <- list("Control", "text", "matched_control", NA, "Sort by Control value", NA, NA, TRUE, FALSE)
 
 # Hidden static columns
-ge_tissue_column <- list(NA, "text", "tissue", NA, NA, NA, NA, TRUE, TRUE)
-ge_biodomains_column <- list(NA, "text", "biodomains", NA, NA, NA, NA, TRUE, TRUE)
-ge_model_group_column <- list(NA, "text", "model_group", NA, NA, NA, NA, FALSE, TRUE)
-ge_model_type_column <- list(NA, "text", "model_type", NA, NA, NA, NA, TRUE, TRUE)
-ge_ensembl_gene_id_column <- list(NA, "text", "ensembl_gene_id", NA, NA, NA, NA, TRUE, TRUE)
+de_tissue_column <- list(NA, "text", "tissue", NA, NA, NA, NA, TRUE, TRUE)
+de_biodomains_column <- list(NA, "text", "biodomains", NA, NA, NA, NA, TRUE, TRUE)
+de_model_group_column <- list(NA, "text", "model_group", NA, NA, NA, NA, FALSE, TRUE)
+de_model_type_column <- list(NA, "text", "model_type", NA, NA, NA, NA, TRUE, TRUE)
+de_ensembl_gene_id_column <- list(NA, "text", "ensembl_gene_id", NA, NA, NA, NA, TRUE, TRUE)
 
 
 # Variable heatmap columns have the same values across all views for these fields
-ge_dynamic_column_type <- "heat_map"
-ge_dynamic_column_sort_tooltip <- "Sort by log2 fold change value"
-ge_dynamic_column_is_exported <- TRUE
-ge_dynamic_column_is_hidden <- FALSE
+de_dynamic_column_type <- "heat_map"
+de_dynamic_column_sort_tooltip <- "Sort by log2 fold change value"
+de_dynamic_column_is_exported <- TRUE
+de_dynamic_column_is_hidden <- FALSE
 
 # Variable heatmap column names vary by contributing center and by tissue, since each center sequences different tissues
-ge_dynamic_names_jax <- c("4 months", "12 months")
-ge_dynamic_names_uci <- c("4 months", "12 months", "18 months")
+rna_de_dynamic_names_jax <- c("4 months", "12 months")
+rna_de_dynamic_names_uci <- c("4 months", "12 months", "18 months")
 
 # Differential Expression Filters
 # -----------------------
-ge_filters <- data.frame(
+de_filters <- data.frame(
   name = c('Biological Domain', 'Model Type', 'Mouse Model', 'Sex'),
-  data_key = c('biodomains', 'model_type', 'name', 'sex_cohort'),
+  data_key = c('biodomains', 'model_type', 'name', 'sex'),
   short_name = c('Biodomain', 'Type', 'Model', 'Sex'),
   query_param_key = c('biodomains', 'modelTypes', 'models', 'sex'),
   stringsAsFactors = FALSE
@@ -211,17 +211,17 @@ ge_filters <- data.frame(
 # MG-750: Only include model filter values for models with results for the selected tissue
 
 # Hemibrain: All JAX models
-ge_model_name_filter_vals_hemibrain <- c(
+rna_de_model_name_filter_vals_hemibrain <- c(
                             '5xFAD (IU/Jax/Pitt)',
                             'APOE4',
                             'LOAD1',
                             'Trem2R47H')
 
 # Cortex: 5xFAD (UCI); need to wrap single value in a list for JSON serialization
-ge_model_name_filter_vals_cerebral_cortex <- list('5xFAD (UCI)')
+rna_de_model_name_filter_vals_cerebral_cortex <- list('5xFAD (UCI)')
 
 # Hippocampus: All UCI models
-ge_model_name_filter_vals_hippocampus <- c(
+rna_de_model_name_filter_vals_hippocampus <- c(
                             '3xTg-AD',
                             '5xFAD (UCI)',
                             'Abca7*V1599M',
@@ -230,45 +230,45 @@ ge_model_name_filter_vals_hippocampus <- c(
                             'Trem2-R47H_NSS.5xFAD')
 
 # Generates Differential Expression ui_config objects
-build_ge_objects <- function() {
+build_rna_de_objects <- function() {
 
   # Static columns are always the same
-  primary <- do.call(build_column, ge_primary_column)
-  ensembl_gene_id  <- do.call(build_column, ge_ensembl_gene_id_column)
-  tissue <- do.call(build_column, ge_tissue_column)
-  model <- do.call(build_column, ge_model_column)
-  sex <- do.call(build_column, ge_sex_column)
-  matched_control <- do.call(build_column, ge_matched_control_column)
-  biodomains <- do.call(build_column, ge_biodomains_column)
-  model_group <- do.call(build_column, ge_model_group_column)
-  model_type <- do.call(build_column, ge_model_type_column)
+  primary <- do.call(build_column, rna_de_primary_column)
+  ensembl_gene_id  <- do.call(build_column, de_ensembl_gene_id_column)
+  tissue <- do.call(build_column, de_tissue_column)
+  model <- do.call(build_column, de_model_column)
+  sex <- do.call(build_column, de_sex_column)
+  matched_control <- do.call(build_column, de_matched_control_column)
+  biodomains <- do.call(build_column, de_biodomains_column)
+  model_group <- do.call(build_column, de_model_group_column)
+  model_type <- do.call(build_column, de_model_type_column)
 
 
   # Build a ui_config for each possible combination of dropdown menu options
-  dropdown_combos <- expand.grid(menu1 = ge_menu1, menu2 = ge_menu2, stringsAsFactors = FALSE)
+  dropdown_combos <- expand.grid(menu1 = rna_de_menu1, menu2 = rna_de_menu2, stringsAsFactors = FALSE)
   lapply(seq_len(nrow(dropdown_combos)), function(i) {
     combo <- dropdown_combos[i, ]
 
     # Dynamic columns vary by tissue dropdown
-    dynamic_names <- if (grepl("Hemibrain", combo$menu2, ignore.case = TRUE)) ge_dynamic_names_jax else ge_dynamic_names_uci
+    dynamic_names <- if (grepl("Hemibrain", combo$menu2, ignore.case = TRUE)) rna_de_dynamic_names_jax else rna_de_dynamic_names_uci
     dynamic_columns <- lapply(dynamic_names,function(name) {
-                           build_column(name, ge_dynamic_column_type, name, NA, ge_dynamic_column_sort_tooltip,
-                                        NA, NA, ge_dynamic_column_is_exported, ge_dynamic_column_is_hidden)
+                           build_column(name, de_dynamic_column_type, name, NA, de_dynamic_column_sort_tooltip,
+                                        NA, NA, de_dynamic_column_is_exported, de_dynamic_column_is_hidden)
     })
 
     # Dynamic model filter values vary by tissue dropdown
     dynamic_model_filters <- if (grepl("Hemibrain", combo$menu2, ignore.case = TRUE)) {
-      ge_model_name_filter_vals_hemibrain
+      rna_de_model_name_filter_vals_hemibrain
     } else if (grepl("Cerebral Cortex", combo$menu2, ignore.case = TRUE)) {
-      ge_model_name_filter_vals_cerebral_cortex
+      rna_de_model_name_filter_vals_cerebral_cortex
     } else if (grepl("Hippocampus", combo$menu2, ignore.case = TRUE)) {
-      ge_model_name_filter_vals_hippocampus
+      rna_de_model_name_filter_vals_hippocampus
     } else {
       stop() # fail if we are missing required filter values
     }
 
     # Construct the filter values list for this specific combo
-    ge_filter_values <- list(
+    de_filter_values <- list(
       biodomain_filter_vals,
       model_type_filter_vals,
       dynamic_model_filters,
@@ -277,7 +277,7 @@ build_ge_objects <- function() {
 
     # The column ordering is mirrored when a CSV is generated
     columns <- c(list(primary, ensembl_gene_id, tissue, model, sex, matched_control), dynamic_columns, c(list(biodomains, model_type, model_group)))
-    filters <- build_filters(ge_filters, ge_filter_values)
+    filters <- build_filters(de_filters, de_filter_values)
 
     list(
       page = "Differential Expression",
@@ -597,7 +597,7 @@ build_marmo_mo_object <- function() {
 # Generate ui_config.json and upload to Synapse
 # *********************************************
 json_list <- c(
-  build_ge_objects(),
+  build_rna_de_objects(),
   build_dc_objects(),
   list(build_mo_object()),
   list(build_marmo_mo_object())
@@ -691,9 +691,9 @@ toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)
 ```
 
 
-# test build_ge_objects
+# test build_rna_de_objects
 ```{r}
-json_list <-  build_ge_objects()
+json_list <-  build_rna_de_objects()
 
 toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)
 ```

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -162,18 +162,11 @@ build_filters <- function(filter_defs, filter_values) {
 # ***********************
 # Differential Expression
 # ***********************
-
-# Differential Expression Dropdown Menus
-# ------------------------------
-rna_de_menu1 <- c("RNA - DIFFERENTIAL EXPRESSION")
-rna_de_menu2 <- c("Tissue - Hemibrain", "Tissue - Cerebral Cortex", "Tissue - Hippocampus")
-
-# Differential Expression Columns
-# -------------------------
 # name, type, data_key, tooltip, sort_tooltip, link_url, link_text, is_exported, is_hidden
-#
-# Static columns are the same across all views
-rna_de_primary_column <- list("Gene", "primary", "gene_symbol", "Mouse Gene", NA, NA, NA, TRUE, FALSE)
+
+# Shared - Columns
+# ----------------
+# Static columns are the same across all DE views
 de_model_column <- list("Model", "link_internal", "name", "Mouse Model", "Sort by Model value", NA, NA, TRUE, FALSE)
 de_sex_column <- list("Sex", "text", "sex", NA, "Sort by Sex value", NA, NA, TRUE, FALSE)
 de_matched_control_column <- list("Control", "text", "matched_control", NA, "Sort by Control value", NA, NA, TRUE, FALSE)
@@ -185,19 +178,15 @@ de_model_group_column <- list(NA, "text", "model_group", NA, NA, NA, NA, FALSE, 
 de_model_type_column <- list(NA, "text", "model_type", NA, NA, NA, NA, TRUE, TRUE)
 de_ensembl_gene_id_column <- list(NA, "text", "ensembl_gene_id", NA, NA, NA, NA, TRUE, TRUE)
 
-
 # Variable heatmap columns have the same values across all views for these fields
 de_dynamic_column_type <- "heat_map"
 de_dynamic_column_sort_tooltip <- "Sort by log2 fold change value"
 de_dynamic_column_is_exported <- TRUE
 de_dynamic_column_is_hidden <- FALSE
 
-# Variable heatmap column names vary by contributing center and by tissue, since each center sequences different tissues
-rna_de_dynamic_names_jax <- c("4 months", "12 months")
-rna_de_dynamic_names_uci <- c("4 months", "12 months", "18 months")
 
-# Differential Expression Filters
-# -----------------------
+# Shared - Filters
+# ----------------
 de_filters <- data.frame(
   name = c('Biological Domain', 'Model Type', 'Mouse Model', 'Sex'),
   data_key = c('biodomains', 'model_type', 'name', 'sex'),
@@ -206,8 +195,23 @@ de_filters <- data.frame(
   stringsAsFactors = FALSE
 )
 
-# Differential Expression Filter values
-# -----------------------------
+# RNA - Dropdowns
+# ---------------
+rna_de_menu1 <- c("RNA - DIFFERENTIAL EXPRESSION")
+rna_de_menu2 <- c("Tissue - Hemibrain", "Tissue - Cerebral Cortex", "Tissue - Hippocampus")
+
+# RNA - Columns
+# -------------
+# Static columns
+rna_de_primary_column <- list("Gene", "primary", "gene_symbol", "Mouse Gene", NA, NA, NA, TRUE, FALSE)
+
+# Variable heatmap column names vary by contributing center and by tissue, since each center sequences different tissues
+rna_de_dynamic_names_jax <- c("4 months", "12 months")
+rna_de_dynamic_names_uci <- c("4 months", "12 months", "18 months")
+
+
+# RNA Filter values
+# -----------------
 # MG-750: Only include model filter values for models with results for the selected tissue
 
 # Hemibrain: All JAX models
@@ -229,63 +233,128 @@ rna_de_model_name_filter_vals_hippocampus <- c(
                             'Trem2-R47H_NSS',
                             'Trem2-R47H_NSS.5xFAD')
 
-# Generates Differential Expression ui_config objects
+
+# Protein - Dropdowns
+# -------------------
+protein_de_menu1 <- c("PROTEIN - DIFFERENTIAL EXPRESSION")
+protein_de_menu2 <- c("Tissue - Hemibrain")
+
+# Protein - Columns
+# -----------------
+# Static columns
+protein_de_primary_column     <- list("Protein", "primary", "display_symbol", "Mouse Protein", NA, NA, NA, TRUE, FALSE)
+protein_de_gene_symbol_column <- list(NA, "text", "gene_symbol", NA, NA, NA, NA, TRUE, TRUE)
+protein_de_uniprotid_column   <- list(NA, "text", "uniprotid", NA, NA, NA, NA, TRUE, TRUE)
+
+
+# Variable heatmap columns
+protein_de_dynamic_names <- list(
+  "Tissue - Hemibrain" = c("4 months", "12 months", "18 months", "24 months")
+)
+
+# Protein Filter values
+# ---------------------
+protein_de_model_name_filter_vals <- list(
+  "Tissue - Hemibrain" = list("LOAD2")   # list() -> JSON array for single value
+)
+
+# Generates a single Differential Expression ui_config object.
+# Shared by RNA and Protein; the assay-specific pieces (menu label, dynamic heatmap column
+# names, model filter values, and leading/trailing column definitions) are passed in.
+build_de_object <- function(menu1_label, tissue_label, dynamic_names,
+                            dynamic_model_filter_vals, leading_columns, trailing_columns) {
+
+  # Dynamic heatmap columns vary by assay and tissue
+  dynamic_columns <- lapply(dynamic_names, function(name) {
+    build_column(name, de_dynamic_column_type, name, NA, de_dynamic_column_sort_tooltip,
+                 NA, NA, de_dynamic_column_is_exported, de_dynamic_column_is_hidden)
+  })
+
+  de_filter_values <- list(
+    biodomain_filter_vals,
+    model_type_filter_vals,
+    dynamic_model_filter_vals,
+    sex_filter_vals
+  )
+
+  # The column ordering is mirrored when a CSV is generated
+  columns <- c(leading_columns, dynamic_columns, trailing_columns)
+
+  list(
+    page = "Differential Expression",
+    dropdowns = c(menu1_label, tissue_label),
+    row_count = gene_expression_row_count,
+    columns = columns,
+    filters = build_filters(de_filters, de_filter_values)
+  )
+}
+
+# Generates RNA Differential Expression ui_config objects (one per tissue)
 build_rna_de_objects <- function() {
 
-  # Static columns are always the same
-  primary <- do.call(build_column, rna_de_primary_column)
-  ensembl_gene_id  <- do.call(build_column, de_ensembl_gene_id_column)
-  tissue <- do.call(build_column, de_tissue_column)
-  model <- do.call(build_column, de_model_column)
-  sex <- do.call(build_column, de_sex_column)
-  matched_control <- do.call(build_column, de_matched_control_column)
-  biodomains <- do.call(build_column, de_biodomains_column)
-  model_group <- do.call(build_column, de_model_group_column)
-  model_type <- do.call(build_column, de_model_type_column)
+  # Leading and trailing static columns are the same across all RNA views
+  leading_columns <- list(
+    do.call(build_column, rna_de_primary_column),
+    do.call(build_column, de_ensembl_gene_id_column),
+    do.call(build_column, de_tissue_column),
+    do.call(build_column, de_model_column),
+    do.call(build_column, de_matched_control_column),
+    do.call(build_column, de_sex_column)
+  )
+  trailing_columns <- list(
+    do.call(build_column, de_biodomains_column),
+    do.call(build_column, de_model_type_column),
+    do.call(build_column, de_model_group_column)
+  )
 
-
-  # Build a ui_config for each possible combination of dropdown menu options
-  dropdown_combos <- expand.grid(menu1 = rna_de_menu1, menu2 = rna_de_menu2, stringsAsFactors = FALSE)
-  lapply(seq_len(nrow(dropdown_combos)), function(i) {
-    combo <- dropdown_combos[i, ]
+  # Build a ui_config for each RNA tissue dropdown option
+  lapply(rna_de_menu2, function(tissue) {
 
     # Dynamic columns vary by tissue dropdown
-    dynamic_names <- if (grepl("Hemibrain", combo$menu2, ignore.case = TRUE)) rna_de_dynamic_names_jax else rna_de_dynamic_names_uci
-    dynamic_columns <- lapply(dynamic_names,function(name) {
-                           build_column(name, de_dynamic_column_type, name, NA, de_dynamic_column_sort_tooltip,
-                                        NA, NA, de_dynamic_column_is_exported, de_dynamic_column_is_hidden)
-    })
+    dynamic_names <- if (grepl("Hemibrain", tissue, ignore.case = TRUE)) rna_de_dynamic_names_jax else rna_de_dynamic_names_uci
 
     # Dynamic model filter values vary by tissue dropdown
-    dynamic_model_filters <- if (grepl("Hemibrain", combo$menu2, ignore.case = TRUE)) {
+    dynamic_model_filter_vals <- if (grepl("Hemibrain", tissue, ignore.case = TRUE)) {
       rna_de_model_name_filter_vals_hemibrain
-    } else if (grepl("Cerebral Cortex", combo$menu2, ignore.case = TRUE)) {
+    } else if (grepl("Cerebral Cortex", tissue, ignore.case = TRUE)) {
       rna_de_model_name_filter_vals_cerebral_cortex
-    } else if (grepl("Hippocampus", combo$menu2, ignore.case = TRUE)) {
+    } else if (grepl("Hippocampus", tissue, ignore.case = TRUE)) {
       rna_de_model_name_filter_vals_hippocampus
     } else {
       stop() # fail if we are missing required filter values
     }
 
-    # Construct the filter values list for this specific combo
-    de_filter_values <- list(
-      biodomain_filter_vals,
-      model_type_filter_vals,
-      dynamic_model_filters,
-      sex_filter_vals
-    )
+    build_de_object(rna_de_menu1, tissue, dynamic_names, dynamic_model_filter_vals,
+                    leading_columns, trailing_columns)
+  })
+}
 
-    # The column ordering is mirrored when a CSV is generated
-    columns <- c(list(primary, ensembl_gene_id, tissue, model, sex, matched_control), dynamic_columns, c(list(biodomains, model_type, model_group)))
-    filters <- build_filters(de_filters, de_filter_values)
+# Generates Protein Differential Expression ui_config objects (one per tissue)
+build_protein_de_objects <- function() {
 
-    list(
-      page = "Differential Expression",
-      dropdowns = c(combo$menu1, combo$menu2, combo$menu3),
-      row_count = gene_expression_row_count,
-      columns = columns,
-      filters = filters
-    )
+  # Leading columns: protein primary + extra hidden gene_symbol/uniprotid, then shared de_* columns
+  leading_columns <- list(
+    do.call(build_column, protein_de_primary_column),
+    do.call(build_column, de_ensembl_gene_id_column),
+    do.call(build_column, protein_de_gene_symbol_column),
+    do.call(build_column, protein_de_uniprotid_column),
+    do.call(build_column, de_tissue_column),
+    do.call(build_column, de_model_column),
+    do.call(build_column, de_matched_control_column),
+    do.call(build_column, de_sex_column)
+  )
+  trailing_columns <- list(
+    do.call(build_column, de_biodomains_column),
+    do.call(build_column, de_model_type_column),
+    do.call(build_column, de_model_group_column)
+  )
+
+  # Build a ui_config for each protein tissue dropdown option
+  lapply(protein_de_menu2, function(tissue) {
+    build_de_object(protein_de_menu1, tissue,
+                    protein_de_dynamic_names[[tissue]],
+                    protein_de_model_name_filter_vals[[tissue]],
+                    leading_columns, trailing_columns)
   })
 }
 
@@ -590,14 +659,12 @@ build_marmo_mo_object <- function() {
 
 ```
 
-# Generate and upload ui_config
+# Generate ui_config.json
 
 ```{r}
-# *********************************************
-# Generate ui_config.json and upload to Synapse
-# *********************************************
 json_list <- c(
   build_rna_de_objects(),
+  build_protein_de_objects(),
   build_dc_objects(),
   list(build_mo_object()),
   list(build_marmo_mo_object())
@@ -613,10 +680,14 @@ if(!dir.exists(output_dir)){
 }
 
 write(json_output, file.path(output_dir, "ui_config.json"))
+```
 
-# BREAK HERE FOR LOCAL VALIDATION - generated file is in ADT notebooks/output
 
-# upload to synapse
+# Upload to synapse
+**********************************************
+Validate ./output/ui_config.json before upload
+**********************************************
+```{r}
 synLogin()
 syn_file <- File(
               file.path(output_dir, "ui_config.json"),
@@ -647,7 +718,6 @@ print(col_def)
 
 json_output <- toJSON(col_def, pretty = TRUE, na = NULL, null = NULL, auto_unbox = TRUE)
 cat(json_output)
-
 ```
 
 ## Test build_object
@@ -673,7 +743,6 @@ json_list <- c(
 
 json_output <- toJSON(json_list, pretty = TRUE, na = NULL, null = NULL, auto_unbox = TRUE)
 cat(json_output)
-
 ```
 
 # test build_mo_object
@@ -690,10 +759,16 @@ json_list <-  build_dc_objects()
 toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)
 ```
 
-
 # test build_rna_de_objects
 ```{r}
 json_list <-  build_rna_de_objects()
+
+toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)
+```
+
+# test build_protein_de_objects
+```{r}
+json_list <-  build_protein_de_objects()
 
 toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)
 ```

--- a/data_analysis/model_ad/notebooks/data_mocks/mock_protein_de_aggregate.rmd
+++ b/data_analysis/model_ad/notebooks/data_mocks/mock_protein_de_aggregate.rmd
@@ -1,0 +1,534 @@
+---
+title: "MG-970: Create proteomics mock data"
+---
+Related Jira issues: MG-970
+
+This notebook generates mock data to support developing proteomics interfaces:
+* Protein - Differential Expression CT
+* ***Not yet implemented: Individual Protein Expression (details box plot pages)***
+
+Mock data for the Protein - Differential Expression CT supports the use cases outlined in this document:
+https://docs.google.com/document/d/1IWsp41hKJN8xcWsAvtsIBmrTfdwi8Z55V48_j92z-As/edit?tab=t.0#heading=h.lmosv24ok9i6
+
+## Library setup
+Install required packages:
+- synapser (also requires a Synapse account with an auth token)
+- jsonlite
+```{r}
+if (!require("synapser", quietly = TRUE)) {
+  install.packages("synapser", repos = c("http://ran.synapse.org",
+                                         "https://cloud.r-project.org"))
+}
+if (!require("jsonlite", quietly = TRUE)) { install.packages("jsonlite") }
+if (!require("purrr")) { install.packages("purrr") }
+
+library(synapser)
+library(dplyr)
+library(tibble)
+library(tidyr)
+library(purrr)
+library(jsonlite)
+```
+
+
+## Variables and functions
+Sources the required variables and functions.
+```{r}
+# *******************************
+# STATIC VARIABLES
+# *******************************
+# mouse values
+MODEL_NAME      <- 'LOAD2'
+MODEL_GROUP     <- 'LOAD2'
+MATCHED_CONTROL <- 'LOAD1'
+MODEL_TYPE      <- 'Late Onset AD'
+TISSUE          <- 'Hemibrain'
+SEXES           <- c('Females', 'Males')
+AGES            <- c(4, 12, 18, 24)
+
+
+# gene/protein values
+ENSEMBL_PREFIX <- 'ENSMUSG'
+BIODOMAINS <- c('Apoptosis',
+                   'APP Metabolism',
+                   'Autophagy',
+                   'Cell Cycle',
+                   'DNA Repair',
+                   'Endolysosome',
+                   'Epigenetic',
+                   'Immune Response',
+                   'Lipid Metabolism',
+                   'Metal Binding and Homeostasis',
+                   'Mitochondrial Metabolism',
+                   'Myelination',
+                   'Oxidative Stress',
+                   'Proteostasis',
+                   'RNA Spliceosome',
+                   'Structural Stabilization',
+                   'Synapse',
+                   'Tau Homeostasis',
+                   'Vasculature')
+
+
+# *********
+# FUNCTIONS
+# *********
+
+# Builds a Proteomics DE CT object
+# ensembl_gene_id, gene_symbol, uniprotid, unique_id, display_symbol, biodomains[], name{}, matched_control, model_group, model_type, tissue, sex, age_cols...
+build_row <- function(ensembl_gene_id, gene_symbol, uniprotid, unique_id, display_symbol, biodomains, name, matched_control, model_group, model_type, tissue, sex, age_rows = list()) {
+
+
+  base_row <- list(
+    ensembl_gene_id = ensembl_gene_id,
+    gene_symbol = gene_symbol,
+    uniprotid = uniprotid,
+    unique_id = unique_id,
+    display_symbol = display_symbol,
+    biodomains = biodomains,
+    name = name,
+    matched_control = matched_control,
+    model_group = model_group,
+    model_type = model_type,
+    tissue = tissue,
+    sex = sex
+  )
+
+  row <- c(base_row, age_rows) %>% purrr::discard(~ is.null(.x) || all(is.na(.x)))
+
+  row
+}
+
+# Extract the specified number of values from a vector
+# if sample_size > length(vec), duplicate values will be included
+sample_vector <- function(sample_size, vec) {
+
+  padding_needed <- sample_size - length(vec)
+
+  if (padding_needed <= 0) {
+    sampled_indices <- sample(seq_along(vec), size = sample_size, replace = FALSE)
+    return(vec[sampled_indices])
+  }
+
+  else {
+    base_indices <- sample(seq_along(vec), size = length(vec), replace = FALSE)
+    base_pool <- vec[base_indices]
+
+    padding_indices <- sample(seq_along(vec), size = padding_needed, replace = TRUE)
+    padding_pool <- vec[padding_indices]
+
+    return(c(base_pool, padding_pool))
+  }
+}
+
+# Generate a heatmap data object
+generate_heatmap_object <- function(key_name, min = -2, max = 2) {
+  log2_fc <- runif(1, min = min, max = max)
+  adj_p_val <- runif(1, min = 0, max = 1)
+
+  value_list <- list(
+    log2_fc = round(log2_fc, 5),
+    adj_p_val = round(adj_p_val, 5)
+  )
+
+  heatmap_obj <- list()
+  heatmap_obj[[key_name]] <- value_list
+
+  return(heatmap_obj)
+}
+
+generate_link_object <- function(key_name, link_url = NULL, link_text = NULL) {
+
+  value_list <- list(
+    link_url = link_url,
+    link_text = link_text
+  )
+
+  link_obj <- list()
+  link_obj[[key_name]] <- value_list
+
+  return(link_obj)
+}
+```
+
+
+# *********
+# Mock Data
+# *********
+Requirement summary
+* >50 unique genes, 1:1, all match the same typeahead value (can be one letter)
+* 1:3+ x2+ genes, must exist in RNA DE
+* TBD gene with RNA but no protein result
+* TBD (fake?) gene with protein but no RNA
+* uniprotid contains a hyphen
+
+
+# 1. basic_results
+* 60 pairs of objects (m/f with matching metadata and unique measurements)
+* 1 gene : 1 uniprotid
+* All gene_symbol values include "GeneP" for typeahead
+* Some objects don't have '18 months' results
+```{r}
+# Populate gene/protein fields: ensembl_gene_id, gene_symbol, uniprotid, unique_id, display_symbol
+ids <- 0:59
+pad_number <- "1"
+object_dict <- tibble(
+
+  ensembl_gene_id = paste0(ENSEMBL_PREFIX, gsub(" ", pad_number, sprintf("%11d", ids))),
+  gene_symbol = paste0("GeneX_", ids),
+  uniprotid = paste0(
+    "P", gsub(" ", pad_number, sprintf("%5d", ids)),
+    sample(c("", "-1", "-2", "-3"), size = length(ids), replace = TRUE, prob = c(0.7, 0.2, 0.07, 0.03))
+  ),
+  unique_id = paste0(ensembl_gene_id, uniprotid),
+  display_symbol = paste0(gene_symbol, " (", uniprotid, ")")
+)
+
+# biodomains[], name{}, matched_control, model_group, model_type, tissue, sex, age_cols...
+
+# generate link object for name field
+name_link_object <- generate_link_object("name", link_url = paste0("/models/", MODEL_NAME), link_text = MODEL_NAME)[["name"]]
+
+# Populate fields that match across sexes
+# biodomains, name, matched_control, model_group, model_type, tissue
+object_dict <- object_dict %>%
+
+  # 15% chance this object won't have 24 months data
+  mutate(has_24_months = runif(nrow(object_dict)) >= 0.15) %>%
+
+  rowwise() %>%
+  mutate(
+    biodomains = list(sample_vector(sample(1:10, 1), BIODOMAINS)),
+    name            = list(name_link_object),
+    matched_control = MATCHED_CONTROL,
+    model_group     = MODEL_GROUP,
+    model_type      = MODEL_TYPE,
+    tissue          = TISSUE,
+  ) %>%
+  ungroup()
+
+# Expand to include an object per sex for each gene:protein
+object_dict_expanded <- object_dict %>%
+  crossing(sex = SEXES)
+
+# Generate row-specific heatmap data
+basic_results <- object_dict_expanded %>%
+  mutate(
+    # 1. Map over an existing column to execute exactly once per row
+    `4 months`  = purrr::map(ensembl_gene_id, ~ generate_heatmap_object("4 months")[["4 months"]]),
+    `12 months` = purrr::map(ensembl_gene_id, ~ generate_heatmap_object("12 months")[["12 months"]]),
+    `18 months` = purrr::map(ensembl_gene_id, ~ generate_heatmap_object("18 months")[["18 months"]]),
+
+    # 2. Loop through the logical flags one-by-one so if() only ever sees a single TRUE/FALSE
+    `24 months` = purrr::map(has_24_months, ~ if (.x) generate_heatmap_object("24 months")[["24 months"]] else NULL)
+  ) %>%
+  select(-has_24_months)
+
+
+basic_results
+```
+
+
+2. rna_exists_multiple_proteins_results
+* 15 pairs of objects (m/f with matching metadata and unique measurments)
+* 1 gene : 3 uniprotid
+* Some objects don't have '18 months' results
+```{r}
+ids <- 100:114
+ensembl_id_in_rna_results <- c("ENSMUSG00000000001", "ENSMUSG00000000001", "ENSMUSG00000000001",
+                               "ENSMUSG00000000056", "ENSMUSG00000000056", "ENSMUSG00000000056",
+                               "ENSMUSG00000000214", "ENSMUSG00000000214", "ENSMUSG00000000214",
+                               "ENSMUSG00000000296", "ENSMUSG00000000296", "ENSMUSG00000000296",
+                               "ENSMUSG00000000340", "ENSMUSG00000000340", "ENSMUSG00000000340"
+                               )
+gene_symbol_in_rna_results <- c("Gnai3", "Gnai3", "Gnai3",
+                                "Narf", "Narf", "Narf",
+                                "Th", "Th", "Th",
+                                "Tpd52l1", "Tpd52l1", "Tpd52l1",
+                                "Dbt", "Dbt", "Dbt"
+                                )
+
+object_dict <- tibble(
+
+  ensembl_gene_id = ensembl_id_in_rna_results,
+  gene_symbol = gene_symbol_in_rna_results,
+  uniprotid = paste0(
+    sprintf("P%05d", ids),
+    sample(c("", "-1", "-2", "-3"), size = length(ids), replace = TRUE, prob = c(0.7, 0.2, 0.07, 0.03))
+  ),
+  unique_id = paste0(ensembl_gene_id, uniprotid),
+  display_symbol = paste0(gene_symbol, " (", uniprotid, ")")
+)
+
+# biodomains[], name{}, matched_control, model_group, model_type, tissue, sex, age_cols...
+
+# generate link object for name field
+name_link_object <- generate_link_object("name", link_url = paste0("/models/", MODEL_NAME), link_text = MODEL_NAME)[["name"]]
+
+# Populate fields that match across sexes
+# biodomains, name, matched_control, model_group, model_type, tissue
+object_dict <- object_dict %>%
+
+  # 15% chance this object won't have 18 months data
+  mutate(has_24_months = runif(nrow(object_dict)) >= 0.15) %>%
+
+  rowwise() %>%
+  mutate(
+    biodomains = list(sample_vector(sample(1:10, 1), BIODOMAINS)),
+    name            = list(name_link_object),
+    matched_control = MATCHED_CONTROL,
+    model_group     = MODEL_GROUP,
+    model_type      = MODEL_TYPE,
+    tissue          = TISSUE,
+  ) %>%
+  ungroup()
+
+# Expand to include an object per sex for each gene:protein
+object_dict_expanded <- object_dict %>%
+  crossing(sex = SEXES)
+
+# Generate row-specific heatmap data
+rna_exists_multiple_proteins_results <- object_dict_expanded %>%
+  mutate(
+    # 1. Map over an existing column to execute exactly once per row
+    `4 months`  = purrr::map(ensembl_gene_id, ~ generate_heatmap_object("4 months")[["4 months"]]),
+    `12 months` = purrr::map(ensembl_gene_id, ~ generate_heatmap_object("12 months")[["12 months"]]),
+    `18 months` = purrr::map(ensembl_gene_id, ~ generate_heatmap_object("18 months")[["18 months"]]),
+
+    # 2. Loop through the logical flags one-by-one so if() only ever sees a single TRUE/FALSE
+    `24 months` = purrr::map(has_24_months, ~ if (.x) generate_heatmap_object("24 months")[["24 months"]] else NULL)
+  ) %>%
+  select(-has_24_months)
+
+
+rna_exists_multiple_proteins_results
+
+```
+
+
+3. no_rna_protein_exists_results
+* 15 pairs of objects (m/f with matching metadata and unique measurements)
+* 1 gene : 3 uniprotid
+* Some objects don't have '18 months' results
+```{r}
+# Populate gene/protein fields: ensembl_gene_id, gene_symbol, uniprotid, unique_id, display_symbol
+ids <- 0:14
+pad_number <- "3"
+
+object_dict <- tibble(
+
+  ensembl_gene_id = paste0(ENSEMBL_PREFIX, gsub(" ", pad_number, sprintf("%11d", ids))),
+  gene_symbol = paste0("GeneP_", ids),
+  uniprotid = paste0(
+    "P", gsub(" ", pad_number, sprintf("%5d", ids)),
+    sample(c("", "-1", "-2", "-3"), size = length(ids), replace = TRUE, prob = c(0.7, 0.2, 0.07, 0.03))
+  ),
+  unique_id = paste0(ensembl_gene_id, uniprotid),
+  display_symbol = paste0(gene_symbol, " (", uniprotid, ")")
+)
+
+# biodomains[], name{}, matched_control, model_group, model_type, tissue, sex, age_cols...
+
+# generate link object for name field
+name_link_object <- generate_link_object("name", link_url = paste0("/models/", MODEL_NAME), link_text = MODEL_NAME)[["name"]]
+
+# Populate fields that match across sexes
+# biodomains, name, matched_control, model_group, model_type, tissue
+object_dict <- object_dict %>%
+
+  # 15% chance this object won't have 24 months data
+  mutate(has_24_months = runif(nrow(object_dict)) >= 0.15) %>%
+
+  rowwise() %>%
+  mutate(
+    biodomains = list(sample_vector(sample(1:10, 1), BIODOMAINS)),
+    name            = list(name_link_object),
+    matched_control = MATCHED_CONTROL,
+    model_group     = MODEL_GROUP,
+    model_type      = MODEL_TYPE,
+    tissue          = TISSUE,
+  ) %>%
+  ungroup()
+
+# Expand to include an object per sex for each gene:protein
+object_dict_expanded <- object_dict %>%
+  crossing(sex = SEXES)
+
+# Generate row-specific heatmap data
+no_rna_protein_exists_results <- object_dict_expanded %>%
+  mutate(
+    # 1. Map over an existing column to execute exactly once per row
+    `4 months`  = purrr::map(ensembl_gene_id, ~ generate_heatmap_object("4 months")[["4 months"]]),
+    `12 months` = purrr::map(ensembl_gene_id, ~ generate_heatmap_object("12 months")[["12 months"]]),
+    `18 months` = purrr::map(ensembl_gene_id, ~ generate_heatmap_object("18 months")[["18 months"]]),
+
+    # 2. Loop through the logical flags one-by-one so if() only ever sees a single TRUE/FALSE
+    `24 months` = purrr::map(has_24_months, ~ if (.x) generate_heatmap_object("24 months")[["24 months"]] else NULL)
+  ) %>%
+  select(-has_24_months)
+
+no_rna_protein_exists_results
+```
+
+
+# Assemble and upload collection
+
+```{r}
+# *********************************************
+# Generate ui_config.json and upload to Synapse
+# *********************************************
+
+raw_tibble_list <- list(
+  basic_results,
+  rna_exists_multiple_proteins_results,
+  no_rna_protein_exists_results
+)
+
+# Since we are using a tibble, we need to do some extra stuff to omit the null 18 months keys entirely
+json_list <- purrr::map(raw_tibble_list, function(df) {
+  df %>%
+    purrr::transpose() %>%
+    purrr::map(~ purrr::discard(.x, is.null))
+})
+
+json_output <- toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)
+# cat(json_output)
+
+# write json file
+output_dir <- file.path("./", "output")
+if(!dir.exists(output_dir)){
+  dir.create(output_dir)
+}
+
+write(json_output, file.path(output_dir, "proteomics_mocks.json"))
+```
+
+
+# Upload to synapse
+*****************************************************
+Validate ./output/proteomics_mocks.json before upload
+*****************************************************
+```{r}
+synLogin()
+syn_file <- File(
+              file.path(output_dir, "ui_config.json"),
+              description = "ui_config.json for Model-AD Explorer 2.0.",
+              parent = "syn51498054"
+            )
+
+res <- synStore(
+          syn_file,
+          forceVersion = FALSE,
+          executed = "https://github.com/Sage-Bionetworks/agora-data-tools/blob/dev/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd"
+        )
+# print synapse_id and new version number
+print(paste0("ID: ", res$id, " v", res$versionNumber, ", Name: ", res$name))
+
+```
+
+
+-----
+TESTS
+-----
+
+
+## Test build_row
+```{r}
+object <- build_row(
+  ensembl_gene_id = "ENSMUSG00000022565",
+  gene_symbol = "PLEC",
+  uniprotid = "Q9QXS1",
+  unique_id = "ENSMUSG00000022565Q9QXS1",
+  display_symbol = "PLEC (Q9QXS1)",
+  biodomains = c("Apoptosis","Autophagy","Cell Cycle"),
+  name = "LOAD2",
+  matched_control = "LOAD1",
+  model_group = "LOAD2",
+  model_type = "Late Onset AD",
+  tissue = "Hemibrain",
+  sex = "Female"
+)
+
+json_list <- c(
+  object
+)
+
+json_output <- toJSON(json_list, pretty = TRUE, na = NULL, null = NULL, auto_unbox = TRUE)
+cat(json_output)
+
+```
+
+
+# test sample_data
+```{r}
+sample_vector(1, sex)
+sample_vector(2, sex)
+sample_vector(3, sex)
+sample_vector(10, sex)
+
+sample_vector(1, biodomains)
+sample_vector(2, biodomains)
+sample_vector(3, biodomains)
+sample_vector(19, biodomains)
+```
+
+# test generate heatmap object
+```{r}
+object <- generate_heatmap_object("12 months")
+
+json_list <- c(
+  object
+)
+
+json_output <- toJSON(json_list, pretty = TRUE, na = NULL, null = NULL, auto_unbox = TRUE)
+cat(json_output)
+
+```
+
+
+# test generate link object
+```{r}
+object <- generate_link_object("name", "/models/LOAD2", "LOAD2")
+
+json_list <- c(
+  object
+)
+
+json_output <- toJSON(json_list, pretty = TRUE, na = NULL, null = NULL, auto_unbox = TRUE)
+cat(json_output)
+```
+
+sanity check results
+```{r}
+all_mocks <- rbind(
+  basic_results,
+  rna_exists_multiple_proteins_results,
+  no_rna_protein_exists_results
+)
+
+nrow(all_mocks)
+
+```
+
+check for duplicate uniprotids
+```{r}
+
+all_mocks <- rbind(
+  basic_results,
+  rna_exists_multiple_proteins_results,
+  no_rna_protein_exists_results
+)
+
+all_mocks %>%
+  # 1. Select only rows with sex == Female
+  filter(sex == "Females") %>%
+
+  # 2. Look for duplicate uniprotid values among those rows
+  group_by(uniprotid) %>%
+  filter(n() > 1) %>%
+  ungroup() %>%
+
+  # Arrange them side-by-side for easy inspection
+  arrange(uniprotid)
+
+```

--- a/data_analysis/model_ad/notebooks/data_mocks/mock_protein_de_aggregate.rmd
+++ b/data_analysis/model_ad/notebooks/data_mocks/mock_protein_de_aggregate.rmd
@@ -50,24 +50,24 @@ AGES            <- c(4, 12, 18, 24)
 # gene/protein values
 ENSEMBL_PREFIX <- 'ENSMUSG'
 BIODOMAINS <- c('Apoptosis',
-                   'APP Metabolism',
-                   'Autophagy',
-                   'Cell Cycle',
-                   'DNA Repair',
-                   'Endolysosome',
-                   'Epigenetic',
-                   'Immune Response',
-                   'Lipid Metabolism',
-                   'Metal Binding and Homeostasis',
-                   'Mitochondrial Metabolism',
-                   'Myelination',
-                   'Oxidative Stress',
-                   'Proteostasis',
-                   'RNA Spliceosome',
-                   'Structural Stabilization',
-                   'Synapse',
-                   'Tau Homeostasis',
-                   'Vasculature')
+                'APP Metabolism',
+                'Autophagy',
+                'Cell Cycle',
+                'DNA Repair',
+                'Endolysosome',
+                'Epigenetic',
+                'Immune Response',
+                'Lipid Metabolism',
+                'Metal Binding and Homeostasis',
+                'Mitochondrial Metabolism',
+                'Myelination',
+                'Oxidative Stress',
+                'Proteostasis',
+                'RNA Spliceosome',
+                'Structural Stabilization',
+                'Synapse',
+                'Tau Homeostasis',
+                'Vasculature')
 
 
 # *********
@@ -378,18 +378,15 @@ no_rna_protein_exists_results
 # Generate ui_config.json and upload to Synapse
 # *********************************************
 
-raw_tibble_list <- list(
+json_list <- list(
   basic_results,
   rna_exists_multiple_proteins_results,
   no_rna_protein_exists_results
-)
-
-# Since we are using a tibble, we need to do some extra stuff to omit the null 18 months keys entirely
-json_list <- purrr::map(raw_tibble_list, function(df) {
-  df %>%
-    purrr::transpose() %>%
-    purrr::map(~ purrr::discard(.x, is.null))
-})
+) %>%
+  list_rbind() %>%
+  purrr::transpose() %>%
+  # Since we are using a tibble, we need to do some extra stuff to omit the null 18 months keys   entirely
+  purrr::map(~ purrr::discard(.x, is.null))
 
 json_output <- toJSON(json_list, pretty = TRUE, auto_unbox = TRUE)
 # cat(json_output)

--- a/data_analysis/model_ad/notebooks/outdated/legacy_immunohisto_expected_row_counts.rmd
+++ b/data_analysis/model_ad/notebooks/outdated/legacy_immunohisto_expected_row_counts.rmd
@@ -1,9 +1,15 @@
 ---
 title: "Immunohisto expected row counts"
 ---
+Related Jira issues: MG-389
+
 This notebook determines the expected number of rows of pathology and biomarker data per model, based on data exported from the legacy explorer.
 
 Legacy data export files are stored in: syn68930581
+
+*****************************************************************************
+This notebook only accounts for the results migrated from the legacy Explorer
+*****************************************************************************
 
 # Library setup
 Install required packages:

--- a/data_analysis/model_ad/notebooks/preprocessing/ENSMUSG_Reference.rmd
+++ b/data_analysis/model_ad/notebooks/preprocessing/ENSMUSG_Reference.rmd
@@ -1,5 +1,7 @@
 # Create ENSMUSG Reference
 
+Related Jira issues: MG-8
+
 This notebook downloads all data files listed in [data_sources.csv](https://github.com/Sage-Bionetworks/magora/blob/main/data-raw/gene_expressions/data_sources.csv), gets a list of all the Ensembl gene IDs used across all the files, and maps them to gene symbols and aliases. The file is then uploaded to Synapse here: [syn51615422](https://www.synapse.org/#!Synapse:syn51615422).
 
 Required packages (will automatically be installed if necessary):

--- a/data_analysis/model_ad/notebooks/preprocessing/biomarkers_results.rmd
+++ b/data_analysis/model_ad/notebooks/preprocessing/biomarkers_results.rmd
@@ -1,5 +1,7 @@
 
-# Create Biomarker source file (MG-88)
+# Create Biomarker source file 
+
+Related Jira issues: MG-88
 
 This notebook generates a single harmonized source file (syn61250724) containing the data required to surface Biomarker evidence in the Model-AD Explorer.
 

--- a/data_analysis/model_ad/notebooks/preprocessing/disease_correlation_legacy_results.rmd
+++ b/data_analysis/model_ad/notebooks/preprocessing/disease_correlation_legacy_results.rmd
@@ -1,5 +1,7 @@
 
-# Modify Disease Correlation source (MG-264)
+# Modify Disease Correlation source 
+
+Related Jira issues: MG-264
 
 This notebook downloads the correlation data that was exported from the legacy explorer (syn65467849.1),
  aligns the model_name values with our other data, then writes the updated file back to the same synID.

--- a/data_analysis/model_ad/notebooks/preprocessing/pathology_results.rmd
+++ b/data_analysis/model_ad/notebooks/preprocessing/pathology_results.rmd
@@ -1,4 +1,6 @@
-# Create Pathology source file (MG-40)
+# Create Pathology source file 
+
+Related Jira issues: MG-40
 
 This notebook generates a single harmonized source file (syn61357279) containing the results data and display values required to surface Pathology evidence in the Model-AD Explorer.
 

--- a/data_analysis/model_ad/notebooks/preprocessing/ui_config_model_ad.rmd
+++ b/data_analysis/model_ad/notebooks/preprocessing/ui_config_model_ad.rmd
@@ -1,6 +1,8 @@
 ---
 title: "MG-402: Create ui_config source file"
 ---
+Related Jira issues: MG-402
+
 This notebook generates the ui_config.json source file (syn66527739) containing the data required to construct Comparison Tool interfaces for the Model-AD Explorer MVP.
 
 Interfaces that are currently handled by this notebook:


### PR DESCRIPTION
# Problem

We are introducing the new proteomics result type to the explorer, which requires:
* A single new Differential Expression CT view (MG-946)
* Updating the Mouse Model Overview CT views  (MG-967)

The proteomics feature is coupled to the introduction of the LOAD2 model, so we also need to ensure that model is incorporated into the impacted CT filtersets:
* Mouse Model
* Modified Gene

And I noticed a few other small issues looking over this notebook:
* The relative ordering of `sex` and `matched_controls` is backwards
* Tthis notebook was not extended to support the new  optional `column_widtth` configuration feature when it was introduced for Agora. This feature let's us prevent on-page layout shifts due to variable length content when sorting etc., and we can leverage it in a couple places in Model AD to imrpove UX.

And finally, we don't have the actual proteomics data for the DE interface yet, so we need to unblock dev by creating some mock data they can use in the meantime.

# Solution

Extend the R notebook to generate a new `ui_config` collection aligned with the new rerquirements.

Shared. updates
* Extend `build_colulmn` to support an optional `column_width` config

##  Differential Expression updates
* Organizes existing inputs into shared vs rna-specific
* Adds protein-specific inputs
* Adds rna- and protein-specific functions to build Differential Expression `ui_config` objects
* Leverages the new functions to generate evidence-type-specific `ui_config` objects with appropriate tissue keys, column definitions, and filter options for all DE views
* Adds LOAD2 to the Mouse Model filtervals (Hemibrain view only)
* Applies a fixed-width to the Control column 

The `ui_config` file generated by this<sup>*</sup> set of changes is at: [syn66527739 v35](https://www.synapse.org/Synapse:syn66527739.35)
<sup>*</sup>The column_width update is not in this version

That version is identical to previous versions, aside from these intentional changes:
* New Protein DE object
* Inverted relative order of `matched_conftrol` and `sex`(RNA DE objects)

## Disese Correlation updates
* Applies a fixed-width to the Age column

## Model Overview updates
* Adds the new `proteomics` result type column
* Add "App" to Modified Gene filtervals (Model Overview only)

The `ui_config` file generated by this<sup>*</sup> set of changes is at: [syn66527739 v37](https://www.synapse.org/Synapse:syn66527739.37)
<sup>*</sup>Plus the DE column_width update

That version is identical to v35, aside from these intentional changes:
* New MO protoemics column
* New  "App" filterval  on Model Overview only
* The new column_width values on DC Age and DE Control

## Proteomics mock data:
* Added a dedicated notebook to generate the mock proteomic data
* Reorganized and renamed data_analysis/model_ad/notebooks for scannability
* Moved Jira IDs from titles to contents for scannability, and also so we can link many issues to one notebook
* Didn't adjust the agora notebooks yet, in case we want to refine the approach before moving forward

Mock data was uploaded directly to the Preprod Data Releases folder as `protein_de_aggregate.json` ([syn76225990.1](https://www.synapse.org/Synapse:syn76225990)) and was picked up by mv94. 