### PR TITLE
Add 3 new models to RNA DE results

### DIFF
--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -5,11 +5,11 @@ gx_table: syn71888382          # preprod
 # Reusable file reference anchors used by datasets below.
 files:
   # Metadata & Configuration
-  - &model_genetic_modifications  { name: model_genetic_modifications  , format: csv  , id: syn76147521.3  }
+  - &model_genetic_modifications  { name: model_genetic_modifications  , format: csv  , id: syn76147521.5  }
   - &immunohisto_measure_order    { name: immunohisto_measure_order    , format: yaml , id: syn71305327.2  }
-  - &model_metadata               { name: model_metadata               , format: csv  , id: syn76069176.2  }
+  - &model_metadata               { name: model_metadata               , format: csv  , id: syn76069176.4  }
   - &mouse_gene_metadata          { name: mouse_gene_metadata          , format: json , id: syn51615422.6  }
-  - &genotype_label_map           { name: genotype_label_map           , format: csv  , id: syn69014401.17 }
+  - &genotype_label_map           { name: genotype_label_map           , format: csv  , id: syn69014401.18 }
   - &ui_config                    { name: ui_config                    , format: json , id: syn66527739 }
   # Results
   - &biodom_genes_mm              { name: biodom_genes_mm              , format: csv  , id: syn66351272.1  }
@@ -19,19 +19,27 @@ files:
   # Differential Expression Results
   - &jax_5xFAD_de                 { name: jax_5xFAD_de                 , format: csv  , id: syn69058660.2  }
   - &jax_APOE4_Trem2_R47H_de      { name: jax_APOE4_Trem2_R47H_de      , format: csv  , id: syn69693082.3  }
+  - &jax_LOAD2_de                 { name: jax_LOAD2_de                 , format: csv  , id: syn76459572.1  }
   - &uci_3xTG_AD_de               { name: uci_3xTG_AD_de               , format: csv  , id: syn69058661.2  }
   - &uci_5xFAD_de                 { name: uci_5xFAD_de                 , format: csv  , id: syn69058664.1  }
   - &uci_ABCA7_de                 { name: uci_ABCA7_de                 , format: csv  , id: syn69058663.3  }
+  - &uci_Bin1_de                  { name: uci_Bin1_de                  , format: csv  , id: syn76457207.1  }
+  - &uci_Clu_de                   { name: uci_Clu_de                   , format: csv  , id: syn76457215.1  }
   - &uci_Trem2_R47H_NSS_de        { name: uci_Trem2_R47H_NSS_de        , format: csv  , id: syn69058662.3  }
   # Normalized Expression Results
   - &jax_5xFAD_ne                 { name: jax_5xFAD_ne                 , format: csv  , id: syn69058674.1  }
   - &jax_APOE4_ne                 { name: jax_APOE4_ne                 , format: csv  , id: syn72388431.2  }
   - &jax_APOE4_Trem2_R47H_ne      { name: jax_APOE4_Trem2_R47H_ne      , format: csv  , id: syn72388432.1  }
   - &jax_Trem2_R47H_ne            { name: jax_Trem2_R47H_ne            , format: csv  , id: syn72388430.2  }
+  - &jax_LOAD2_ne                 { name: jax_LOAD2_ne                 , format: csv  , id: syn76459553.1  }
   - &uci_3xTG_AD_ne               { name: uci_3xTG_AD_ne               , format: csv  , id: syn69058676.1  }
   - &uci_5xFAD_ne                 { name: uci_5xFAD_ne                 , format: csv  , id: syn69058679.1  }
   - &uci_ABCA7_ne                 { name: uci_ABCA7_ne                 , format: csv  , id: syn72388477.1  }
   - &uci_ABCA7_5xFAD_ne           { name: uci_ABCA7_5xFAD_ne           , format: csv  , id: syn72388476.2  }
+  - &uci_Bin1_ne                  { name: uci_Bin1_ne                  , format: csv  , id: syn76459725.1  }
+  - &uci_Bin1_5xFAD_ne            { name: uci_Bin1_5xFAD_ne            , format: csv  , id: syn76459724.1  }
+  - &uci_Clu_ne                   { name: uci_Clu_ne                   , format: csv  , id: syn76459751.1  }
+  - &uci_Clu_5xFAD_ne             { name: uci_Clu_5xFAD_ne             , format: csv  , id: syn76459744.1  }
   - &uci_Trem2_R47H_NSS_ne        { name: uci_Trem2_R47H_NSS_ne        , format: csv  , id: syn72388498.1  }
   - &uci_Trem2_R47H_NSS_5xFAD_ne  { name: uci_Trem2_R47H_NSS_5xFAD_ne  , format: csv  , id: syn72388499.2  }
 
@@ -107,9 +115,12 @@ datasets:
         - <<: *biodom_genes_mm
         - <<: *jax_5xFAD_de
         - <<: *jax_APOE4_Trem2_R47H_de
+        - <<: *jax_LOAD2_de
         - <<: *uci_3xTG_AD_de
         - <<: *uci_5xFAD_de
         - <<: *uci_ABCA7_de
+        - <<: *uci_Bin1_de
+        - <<: *uci_Clu_de
         - <<: *uci_Trem2_R47H_NSS_de
       final_format: json
       destination: *dest
@@ -122,8 +133,13 @@ datasets:
         - <<: *jax_APOE4_Trem2_R47H_ne
         - <<: *jax_APOE4_ne
         - <<: *jax_Trem2_R47H_ne
+        - <<: *jax_LOAD2_ne
         - <<: *uci_ABCA7_5xFAD_ne
         - <<: *uci_ABCA7_ne
+        - <<: *uci_Bin1_ne
+        - <<: *uci_Bin1_5xFAD_ne
+        - <<: *uci_Clu_ne
+        - <<: *uci_Clu_5xFAD_ne
         - <<: *uci_Trem2_R47H_NSS_5xFAD_ne
         - <<: *uci_Trem2_R47H_NSS_ne
         - <<: *uci_3xTG_AD_ne

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -24,7 +24,7 @@ files:
   - &uci_5xFAD_de                 { name: uci_5xFAD_de                 , format: csv  , id: syn69058664.1  }
   - &uci_ABCA7_de                 { name: uci_ABCA7_de                 , format: csv  , id: syn69058663.3  }
   - &uci_Bin1_de                  { name: uci_Bin1_de                  , format: csv  , id: syn76457207.1  }
-  - &uci_Clu_de                   { name: uci_Clu_de                   , format: csv  , id: syn76457215.1  }
+  - &uci_Clu_de                   { name: uci_Clu_de                   , format: csv  , id: syn76457215.2  }
   - &uci_Trem2_R47H_NSS_de        { name: uci_Trem2_R47H_NSS_de        , format: csv  , id: syn69058662.3  }
   # Normalized Expression Results
   - &jax_5xFAD_ne                 { name: jax_5xFAD_ne                 , format: csv  , id: syn69058674.1  }

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -18,7 +18,7 @@ files:
   - &pathology                    { name: pathology                    , format: csv  , id: syn61357279.18 }
   # Differential Expression Results
   - &jax_5xFAD_de                 { name: jax_5xFAD_de                 , format: csv  , id: syn69058660.2  }
-  - &jax_APOE4_Trem2_R47H_de      { name: jax_APOE4_Trem2_R47H_de      , format: csv  , id: syn69693082.3  }
+  - &jax_APOE4_Trem2_R47H_de      { name: jax_APOE4_Trem2_R47H_de      , format: csv  , id: syn76459470.1  } #syn69693082.4 when released to portal
   - &jax_LOAD2_de                 { name: jax_LOAD2_de                 , format: csv  , id: syn76459572.1  }
   - &uci_3xTG_AD_de               { name: uci_3xTG_AD_de               , format: csv  , id: syn69058661.2  }
   - &uci_5xFAD_de                 { name: uci_5xFAD_de                 , format: csv  , id: syn69058664.1  }
@@ -28,9 +28,9 @@ files:
   - &uci_Trem2_R47H_NSS_de        { name: uci_Trem2_R47H_NSS_de        , format: csv  , id: syn69058662.3  }
   # Normalized Expression Results
   - &jax_5xFAD_ne                 { name: jax_5xFAD_ne                 , format: csv  , id: syn69058674.1  }
-  - &jax_APOE4_ne                 { name: jax_APOE4_ne                 , format: csv  , id: syn72388431.2  }
-  - &jax_APOE4_Trem2_R47H_ne      { name: jax_APOE4_Trem2_R47H_ne      , format: csv  , id: syn72388432.1  }
-  - &jax_Trem2_R47H_ne            { name: jax_Trem2_R47H_ne            , format: csv  , id: syn72388430.2  }
+  - &jax_APOE4_ne                 { name: jax_APOE4_ne                 , format: csv  , id: syn72388431.3  }
+  - &jax_APOE4_Trem2_R47H_ne      { name: jax_APOE4_Trem2_R47H_ne      , format: csv  , id: syn72388432.2  }
+  - &jax_Trem2_R47H_ne            { name: jax_Trem2_R47H_ne            , format: csv  , id: syn72388430.3  }
   - &jax_LOAD2_ne                 { name: jax_LOAD2_ne                 , format: csv  , id: syn76459553.1  }
   - &uci_3xTG_AD_ne               { name: uci_3xTG_AD_ne               , format: csv  , id: syn69058676.1  }
   - &uci_5xFAD_ne                 { name: uci_5xFAD_ne                 , format: csv  , id: syn69058679.1  }

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -5,11 +5,11 @@ gx_table: syn71888383            # prod
 # Reusable file reference anchors used by datasets below.
 files:
   # Metadata & Configuration
-  - &model_genetic_modifications  { name: model_genetic_modifications  , format: csv  , id: syn76147521.3  }
+  - &model_genetic_modifications  { name: model_genetic_modifications  , format: csv  , id: syn76147521.5  }
   - &immunohisto_measure_order    { name: immunohisto_measure_order    , format: yaml , id: syn71305327.2  }
-  - &model_metadata               { name: model_metadata               , format: csv  , id: syn76069176.2  }
+  - &model_metadata               { name: model_metadata               , format: csv  , id: syn76069176.4  }
   - &mouse_gene_metadata          { name: mouse_gene_metadata          , format: json , id: syn51615422.6  }
-  - &genotype_label_map           { name: genotype_label_map           , format: csv  , id: syn69014401.17 }
+  - &genotype_label_map           { name: genotype_label_map           , format: csv  , id: syn69014401.18 }
   - &ui_config                    { name: ui_config                    , format: json , id: syn66527739.30 }
   # Results
   - &biodom_genes_mm              { name: biodom_genes_mm              , format: csv  , id: syn66351272.1  }
@@ -19,19 +19,27 @@ files:
   # Differential Expression Results
   - &jax_5xFAD_de                 { name: jax_5xFAD_de                 , format: csv  , id: syn69058660.2  }
   - &jax_APOE4_Trem2_R47H_de      { name: jax_APOE4_Trem2_R47H_de      , format: csv  , id: syn69693082.3  }
+  - &jax_LOAD2_de                 { name: jax_LOAD2_de                 , format: csv  , id: syn76459572.1  }
   - &uci_3xTG_AD_de               { name: uci_3xTG_AD_de               , format: csv  , id: syn69058661.2  }
   - &uci_5xFAD_de                 { name: uci_5xFAD_de                 , format: csv  , id: syn69058664.1  }
   - &uci_ABCA7_de                 { name: uci_ABCA7_de                 , format: csv  , id: syn69058663.3  }
+  - &uci_Bin1_de                  { name: uci_Bin1_de                  , format: csv  , id: syn76457207.1  }
+  - &uci_Clu_de                   { name: uci_Clu_de                   , format: csv  , id: syn76457215.1  }
   - &uci_Trem2_R47H_NSS_de        { name: uci_Trem2_R47H_NSS_de        , format: csv  , id: syn69058662.3  }
   # Normalized Expression Results
   - &jax_5xFAD_ne                 { name: jax_5xFAD_ne                 , format: csv  , id: syn69058674.1  }
   - &jax_APOE4_ne                 { name: jax_APOE4_ne                 , format: csv  , id: syn72388431.2  }
   - &jax_APOE4_Trem2_R47H_ne      { name: jax_APOE4_Trem2_R47H_ne      , format: csv  , id: syn72388432.1  }
   - &jax_Trem2_R47H_ne            { name: jax_Trem2_R47H_ne            , format: csv  , id: syn72388430.2  }
+  - &jax_LOAD2_ne                 { name: jax_LOAD2_ne                 , format: csv  , id: syn76459553.1  }
   - &uci_3xTG_AD_ne               { name: uci_3xTG_AD_ne               , format: csv  , id: syn69058676.1  }
   - &uci_5xFAD_ne                 { name: uci_5xFAD_ne                 , format: csv  , id: syn69058679.1  }
   - &uci_ABCA7_ne                 { name: uci_ABCA7_ne                 , format: csv  , id: syn72388477.1  }
   - &uci_ABCA7_5xFAD_ne           { name: uci_ABCA7_5xFAD_ne           , format: csv  , id: syn72388476.2  }
+  - &uci_Bin1_ne                  { name: uci_Bin1_ne                  , format: csv  , id: syn76459725.1  }
+  - &uci_Bin1_5xFAD_ne            { name: uci_Bin1_5xFAD_ne            , format: csv  , id: syn76459724.1  }
+  - &uci_Clu_ne                   { name: uci_Clu_ne                   , format: csv  , id: syn76459751.1  }
+  - &uci_Clu_5xFAD_ne             { name: uci_Clu_5xFAD_ne             , format: csv  , id: syn76459744.1  }
   - &uci_Trem2_R47H_NSS_ne        { name: uci_Trem2_R47H_NSS_ne        , format: csv  , id: syn72388498.1  }
   - &uci_Trem2_R47H_NSS_5xFAD_ne  { name: uci_Trem2_R47H_NSS_5xFAD_ne  , format: csv  , id: syn72388499.2  }
 
@@ -107,9 +115,12 @@ datasets:
         - <<: *biodom_genes_mm
         - <<: *jax_5xFAD_de
         - <<: *jax_APOE4_Trem2_R47H_de
+        - <<: *jax_LOAD2_de
         - <<: *uci_3xTG_AD_de
         - <<: *uci_5xFAD_de
         - <<: *uci_ABCA7_de
+        - <<: *uci_Bin1_de
+        - <<: *uci_Clu_de
         - <<: *uci_Trem2_R47H_NSS_de
       final_format: json
       destination: *dest
@@ -122,8 +133,13 @@ datasets:
         - <<: *jax_APOE4_Trem2_R47H_ne
         - <<: *jax_APOE4_ne
         - <<: *jax_Trem2_R47H_ne
+        - <<: *jax_LOAD2_ne
         - <<: *uci_ABCA7_5xFAD_ne
         - <<: *uci_ABCA7_ne
+        - <<: *uci_Bin1_ne
+        - <<: *uci_Bin1_5xFAD_ne
+        - <<: *uci_Clu_ne
+        - <<: *uci_Clu_5xFAD_ne
         - <<: *uci_Trem2_R47H_NSS_5xFAD_ne
         - <<: *uci_Trem2_R47H_NSS_ne
         - <<: *uci_3xTG_AD_ne

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -24,7 +24,7 @@ files:
   - &uci_5xFAD_de                 { name: uci_5xFAD_de                 , format: csv  , id: syn69058664.1  }
   - &uci_ABCA7_de                 { name: uci_ABCA7_de                 , format: csv  , id: syn69058663.3  }
   - &uci_Bin1_de                  { name: uci_Bin1_de                  , format: csv  , id: syn76457207.1  }
-  - &uci_Clu_de                   { name: uci_Clu_de                   , format: csv  , id: syn76457215.1  }
+  - &uci_Clu_de                   { name: uci_Clu_de                   , format: csv  , id: syn76457215.2  }
   - &uci_Trem2_R47H_NSS_de        { name: uci_Trem2_R47H_NSS_de        , format: csv  , id: syn69058662.3  }
   # Normalized Expression Results
   - &jax_5xFAD_ne                 { name: jax_5xFAD_ne                 , format: csv  , id: syn69058674.1  }

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -18,7 +18,7 @@ files:
   - &pathology                    { name: pathology                    , format: csv  , id: syn61357279.18 }
   # Differential Expression Results
   - &jax_5xFAD_de                 { name: jax_5xFAD_de                 , format: csv  , id: syn69058660.2  }
-  - &jax_APOE4_Trem2_R47H_de      { name: jax_APOE4_Trem2_R47H_de      , format: csv  , id: syn69693082.3  }
+  - &jax_APOE4_Trem2_R47H_de      { name: jax_APOE4_Trem2_R47H_de      , format: csv  , id: syn76459470.1  } #syn69693082.4 when released to portal
   - &jax_LOAD2_de                 { name: jax_LOAD2_de                 , format: csv  , id: syn76459572.1  }
   - &uci_3xTG_AD_de               { name: uci_3xTG_AD_de               , format: csv  , id: syn69058661.2  }
   - &uci_5xFAD_de                 { name: uci_5xFAD_de                 , format: csv  , id: syn69058664.1  }
@@ -28,9 +28,9 @@ files:
   - &uci_Trem2_R47H_NSS_de        { name: uci_Trem2_R47H_NSS_de        , format: csv  , id: syn69058662.3  }
   # Normalized Expression Results
   - &jax_5xFAD_ne                 { name: jax_5xFAD_ne                 , format: csv  , id: syn69058674.1  }
-  - &jax_APOE4_ne                 { name: jax_APOE4_ne                 , format: csv  , id: syn72388431.2  }
-  - &jax_APOE4_Trem2_R47H_ne      { name: jax_APOE4_Trem2_R47H_ne      , format: csv  , id: syn72388432.1  }
-  - &jax_Trem2_R47H_ne            { name: jax_Trem2_R47H_ne            , format: csv  , id: syn72388430.2  }
+  - &jax_APOE4_ne                 { name: jax_APOE4_ne                 , format: csv  , id: syn72388431.3  }
+  - &jax_APOE4_Trem2_R47H_ne      { name: jax_APOE4_Trem2_R47H_ne      , format: csv  , id: syn72388432.2  }
+  - &jax_Trem2_R47H_ne            { name: jax_Trem2_R47H_ne            , format: csv  , id: syn72388430.3  }
   - &jax_LOAD2_ne                 { name: jax_LOAD2_ne                 , format: csv  , id: syn76459553.1  }
   - &uci_3xTG_AD_ne               { name: uci_3xTG_AD_ne               , format: csv  , id: syn69058676.1  }
   - &uci_5xFAD_ne                 { name: uci_5xFAD_ne                 , format: csv  , id: syn69058679.1  }

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -193,7 +193,7 @@ ge_dynamic_column_is_exported <- TRUE
 ge_dynamic_column_is_hidden <- FALSE
 
 # Variable heatmap column names vary by contributing center and by tissue, since each center sequences different tissues
-ge_dynamic_names_jax <- c("4 months", "12 months")
+ge_dynamic_names_jax <- c("4 months", "12 months", "18 months", "24 months")
 ge_dynamic_names_uci <- c("4 months", "12 months", "18 months")
 
 # Differential Expression Filters
@@ -215,10 +215,13 @@ ge_model_name_filter_vals_hemibrain <- c(
                             '5xFAD (IU/Jax/Pitt)',
                             'APOE4',
                             'LOAD1',
-                            'Trem2R47H')
+                            'Trem2R47H',
+                            'LOAD2')
 
-# Cortex: 5xFAD (UCI); need to wrap single value in a list for JSON serialization
-ge_model_name_filter_vals_cerebral_cortex <- list('5xFAD (UCI)')
+# Cortex: 5xFAD (UCI) and Clu-h2kbKI
+ge_model_name_filter_vals_cerebral_cortex <- list('5xFAD (UCI)',
+                                                  'Clu-h2kbKI',
+                                                  'Clu-h2kbKI.5xFAD')
 
 # Hippocampus: All UCI models
 ge_model_name_filter_vals_hippocampus <- c(
@@ -226,6 +229,10 @@ ge_model_name_filter_vals_hippocampus <- c(
                             '5xFAD (UCI)',
                             'Abca7*V1599M',
                             'Abca7*V1599M.5xFAD',
+                            'Bin1-K358R',
+                            'Bin1-K358R.5xFAD',
+                            'Clu-h2kbKI',
+                            'Clu-h2kbKI.5xFAD',
                             'Trem2-R47H_NSS',
                             'Trem2-R47H_NSS.5xFAD')
 
@@ -492,8 +499,11 @@ mo_filters <- data.frame(
 mo_modified_gene_filter_vals <- c('Abca7',
                                'APOE',
                                'APP',
+                               'App',
+                               'Bin1',
                                'Ceacam1',
                                'Clasp2',
+                               'CLU',
                                'CR1',
                                'CR2',
                                'Il1rap',

--- a/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
+++ b/data_analysis/model_ad/notebooks/MG-402_Create ui_config source file.rmd
@@ -219,9 +219,9 @@ ge_model_name_filter_vals_hemibrain <- c(
                             'LOAD2')
 
 # Cortex: 5xFAD (UCI) and Clu-h2kbKI
-ge_model_name_filter_vals_cerebral_cortex <- list('5xFAD (UCI)',
-                                                  'Clu-h2kbKI',
-                                                  'Clu-h2kbKI.5xFAD')
+ge_model_name_filter_vals_cerebral_cortex <- c('5xFAD (UCI)',
+                                               'Clu-h2kbKI',
+                                               'Clu-h2kbKI.5xFAD')
 
 # Hippocampus: All UCI models
 ge_model_name_filter_vals_hippocampus <- c(


### PR DESCRIPTION
# Add LOAD2, Bin1, and Clu RNA seq data

Per [MG-378](https://sagebionetworks.jira.com/browse/MG-378), we want to add some new RNA results to the explorer. The three studies being added are Jax.IU.Pitt_LOAD2, UCI_Bin1K358R, and UCI_Clu-h2kbKI. 

## Changes outside this PR

I aligned, QC-ed, and analyzed the data from these studies using my harmonization pipeline. 
* DE files are in the [Staging Differential Expression Analysis](https://www.synapse.org/Synapse:syn75315759) folder of the harmonization project on Synapse. **These files are not yet released to the portal but will be eventually!**
* Normalized counts files are in the [Model-AD Explorer individual expression](https://www.synapse.org/Synapse:syn69058670) folder with the other explorer source files on Synapse.

We were previously filtering out 24 month mice from the LOAD1 study, however the new LOAD2 study also has 24 month mice, so per Jess we are now keeping 24 month data. LOAD1 DE and norm counts files have been updated to include the 24 month timepoint.

I also updated two related source metadata files:

- [genotype_label_map.csv](https://www.synapse.org/Synapse:syn69014401) - Added the correct information for the three new studies
- [model_genetic_modifications.csv](https://www.synapse.org/Synapse:syn76147521) - Removed redundant LOAD2 entries, added human ENSG for UCI_Clu, and removed a row of column names that got inserted near the bottom of the file.

## Changes in this PR

This PR adds the DE and norm counts files for the three studies to the ADT config files and bumps the versions of the two related metadata files. It also bumps the version of [model_metadata.csv](https://www.synapse.org/Synapse:syn76069176) to the latest.

It also updates the uiconfig notebook:

- `ge_dynamic_names_jax`: Added 18 months and 24 months to Jax ages (LOAD2 has 18 month data)
- `ge_model_name_filter_vals_hemibrain`: Added LOAD2 to the list of models that have Hemibrain data
- `ge_model_name_filter_vals_cerebral_cortex`: Added UCI_Clu models to the list of models that have Cerebral Cortex data
- `ge_model_name_filter_vals_hippocampus`: Added UCI_Bin1 and UCI_Clu models to the list of models that have Hippocampus data
- `mo_modified_gene_filter_vals`: Added "App", "Bin1", and "CLU" (from LOAD2, UCI_Bin1, and UCI_Clu, respectively) to the list of modified genes

## Important notes

Because the LOAD1 DE file has already been released to the portal, the _updated_ DE file is in the Staging folder instead of a new version of the released file. The synID of the LOAD1 DE file in the configs is temporarily `syn76459470.1` so the updated, non-released file is used. Once all the files in staging have been curated and released to the portal, this ID should change back to `syn69693082.4`. 

I have verified that the uiconfig notebook changes successfully generate a uiconfig file with the correct values, however **I have not uploaded the new uiconfig file to Synapse yet** because uiconfig isn't pinned to a specific version and I didn't want to risk messing up other people's PRs. I will upload the new version once we've had a chance to look at this PR and are sure we want to include the new data.

[MG-378]: https://sagebionetworks.jira.com/browse/MG-378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ