### PR TITLE
MG-1004: Remap RNA expression sex display values to singluar format

### DIFF
--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -8,6 +8,7 @@ and biodomain annotations to create a structured output format.
 The transformation:
 - Filters to mouse genes only (ENSMUSG*), excluding human genes (ENSG*)
 - Filters out combined-cohort rows where sex is "Females & Males", keeping single-sex rows only
+- Maps plural sex labels to singular display values ("Females" -> "Female", "Males" -> "Male")
 - Groups differential expression data by gene, model, tissue, sex, case, and control
 - Creates age-based entries containing log2 fold change and adjusted p-values
 - Validates and sorts age entries by numeric value
@@ -68,6 +69,9 @@ REQUIRED_INPUT = {
         "ensembl_id",
     ],
 }
+
+# Source data uses plural sex cohort labels; the Comparison Tool displays singular values.
+SEX_DISPLAY_MAP = {"Females": "Female", "Males": "Male"}
 
 
 def _validate_and_sort_age_entries(
@@ -262,7 +266,7 @@ def _create_output_entry_from_group(
                 'model_group': '5XFAD',
                 'model_type': 'Familial AD',
                 'tissue': 'Hemibrain',
-                'sex': 'M',
+                'sex': 'Male',
                 '3 months': {'log2_fc': 1.234, 'adj_p_val': 0.001},
                 '6 months': {'log2_fc': 2.456, 'adj_p_val': 0.0001}
             }
@@ -352,10 +356,11 @@ def _process_single_data_file(
     3. Validating that all required columns are present
     4. Filtering to keep only mouse genes (ENSMUSG*), excluding human genes (ENSG*)
     5. Filtering out combined-cohort rows where sex is "Females & Males"
-    6. Rounding numeric columns to 5 decimal places for consistency
-    7. Grouping data by gene, model, tissue, sex, case, and control
-    8. Creating enriched output entries for each group using metadata dictionaries
-    9. Cleaning up memory by deleting the processed DataFrame and running garbage collection
+    6. Mapping plural sex labels to singular display values ("Females" -> "Female", "Males" -> "Male")
+    7. Rounding numeric columns to 5 decimal places for consistency
+    8. Grouping data by gene, model, tissue, sex, case, and control
+    9. Creating enriched output entries for each group using metadata dictionaries
+    10. Cleaning up memory by deleting the processed DataFrame and running garbage collection
 
     Each output entry represents a unique combination of gene, model, tissue, and sex,
     with age-based differential expression measurements and enriched metadata.
@@ -424,6 +429,9 @@ def _process_single_data_file(
     # Filter out combined-cohort rows; keep single-sex rows only
     data_file = data_file[data_file["sex"] != "Females & Males"]
 
+    # Map plural source sex labels to their singular display form
+    data_file = data_file.assign(sex=data_file["sex"].replace(SEX_DISPLAY_MAP))
+
     # Round numeric columns to 5 decimal places for consistency
     data_file = data_file.round(decimals=5)
 
@@ -475,6 +483,7 @@ def transform_rna_de_aggregate(
     4. Processes one or more differential expression data files sequentially:
        - Filters to mouse genes only (ENSMUSG*)
        - Filters out combined-cohort rows where sex is "Females & Males"
+       - Maps plural sex labels to singular display values ("Females" -> "Female", "Males" -> "Male")
        - Groups data by gene, model, tissue, sex, case, and control
        - Enriches each group with metadata
        - Creates age-based entries with log2 fold change and adjusted p-values
@@ -519,7 +528,7 @@ def transform_rna_de_aggregate(
                 'model_group': '5XFAD',
                 'model_type': 'Familial AD',
                 'tissue': 'Hemibrain',
-                'sex': 'M',
+                'sex': 'Male',
                 '3 months': {'log2_fc': 1.234, 'adj_p_val': 0.001},
                 '6 months': {'log2_fc': 2.456, 'adj_p_val': 0.0001}
             }

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -8,7 +8,7 @@ and biodomain annotations to create a structured output format.
 The transformation:
 - Filters to mouse genes only (ENSMUSG*), excluding human genes (ENSG*)
 - Filters out combined-cohort rows where sex is "Females & Males", keeping single-sex rows only
-- Maps plural sex labels to singular display values
+- Maps plural sex values to singular display labels
 - Groups differential expression data by gene, model, tissue, sex, case, and control
 - Creates age-based entries containing log2 fold change and adjusted p-values
 - Validates and sorts age entries by numeric value
@@ -357,7 +357,7 @@ def _process_single_data_file(
     3. Validating that all required columns are present
     4. Filtering to keep only mouse genes (ENSMUSG*), excluding human genes (ENSG*)
     5. Filtering out combined-cohort rows where sex is "Females & Males"
-    6. Mapping plural sex labels to singular display values
+    6. Mapping plural sex values to singular display labels
     7. Rounding numeric columns to 5 decimal places for consistency
     8. Grouping data by gene, model, tissue, sex, case, and control
     9. Creating enriched output entries for each group using metadata dictionaries
@@ -484,7 +484,7 @@ def transform_rna_de_aggregate(
     4. Processes one or more differential expression data files sequentially:
        - Filters to mouse genes only (ENSMUSG*)
        - Filters out combined-cohort rows where sex is "Females & Males"
-       - Maps plural sex labels to singular display values
+       - Maps plural sex values to singular display labels
        - Groups data by gene, model, tissue, sex, case, and control
        - Enriches each group with metadata
        - Creates age-based entries with log2 fold change and adjusted p-values

--- a/src/agoradatatools/etl/transform/rna_de_aggregate.py
+++ b/src/agoradatatools/etl/transform/rna_de_aggregate.py
@@ -8,7 +8,7 @@ and biodomain annotations to create a structured output format.
 The transformation:
 - Filters to mouse genes only (ENSMUSG*), excluding human genes (ENSG*)
 - Filters out combined-cohort rows where sex is "Females & Males", keeping single-sex rows only
-- Maps plural sex labels to singular display values ("Females" -> "Female", "Males" -> "Male")
+- Maps plural sex labels to singular display values
 - Groups differential expression data by gene, model, tissue, sex, case, and control
 - Creates age-based entries containing log2 fold change and adjusted p-values
 - Validates and sorts age entries by numeric value
@@ -46,6 +46,10 @@ from agoradatatools.etl.utils import (
     normalize_zero,
 )
 
+from agoradatatools.etl.transform.transform_utils.model_ad_transform_utils import (
+    remap_sex_labels,
+)
+
 logger = logging.getLogger(__name__)
 
 REQUIRED_INPUT = {
@@ -69,9 +73,6 @@ REQUIRED_INPUT = {
         "ensembl_id",
     ],
 }
-
-# Source data uses plural sex cohort labels; the Comparison Tool displays singular values.
-SEX_DISPLAY_MAP = {"Females": "Female", "Males": "Male"}
 
 
 def _validate_and_sort_age_entries(
@@ -356,7 +357,7 @@ def _process_single_data_file(
     3. Validating that all required columns are present
     4. Filtering to keep only mouse genes (ENSMUSG*), excluding human genes (ENSG*)
     5. Filtering out combined-cohort rows where sex is "Females & Males"
-    6. Mapping plural sex labels to singular display values ("Females" -> "Female", "Males" -> "Male")
+    6. Mapping plural sex labels to singular display values
     7. Rounding numeric columns to 5 decimal places for consistency
     8. Grouping data by gene, model, tissue, sex, case, and control
     9. Creating enriched output entries for each group using metadata dictionaries
@@ -430,7 +431,7 @@ def _process_single_data_file(
     data_file = data_file[data_file["sex"] != "Females & Males"]
 
     # Map plural source sex labels to their singular display form
-    data_file = data_file.assign(sex=data_file["sex"].replace(SEX_DISPLAY_MAP))
+    data_file["sex"] = remap_sex_labels(data_file["sex"])
 
     # Round numeric columns to 5 decimal places for consistency
     data_file = data_file.round(decimals=5)
@@ -483,7 +484,7 @@ def transform_rna_de_aggregate(
     4. Processes one or more differential expression data files sequentially:
        - Filters to mouse genes only (ENSMUSG*)
        - Filters out combined-cohort rows where sex is "Females & Males"
-       - Maps plural sex labels to singular display values ("Females" -> "Female", "Males" -> "Male")
+       - Maps plural sex labels to singular display values
        - Groups data by gene, model, tissue, sex, case, and control
        - Enriches each group with metadata
        - Creates age-based entries with log2 fold change and adjusted p-values

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -21,7 +21,7 @@ The transformation:
 - Organizes data by model_group to support both single and multiple control display paradigms
 - Enriches data with gene symbols from gene metadata
 - Maps genotypes to display labels for better readability
-- Maps plural sex labels to singular display values ("Females" -> "Female", "Males" -> "Male")
+- Maps plural sex values to singular display labels
 - Applies tissue name transformations: "Right Cerebral Hemisphere" → "Hemibrain" and
   converts all tissues to sentence case
 - Rounds numeric columns to 5 decimal places for consistency

--- a/src/agoradatatools/etl/transform/rna_de_individual.py
+++ b/src/agoradatatools/etl/transform/rna_de_individual.py
@@ -21,7 +21,7 @@ The transformation:
 - Organizes data by model_group to support both single and multiple control display paradigms
 - Enriches data with gene symbols from gene metadata
 - Maps genotypes to display labels for better readability
-- Passes sex values through as-is from the source data
+- Maps plural sex labels to singular display values ("Females" -> "Female", "Males" -> "Male")
 - Applies tissue name transformations: "Right Cerebral Hemisphere" → "Hemibrain" and
   converts all tissues to sentence case
 - Rounds numeric columns to 5 decimal places for consistency

--- a/src/agoradatatools/etl/transform/transform_utils/model_ad_transform_utils.py
+++ b/src/agoradatatools/etl/transform/transform_utils/model_ad_transform_utils.py
@@ -5,7 +5,7 @@ Functions:
     process_genetic_info - process a gene information DataFrame into a dictionary for model details/overview
     build_transcriptomics_url - build a URL linking to the gene comparison table for a given study
     zero_pad_jax_ids - convert Jax IDs to strings with leading zeros preserved, and handle missing values appropriately
-    map_sex_labels - convert any plural sex values to singular form for consistent display
+    remap_sex_labels - convert any plural sex values to singular form for consistent display
 """
 
 from typing import Any, Dict, List, Union

--- a/src/agoradatatools/etl/transform/transform_utils/model_ad_transform_utils.py
+++ b/src/agoradatatools/etl/transform/transform_utils/model_ad_transform_utils.py
@@ -5,7 +5,7 @@ Functions:
     process_genetic_info - process a gene information DataFrame into a dictionary for model details/overview
     build_transcriptomics_url - build a URL linking to the gene comparison table for a given study
     zero_pad_jax_ids - convert Jax IDs to strings with leading zeros preserved, and handle missing values appropriately
-    map_sex_labels - convert any plural sex labels to singular form
+    map_sex_labels - convert any plural sex values to singular form for consistent display
 """
 
 from typing import Any, Dict, List, Union
@@ -187,8 +187,8 @@ def validate_jax_ids(jax_id: pd.Series) -> None:
 
 def remap_sex_labels(sex: pd.Series) -> pd.Series:
     """
-    Converts plural sex labels ("Females" or "Males") to singular form ("Female" or "Male"). Values that are
-    already singular are not modified.
+    Converts plural sex values ("Females" or "Males") to singular form ("Female" or "Male"). Sex values that are
+    already singular, and any other value, are not modified.
 
     Args:
         sex (pd.Series): A pandas Series containing sex labels that may need to be converted.

--- a/src/agoradatatools/etl/transform/transform_utils/model_ad_transform_utils.py
+++ b/src/agoradatatools/etl/transform/transform_utils/model_ad_transform_utils.py
@@ -5,6 +5,7 @@ Functions:
     process_genetic_info - process a gene information DataFrame into a dictionary for model details/overview
     build_transcriptomics_url - build a URL linking to the gene comparison table for a given study
     zero_pad_jax_ids - convert Jax IDs to strings with leading zeros preserved, and handle missing values appropriately
+    map_sex_labels - convert any plural sex labels to singular form
 """
 
 from typing import Any, Dict, List, Union
@@ -182,3 +183,17 @@ def validate_jax_ids(jax_id: pd.Series) -> None:
             "Jax IDs must be strings that contain only digits and are at least 6 characters long, or must be empty strings"
         )
     return None
+
+
+def remap_sex_labels(sex: pd.Series) -> pd.Series:
+    """
+    Converts plural sex labels ("Females" or "Males") to singular form ("Female" or "Male"). Values that are
+    already singular are not modified.
+
+    Args:
+        sex (pd.Series): A pandas Series containing sex labels that may need to be converted.
+
+    Returns:
+        pd.Series: A pandas Series containing sex labels in only the singular form.
+    """
+    return sex.replace({"Females": "Female", "Males": "Male"})

--- a/src/agoradatatools/etl/transform/transform_utils/rna_de_individual_utils.py
+++ b/src/agoradatatools/etl/transform/transform_utils/rna_de_individual_utils.py
@@ -26,6 +26,10 @@ from agoradatatools.etl.utils import (
     ColumnRule,
 )
 
+from agoradatatools.etl.transform.transform_utils.model_ad_transform_utils import (
+    remap_sex_labels,
+)
+
 logger = logging.getLogger(__name__)
 
 
@@ -170,8 +174,7 @@ def preprocess_data_file(
         "Right Cerebral Hemisphere", "Hemibrain", regex=False
     )
     # Map plural source sex labels to their singular display form
-    SEX_DISPLAY_MAP = {"Females": "Female", "Males": "Male"}
-    data_file["sex"] = data_file["sex"].replace(SEX_DISPLAY_MAP)
+    data_file["sex"] = remap_sex_labels(data_file["sex"])
     data_file["expression"] = data_file["expression"].astype(float)
     data_file = data_file.round(decimals=5)
     data_file["individualid"] = data_file["individualid"].astype(str)

--- a/src/agoradatatools/etl/transform/transform_utils/rna_de_individual_utils.py
+++ b/src/agoradatatools/etl/transform/transform_utils/rna_de_individual_utils.py
@@ -150,7 +150,8 @@ def preprocess_data_file(
 
     Returns:
         Preprocessed DataFrame with mouse genes only, tissue names mapped and
-        sentence-cased, and numeric values rounded to 5 decimal places.
+        sentence-cased, plural sex labels mapped to singular display values, and
+        numeric values rounded to 5 decimal places.
 
     Raises:
         ValueError: If the file is empty, missing required columns, or any column
@@ -168,6 +169,9 @@ def preprocess_data_file(
     data_file["tissue"] = data_file["tissue"].str.replace(
         "Right Cerebral Hemisphere", "Hemibrain", regex=False
     )
+    # Map plural source sex labels to their singular display form
+    SEX_DISPLAY_MAP = {"Females": "Female", "Males": "Male"}
+    data_file["sex"] = data_file["sex"].replace(SEX_DISPLAY_MAP)
     data_file["expression"] = data_file["expression"].astype(float)
     data_file = data_file.round(decimals=5)
     data_file["individualid"] = data_file["individualid"].astype(str)

--- a/src/agoradatatools/etl/transform/transform_utils/rna_de_individual_utils.py
+++ b/src/agoradatatools/etl/transform/transform_utils/rna_de_individual_utils.py
@@ -154,7 +154,7 @@ def preprocess_data_file(
 
     Returns:
         Preprocessed DataFrame with mouse genes only, tissue names mapped and
-        sentence-cased, plural sex labels mapped to singular display values, and
+        sentence-cased, plural sex values mapped to singular display labels, and
         numeric values rounded to 5 decimal places.
 
     Raises:
@@ -173,7 +173,7 @@ def preprocess_data_file(
     data_file["tissue"] = data_file["tissue"].str.replace(
         "Right Cerebral Hemisphere", "Hemibrain", regex=False
     )
-    # Map plural source sex labels to their singular display form
+    # Map plural source sex values to the singular display form
     data_file["sex"] = remap_sex_labels(data_file["sex"])
     data_file["expression"] = data_file["expression"].astype(float)
     data_file = data_file.round(decimals=5)

--- a/tests/test_assets/rna_de_aggregate/output/synthetic_sex_cohort_filter_output.json
+++ b/tests/test_assets/rna_de_aggregate/output/synthetic_sex_cohort_filter_output.json
@@ -11,7 +11,7 @@
     "model_group": "AD",
     "model_type": "Late Onset AD",
     "tissue": "Brain",
-    "sex": "Females",
+    "sex": "Female",
     "3 months": {
       "log2_fc": 1.5,
       "adj_p_val": 0.15
@@ -29,7 +29,7 @@
     "model_group": "AD",
     "model_type": "Late Onset AD",
     "tissue": "Brain",
-    "sex": "Males",
+    "sex": "Male",
     "6 months": {
       "log2_fc": -1.0,
       "adj_p_val": 0.1

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -1084,6 +1084,54 @@ class TestProcessSingleDataFile:
         assert {entry["sex"] for entry in result} == {"Male", "Female"}
         assert not any(entry["sex"] in {"Females", "Males"} for entry in result)
 
+    def test_process_single_data_file__passes_singular_sex_values(self) -> None:
+        """Singular source sex labels are passed thorugh unaltered")."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
+                "log2foldchange": [1.5, 2.0],
+                "padj": [0.01, 0.02],
+                "model": ["Model_A", "Model_A"],
+                "case": ["Tg", "Tg"],
+                "control": ["Wt", "Wt"],
+                "age": ["6 months", "6 months"],
+                "sex": ["Female", "Male"],
+                "tissue": ["Cortex", "Cortex"],
+            }
+        )
+
+        label_map_dict = {
+            ("Model_A", "Tg"): "Transgenic",
+            ("Model_A", "Wt"): "Wildtype",
+        }
+        data_file_required_columns = [
+            "ensembl_gene_id",
+            "log2foldchange",
+            "padj",
+            "model",
+            "case",
+            "control",
+            "age",
+            "sex",
+            "tissue",
+        ]
+
+        result = _process_single_data_file(
+            file_name="sex_mapping.csv",
+            data_file=data_file,
+            data_file_required_columns=data_file_required_columns,
+            gene_metadata_dict={},
+            label_map_dict=label_map_dict,
+            model_group_dict={},
+            biodomain_dict={},
+            model_type_dict={},
+            file_index=0,
+            total_files=1,
+        )
+
+        assert {entry["sex"] for entry in result} == {"Male", "Female"}
+
+
     def test_process_single_data_file_rounding(self) -> None:
         """Test that numeric values are rounded to 5 decimal places."""
         data_file = pd.DataFrame(

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -976,7 +976,8 @@ class TestProcessSingleDataFile:
         assert not any(entry["ensembl_gene_id"].startswith("ENSG") for entry in result)
 
     def test_process_single_data_file_filters_combined_sex_cohort(self) -> None:
-        """Test that combined-cohort rows (sex == "Females & Males") are filtered out."""
+        """Test that combined-cohort rows (sex == "Females & Males") are filtered out and
+        the surviving plural sex labels are mapped to singular display values."""
         data_file = pd.DataFrame(
             {
                 "ensembl_gene_id": [
@@ -1029,10 +1030,59 @@ class TestProcessSingleDataFile:
             total_files=1,
         )
 
-        # Should only have 2 entries (single-sex rows only)
+        # Should only have 2 entries (single-sex rows only), with singular sex labels
         assert len(result) == 2
-        assert {entry["sex"] for entry in result} == {"Males", "Females"}
+        assert {entry["sex"] for entry in result} == {"Male", "Female"}
         assert not any(entry["sex"] == "Females & Males" for entry in result)
+
+    def test_process_single_data_file_maps_sex_to_singular(self) -> None:
+        """Plural source sex labels are mapped to singular display values
+        ("Females" -> "Female", "Males" -> "Male")."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
+                "log2foldchange": [1.5, 2.0],
+                "padj": [0.01, 0.02],
+                "model": ["Model_A", "Model_A"],
+                "case": ["Tg", "Tg"],
+                "control": ["Wt", "Wt"],
+                "age": ["6 months", "6 months"],
+                "sex": ["Females", "Males"],
+                "tissue": ["Cortex", "Cortex"],
+            }
+        )
+
+        label_map_dict = {
+            ("Model_A", "Tg"): "Transgenic",
+            ("Model_A", "Wt"): "Wildtype",
+        }
+        data_file_required_columns = [
+            "ensembl_gene_id",
+            "log2foldchange",
+            "padj",
+            "model",
+            "case",
+            "control",
+            "age",
+            "sex",
+            "tissue",
+        ]
+
+        result = _process_single_data_file(
+            file_name="sex_mapping.csv",
+            data_file=data_file,
+            data_file_required_columns=data_file_required_columns,
+            gene_metadata_dict={},
+            label_map_dict=label_map_dict,
+            model_group_dict={},
+            biodomain_dict={},
+            model_type_dict={},
+            file_index=0,
+            total_files=1,
+        )
+
+        assert {entry["sex"] for entry in result} == {"Male", "Female"}
+        assert not any(entry["sex"] in {"Females", "Males"} for entry in result)
 
     def test_process_single_data_file_rounding(self) -> None:
         """Test that numeric values are rounded to 5 decimal places."""

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -976,8 +976,7 @@ class TestProcessSingleDataFile:
         assert not any(entry["ensembl_gene_id"].startswith("ENSG") for entry in result)
 
     def test_process_single_data_file_filters_combined_sex_cohort(self) -> None:
-        """Test that combined-cohort rows (sex == "Females & Males") are filtered out and
-        the surviving plural sex labels are mapped to singular display values."""
+        """Test that combined-cohort rows (sex == "Females & Males") are filtered out."""
         data_file = pd.DataFrame(
             {
                 "ensembl_gene_id": [
@@ -1034,102 +1033,6 @@ class TestProcessSingleDataFile:
         assert len(result) == 2
         assert {entry["sex"] for entry in result} == {"Male", "Female"}
         assert not any(entry["sex"] == "Females & Males" for entry in result)
-
-    def test_process_single_data_file_maps_sex_to_singular(self) -> None:
-        """Plural source sex labels are mapped to singular display values
-        ("Females" -> "Female", "Males" -> "Male")."""
-        data_file = pd.DataFrame(
-            {
-                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
-                "log2foldchange": [1.5, 2.0],
-                "padj": [0.01, 0.02],
-                "model": ["Model_A", "Model_A"],
-                "case": ["Tg", "Tg"],
-                "control": ["Wt", "Wt"],
-                "age": ["6 months", "6 months"],
-                "sex": ["Females", "Males"],
-                "tissue": ["Cortex", "Cortex"],
-            }
-        )
-
-        label_map_dict = {
-            ("Model_A", "Tg"): "Transgenic",
-            ("Model_A", "Wt"): "Wildtype",
-        }
-        data_file_required_columns = [
-            "ensembl_gene_id",
-            "log2foldchange",
-            "padj",
-            "model",
-            "case",
-            "control",
-            "age",
-            "sex",
-            "tissue",
-        ]
-
-        result = _process_single_data_file(
-            file_name="sex_mapping.csv",
-            data_file=data_file,
-            data_file_required_columns=data_file_required_columns,
-            gene_metadata_dict={},
-            label_map_dict=label_map_dict,
-            model_group_dict={},
-            biodomain_dict={},
-            model_type_dict={},
-            file_index=0,
-            total_files=1,
-        )
-
-        assert {entry["sex"] for entry in result} == {"Male", "Female"}
-        assert not any(entry["sex"] in {"Females", "Males"} for entry in result)
-
-    def test_process_single_data_file_singular_sex_values_pass_through(self) -> None:
-        """Singular source sex labels are passed through without alteration")."""
-        data_file = pd.DataFrame(
-            {
-                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
-                "log2foldchange": [1.5, 2.0],
-                "padj": [0.01, 0.02],
-                "model": ["Model_A", "Model_A"],
-                "case": ["Tg", "Tg"],
-                "control": ["Wt", "Wt"],
-                "age": ["6 months", "6 months"],
-                "sex": ["Female", "Male"],
-                "tissue": ["Cortex", "Cortex"],
-            }
-        )
-
-        label_map_dict = {
-            ("Model_A", "Tg"): "Transgenic",
-            ("Model_A", "Wt"): "Wildtype",
-        }
-        data_file_required_columns = [
-            "ensembl_gene_id",
-            "log2foldchange",
-            "padj",
-            "model",
-            "case",
-            "control",
-            "age",
-            "sex",
-            "tissue",
-        ]
-
-        result = _process_single_data_file(
-            file_name="sex_mapping.csv",
-            data_file=data_file,
-            data_file_required_columns=data_file_required_columns,
-            gene_metadata_dict={},
-            label_map_dict=label_map_dict,
-            model_group_dict={},
-            biodomain_dict={},
-            model_type_dict={},
-            file_index=0,
-            total_files=1,
-        )
-
-        assert {entry["sex"] for entry in result} == {"Male", "Female"}
 
     def test_process_single_data_file_rounding(self) -> None:
         """Test that numeric values are rounded to 5 decimal places."""

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -1032,7 +1032,6 @@ class TestProcessSingleDataFile:
         # Should only have 2 entries (single-sex rows only), with singular sex labels
         assert len(result) == 2
         assert {entry["sex"] for entry in result} == {"Male", "Female"}
-        assert not any(entry["sex"] == "Females & Males" for entry in result)
 
     def test_process_single_data_file_rounding(self) -> None:
         """Test that numeric values are rounded to 5 decimal places."""

--- a/tests/transform/test_rna_de_aggregate.py
+++ b/tests/transform/test_rna_de_aggregate.py
@@ -1084,8 +1084,8 @@ class TestProcessSingleDataFile:
         assert {entry["sex"] for entry in result} == {"Male", "Female"}
         assert not any(entry["sex"] in {"Females", "Males"} for entry in result)
 
-    def test_process_single_data_file__passes_singular_sex_values(self) -> None:
-        """Singular source sex labels are passed thorugh unaltered")."""
+    def test_process_single_data_file_singular_sex_values_pass_through(self) -> None:
+        """Singular source sex labels are passed through without alteration")."""
         data_file = pd.DataFrame(
             {
                 "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
@@ -1130,7 +1130,6 @@ class TestProcessSingleDataFile:
         )
 
         assert {entry["sex"] for entry in result} == {"Male", "Female"}
-
 
     def test_process_single_data_file_rounding(self) -> None:
         """Test that numeric values are rounded to 5 decimal places."""

--- a/tests/transform/test_rna_de_individual.py
+++ b/tests/transform/test_rna_de_individual.py
@@ -43,71 +43,8 @@ from agoradatatools.etl.transform.rna_de_individual import (
     transform_rna_de_individual,
     _determine_result_order,
     _process_individual_data_file_core,
-    DATA_FILE_REQUIRED_COLUMNS,
-    DATA_FILE_COLUMN_RULES,
-)
-from agoradatatools.etl.transform.transform_utils.rna_de_individual_utils import (
-    preprocess_data_file,
 )
 from agoradatatools.etl.utils import ContainsSubstringRule
-
-
-class TestPreprocessDataFile:
-    """Tests for preprocess_data_file."""
-
-    def test_preprocess_data_file_maps_sex_to_singular(self) -> None:
-        """Plural source sex labels are mapped to singular display values
-        ("Females" -> "Female", "Males" -> "Male")."""
-        data_file = pd.DataFrame(
-            {
-                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
-                "expression": [1.0, 2.0],
-                "model": ["Model_A", "Model_A"],
-                "genotype": ["Tg", "Wt"],
-                "age": ["6 months", "6 months"],
-                "sex": ["Females", "Males"],
-                "tissue": ["Cortex", "Cortex"],
-                "individualid": ["1", "2"],
-            }
-        )
-
-        result = preprocess_data_file(
-            file_name="sex_mapping.csv",
-            data_file=data_file,
-            file_index=0,
-            total_files=1,
-            data_file_required_columns=DATA_FILE_REQUIRED_COLUMNS,
-            data_file_column_rules=DATA_FILE_COLUMN_RULES,
-        )
-
-        assert set(result["sex"]) == {"Female", "Male"}
-        assert not result["sex"].isin(["Females", "Males"]).any()
-
-    def test_preprocess_data_file_singular_sex_values_pass_through(self) -> None:
-        """Singular source sex labels are passed through unaltered."""
-        data_file = pd.DataFrame(
-            {
-                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
-                "expression": [1.0, 2.0],
-                "model": ["Model_A", "Model_A"],
-                "genotype": ["Tg", "Wt"],
-                "age": ["6 months", "6 months"],
-                "sex": ["Female", "Male"],
-                "tissue": ["Cortex", "Cortex"],
-                "individualid": ["1", "2"],
-            }
-        )
-
-        result = preprocess_data_file(
-            file_name="sex_mapping.csv",
-            data_file=data_file,
-            file_index=0,
-            total_files=1,
-            data_file_required_columns=DATA_FILE_REQUIRED_COLUMNS,
-            data_file_column_rules=DATA_FILE_COLUMN_RULES,
-        )
-
-        assert set(result["sex"]) == {"Female", "Male"}
 
 
 class TestDetermineResultOrder:

--- a/tests/transform/test_rna_de_individual.py
+++ b/tests/transform/test_rna_de_individual.py
@@ -83,8 +83,7 @@ class TestPreprocessDataFile:
         assert set(result["sex"]) == {"Female", "Male"}
         assert not result["sex"].isin(["Females", "Males"]).any()
 
-
-    def test_preprocess_data_file_passes_singular_sex_values(self) -> None:
+    def test_preprocess_data_file_singular_sex_values_pass_through(self) -> None:
         """Singular source sex labels are passed through unaltered."""
         data_file = pd.DataFrame(
             {
@@ -109,6 +108,7 @@ class TestPreprocessDataFile:
         )
 
         assert set(result["sex"]) == {"Female", "Male"}
+
 
 class TestDetermineResultOrder:
     """

--- a/tests/transform/test_rna_de_individual.py
+++ b/tests/transform/test_rna_de_individual.py
@@ -43,9 +43,72 @@ from agoradatatools.etl.transform.rna_de_individual import (
     transform_rna_de_individual,
     _determine_result_order,
     _process_individual_data_file_core,
+    DATA_FILE_REQUIRED_COLUMNS,
+    DATA_FILE_COLUMN_RULES,
+)
+from agoradatatools.etl.transform.transform_utils.rna_de_individual_utils import (
+    preprocess_data_file,
 )
 from agoradatatools.etl.utils import ContainsSubstringRule
 
+
+class TestPreprocessDataFile:
+    """Tests for preprocess_data_file."""
+
+    def test_preprocess_data_file_maps_sex_to_singular(self) -> None:
+        """Plural source sex labels are mapped to singular display values
+        ("Females" -> "Female", "Males" -> "Male")."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
+                "expression": [1.0, 2.0],
+                "model": ["Model_A", "Model_A"],
+                "genotype": ["Tg", "Wt"],
+                "age": ["6 months", "6 months"],
+                "sex": ["Females", "Males"],
+                "tissue": ["Cortex", "Cortex"],
+                "individualid": ["1", "2"],
+            }
+        )
+
+        result = preprocess_data_file(
+            file_name="sex_mapping.csv",
+            data_file=data_file,
+            file_index=0,
+            total_files=1,
+            data_file_required_columns=DATA_FILE_REQUIRED_COLUMNS,
+            data_file_column_rules=DATA_FILE_COLUMN_RULES,
+        )
+
+        assert set(result["sex"]) == {"Female", "Male"}
+        assert not result["sex"].isin(["Females", "Males"]).any()
+
+
+    def test_preprocess_data_file_passes_singular_sex_values(self) -> None:
+        """Singular source sex labels are passed through unaltered."""
+        data_file = pd.DataFrame(
+            {
+                "ensembl_gene_id": ["ENSMUSG00000000001", "ENSMUSG00000000002"],
+                "expression": [1.0, 2.0],
+                "model": ["Model_A", "Model_A"],
+                "genotype": ["Tg", "Wt"],
+                "age": ["6 months", "6 months"],
+                "sex": ["Female", "Male"],
+                "tissue": ["Cortex", "Cortex"],
+                "individualid": ["1", "2"],
+            }
+        )
+
+        result = preprocess_data_file(
+            file_name="sex_mapping.csv",
+            data_file=data_file,
+            file_index=0,
+            total_files=1,
+            data_file_required_columns=DATA_FILE_REQUIRED_COLUMNS,
+            data_file_column_rules=DATA_FILE_COLUMN_RULES,
+        )
+
+        assert set(result["sex"]) == {"Female", "Male"}
 
 class TestDetermineResultOrder:
     """

--- a/tests/transform/transform_utils/test_model_ad_transform_utils.py
+++ b/tests/transform/transform_utils/test_model_ad_transform_utils.py
@@ -436,7 +436,7 @@ class TestRemapSexLabels:
         self, input_ids: pd.Series, expected_output: pd.Series
     ) -> None:
         """
-        Tests that the function TODO.
+        Tests that the remap_sex_labels function remaps the expected plural values without altering other values.
         """
         output = remap_sex_labels(input_ids)
 

--- a/tests/transform/transform_utils/test_model_ad_transform_utils.py
+++ b/tests/transform/transform_utils/test_model_ad_transform_utils.py
@@ -11,6 +11,7 @@ from agoradatatools.etl.transform.transform_utils.model_ad_transform_utils impor
     process_genetic_info,
     zero_pad_jax_ids,
     validate_jax_ids,
+    remap_sex_labels,
 )
 
 
@@ -405,3 +406,38 @@ class TestValidateJaxIds:
             ValueError, match="Jax IDs must be strings that contain only digits"
         ):
             validate_jax_ids(input_ids)
+
+
+class TestRemapSexLabels:
+    """
+    This class tests the remap_sex_labels function to ensure that it converts plural labels to singular, and does
+    not modify labels that are already singular.
+    """
+
+    @pytest.mark.parametrize(
+        "input_ids, expected_output",
+        [
+            (pd.Series(["Females", "Males"]), pd.Series(["Female", "Male"])),
+            (pd.Series(["Female", "Male"]), pd.Series(["Female", "Male"])),
+            (pd.Series(["Male", "Females"]), pd.Series(["Male", "Female"])),
+            (
+                pd.Series(["Male", "Females", "Aardvarks", "", None]),
+                pd.Series(["Male", "Female", "Aardvarks", "", None]),
+            ),
+        ],
+        ids=[
+            "Pass with all plural input",
+            "Pass with all singular input",
+            "Pass with mixed input",
+            "Pass with missing & other input",
+        ],
+    )
+    def test_remap_sex_labels_should_pass(
+        self, input_ids: pd.Series, expected_output: pd.Series
+    ) -> None:
+        """
+        Tests that the function TODO.
+        """
+        output = remap_sex_labels(input_ids)
+
+        pd.testing.assert_series_equal(output, expected_output)

--- a/tests/transform/transform_utils/test_rna_de_individual_utils.py
+++ b/tests/transform/transform_utils/test_rna_de_individual_utils.py
@@ -190,6 +190,48 @@ class TestPreprocessDataFileTypeCasting:
         result = preprocess_data_file("test.csv", df, 0, 1, self._REQUIRED_COLUMNS, {})
         assert result["expression"].dtype == float
 
+class TestPreprocessDataRemapsSexLabels:
+    """Tests for the sex label mapping applied inside preprocess_data_file."""
+
+    _REQUIRED_COLUMNS = [
+        "ensembl_gene_id",
+        "expression",
+        "model",
+        "genotype",
+        "age",
+        "sex",
+        "tissue",
+        "individualid",
+    ]
+
+    @staticmethod
+    def _make_df(sex_values: list[str]) -> pd.DataFrame:
+        """Build a minimal valid DataFrame with the given sex values."""
+        n = len(sex_values)
+        return pd.DataFrame(
+            {
+                "ensembl_gene_id": [f"ENSMUSG{i:011d}" for i in range(n)],
+                "expression": [1.0] * n,
+                "model": ["Model_A"] * n,
+                "genotype": ["Tg"] * n,
+                "age": ["4 months"] * n,
+                "sex": sex_values,
+                "tissue": ["Hemibrain"] * n,
+                "individualid": [f"ID{i}" for i in range(n)],
+            }
+        )
+
+    @classmethod
+    def _preprocess(cls, sex_values: list[str]) -> pd.Series:
+        df = cls._make_df(sex_values)
+        result = preprocess_data_file("test.csv", df, 0, 1, cls._REQUIRED_COLUMNS, {})
+        return result["sex"].reset_index(drop=True)
+
+    def test_maps_sex_values(self) -> None:
+        """'Plurals sex values are mapped to singular display labels"""
+        assert self._preprocess(["Males", "Females"]).tolist() == ["Male", "Female"]
+
+
 
 class TestValidateModelGroupConsistency:
     """Tests for validate_model_group_consistency function."""

--- a/tests/transform/transform_utils/test_rna_de_individual_utils.py
+++ b/tests/transform/transform_utils/test_rna_de_individual_utils.py
@@ -190,6 +190,7 @@ class TestPreprocessDataFileTypeCasting:
         result = preprocess_data_file("test.csv", df, 0, 1, self._REQUIRED_COLUMNS, {})
         assert result["expression"].dtype == float
 
+
 class TestPreprocessDataRemapsSexLabels:
     """Tests for the sex label mapping applied inside preprocess_data_file."""
 
@@ -230,7 +231,6 @@ class TestPreprocessDataRemapsSexLabels:
     def test_maps_sex_values(self) -> None:
         """'Plurals sex values are mapped to singular display labels"""
         assert self._preprocess(["Males", "Females"]).tolist() == ["Male", "Female"]
-
 
 
 class TestValidateModelGroupConsistency:


### PR DESCRIPTION
# Problem

The Sex column in the Disease Correlation CT uses singular sex values (Female, Male), but the new Sex column in the RNA DE CT is displaying plural values (Females, Males). The individual RNA results page also displays the plural values.


# Solution

Update the rna_de_aggregate and rna_de_individual custom transforms to map the plural versions to the singular form, while allowing unmapped sex values (such as those from any results files that already contain the singular form) to pass through unaltered.

Note: Depending on merge order, either this PR or the [rna_de GX PR](https://github.com/Sage-Bionetworks/agora-data-tools/pull/369) will need to update the GX allowed values for this field.