### PR TITLE
MG-761/MG-762: Add GX suites for rna_de datasets

### DIFF
--- a/.cursor/rules/gx-validation-suite-authoring.mdc
+++ b/.cursor/rules/gx-validation-suite-authoring.mdc
@@ -43,6 +43,69 @@ print(lengths.min(), lengths.max())
 
 ---
 
+## Choosing the Validation Mechanism (native expectations vs JSON Schema)
+
+Decide the mechanism from the **shape of each field's values in the processed output** (inspect it
+per Step 0) — *not* from whether the column already appears in `gx_nested_columns`. Identifying the
+nested fields and adding them to `gx_nested_columns` is itself part of authoring the suite: it's the
+lever **you pull once you've decided** a field needs structural validation, an output of the
+decision below, not a precondition for it.
+
+Judge each field by its value shape:
+
+| Field's value shape | Mechanism | Nested? |
+|---|---|---|
+| **Scalar** (str / number / bool / null) | Native/custom: `not_null`, `be_of_type`, `be_between` (ranges), `be_in_set` (enums), `match_regex` | No |
+| **List of scalars** (e.g. `biodomains`, `programs`) | Custom list expectations: `expect_column_values_to_have_list_length_in_range`, `..._members`, `..._members_of_type` | No — keep it a real Python list |
+| **Object, list of objects, or any value whose internal structure must be validated** (keys, nested types, nullability) | `expect_column_values_to_match_json_schema` for the interior — required keys, nested types, nullability (`oneOf` null), plus interior list lengths (`minItems`/`maxItems`), value ranges (`minimum`/`maximum`), and enums | **Yes — add it to `gx_nested_columns`** |
+| **Volume / statistical / cross-row** (row counts, uniqueness, distributions, means, multi-column relationships) | Native GX **only, always** — JSON Schema validates one document at a time and cannot express anything across rows | N/A |
+
+The governing question is: *what is this field's value shape, and does it have internal structure
+that only a schema can validate?* If yes → make it a nested column (`gx_nested_columns`) and use
+JSON Schema; if no → native/custom expectations on the un-nested column.
+
+### Why nesting shifts interior checks into the schema
+
+Adding a field to `gx_nested_columns` runs `convert_nested_columns_to_json`, which serializes that
+column to a **JSON string** before GX runs. That is what makes `expect_column_values_to_match_json_schema`
+work — and it's also why, for a nested field, the interior list lengths / value ranges / enums must
+live in the schema: native/custom expectations can no longer see the parsed structure.
+
+Native expectations still *run* against the JSON string, but because `json.dumps` yields a non-null
+string for every cell, most become **tautological or fragile** — the schema does the real work:
+- **Effectively no-ops (do not rely on them):** `expect_column_values_to_not_be_null` and
+  `expect_column_values_to_be_of_type("<col>", "str")` always pass — `json.dumps` never yields null
+  and always yields a string (even a missing `None` becomes the string `"null"`).
+- **Runs but fragile:** `match_regex` / value-length / `be_in_set` against the raw serialized text.
+- **Do NOT work:** the custom list expectations — they check `isinstance(cell, list)`, which is now
+  `False` for every row, so they silently fail (see the Step 3 warning) — and any numeric/statistical
+  check that needs a value *inside* the object. Encode those in the JSON Schema instead.
+
+**Required / non-null for a nested field is a schema concern, not a `not_be_null` concern.** Since a
+missing value serializes to the string `"null"`, `expect_column_values_to_not_be_null` can never
+fail on a nested column (it's a no-op that gives false assurance). Enforce presence through the
+schema instead — specifically, whether the **root of the schema** (its outermost `type`) permits null:
+- **Required (never null):** the schema's root is `{"type": "object", ..., "required": [...]}` (or
+  `"array"`, etc.) with no null permitted. `match_json_schema` parses `"null"` back to `null` and
+  fails it against the schema, so the missing value is caught. (Verified: a serialized `"null"` cell
+  is reported unexpected and the expectation fails.)
+- **Nullable:** permit null at the root with the `oneOf` `[ {"type": "null"}, {...} ]` pattern —
+  only when the field is legitimately nullable.
+
+A single `expect_column_values_to_match_json_schema(<col>, json_schema=<schema>)` therefore covers
+both the field's shape and its presence; no companion `not_be_null` or `be_of_type("str")` is needed
+(on a nested column those always pass and validate nothing).
+
+### Prefer the lightest mechanism the shape allows (observability)
+
+Only nest a field when its values genuinely have internal structure a schema must check. If a
+field's values are simple enough that native/custom expectations fully cover them (a scalar, or a
+list of scalars), keep it un-nested and use those — each native expectation renders as its own
+pass/fail row in GX Data Docs, whereas a JSON Schema is a single monolithic pass/fail. Reserve JSON
+Schema for what only it can reach: the interior of genuinely nested fields.
+
+---
+
 ## Step 0 — Research the Transform Before Planning
 
 **Do all of the following before writing any plan or authoring any expectations.** These steps give you the complete picture of the transform's inputs, logic, output schema, and edge cases.
@@ -105,11 +168,24 @@ gx_nested_columns:
 
 ## Step 2 — Create JSON Schemas (if needed)
 
-For columns that are link objects, create schemas in `src/agoradatatools/great_expectations/gx/json_schemas/<transform>/`.
+For nested columns — dict or list objects declared in `gx_nested_columns` — that need deep
+validation, create schemas in `src/agoradatatools/great_expectations/gx/json_schemas/<transform>/`.
+
+**Every GX JSON schema file MUST begin with these two keys** (keeps identifiers consistent across
+the library — the templates below already include them):
+- `"$schema": "https://json-schema.org/draft/2019-09/schema"`
+- `"$id"`: the file's GitHub repo path = `https://github.com/Sage-Bionetworks/agora-data-tools/`
+  + the file's repo-relative path, e.g.
+  `https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/<transform>/<schema>.json`
+
+The templates below cover common link-object columns; array/list columns use the same
+`$schema`/`$id` header with an `array` schema (see the array example in Step 3).
 
 **Nullable link column** (value can be `null` OR a `{link_url}` object):
 ```json
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/<transform>/<schema>.json",
   "oneOf": [
     { "type": "null" },
     {
@@ -125,6 +201,8 @@ For columns that are link objects, create schemas in `src/agoradatatools/great_e
 **Required link column** (never null, must have `link_url`):
 ```json
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/<transform>/<schema>.json",
   "type": "object",
   "properties": { "link_url": { "type": "string", "minLength": 1 } },
   "required": ["link_url"],
@@ -135,6 +213,8 @@ For columns that are link objects, create schemas in `src/agoradatatools/great_e
 **Center-style column** (never null, must have both `link_url` and `link_text`):
 ```json
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/<transform>/<schema>.json",
   "type": "object",
   "properties": {
     "link_url": { "type": "string", "minLength": 1 },
@@ -444,3 +524,4 @@ Check the output for GX validation results.
 | Wrong regex flavor used | Use Python `re`/RE2 syntax in `.py`/`.ipynb` files; use ECMAScript syntax in `json_schemas/**/*.json` `"pattern"` fields |
 | `expect_column_values_to_have_list_length_in_range` / `expect_column_values_to_have_list_members_of_type` always fail on nested columns | These expectations check `isinstance(cell, list)` and fail after `convert_nested_columns_to_json` converts the column to a JSON string. Use `expect_column_values_to_match_json_schema` with `minItems`/`maxItems` and `"items": {"type": ...}` instead |
 | `nbconvert` execution hangs or takes 60+ minutes | The staging file is too large for `pd.read_json()` to process interactively. Switch to Option B in Step 4: write the JSON directly, then ask the user for a confirmed data source (local file or Synapse ID) to verify the suite on a 500-record sample — do not assume `staging/` is available or up-to-date |
+| New JSON schema missing `$schema` / `$id` | Every GX JSON schema file must begin with `$schema` (draft 2019-09) and a GitHub repo-path `$id` — see Step 2 |

--- a/.cursor/rules/gx-validation-suite-authoring.mdc
+++ b/.cursor/rules/gx-validation-suite-authoring.mdc
@@ -64,6 +64,17 @@ The governing question is: *what is this field's value shape, and does it have i
 that only a schema can validate?* If yes → make it a nested column (`gx_nested_columns`) and use
 JSON Schema; if no → native/custom expectations on the un-nested column.
 
+**When auditing an existing suite, re-derive each field's mechanism from its value shape — do not
+trust the current `gx_nested_columns` list.** The existing configuration can itself be the
+deviation. Treat a field's presence in `gx_nested_columns` as a *hypothesis to verify against the
+shape judgment*, never as the answer. A classic miss: a **list of scalars** (e.g. `result_order`, a
+list of display-label strings) that was wrongly nested and validated with `match_json_schema` — its
+items have no internal structure, so it should be **un-nested** and checked with the native list
+expectations (the `biodomains` pattern). Because it sits next to a legitimately-nested list-of-objects
+column (e.g. `data`), it's tempting to treat "the nested list columns" as a unit — but "is it a
+list?" is the wrong question; "do its *items* have structure only a schema can validate?" is the
+right one. Run every field through that test independently, including the ones already nested.
+
 ### Why nesting shifts interior checks into the schema
 
 Adding a field to `gx_nested_columns` runs `convert_nested_columns_to_json`, which serializes that
@@ -177,6 +188,13 @@ the library — the templates below already include them):
 - `"$id"`: the file's GitHub repo path = `https://github.com/Sage-Bionetworks/agora-data-tools/`
   + the file's repo-relative path, e.g.
   `https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/<transform>/<schema>.json`
+
+**These two keys travel with the schema even when it is embedded inline.** Whether the schema
+lives in a standalone file or is inlined into a suite's `expect_column_values_to_match_json_schema`
+kwargs, it must carry `$schema` and `$id`. Notebook-generated suites embed the full schema file
+(header included) automatically; when hand-writing a suite via Option B (Step 4), copy the same
+`$schema`/`$id` header into each inline `json_schema` so both authoring paths produce identical
+suites.
 
 The templates below cover common link-object columns; array/list columns use the same
 `$schema`/`$id` header with an `array` schema (see the array example in Step 3).
@@ -447,12 +465,30 @@ The format mirrors existing suites (e.g. `rnaseq_differential_expression.json`):
       "expectation_type": "expect_column_values_to_be_of_type",
       "kwargs": { "column": "my_col", "type_": "str" },
       "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_match_json_schema",
+      "kwargs": {
+        "column": "my_nested_col",
+        "json_schema": {
+          "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/<transform>/<schema>.json",
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "type": "object",
+          "properties": { "link_url": { "type": "string", "minLength": 1 } },
+          "required": ["link_url"],
+          "additionalProperties": false
+        }
+      },
+      "meta": {}
     }
   ],
   "ge_cloud_id": null,
   "meta": { "great_expectations_version": "0.18.1" }
 }
 ```
+
+When hand-writing an inline `json_schema` here, include the `$schema`/`$id` header (as shown
+above) so the suite matches what a notebook would generate — see Step 2.
 
 After writing the file directly, **always verify the suite passes** by running GX on a small sample in a standalone script. This catches any expectation mismatches without loading the full file.
 
@@ -524,4 +560,4 @@ Check the output for GX validation results.
 | Wrong regex flavor used | Use Python `re`/RE2 syntax in `.py`/`.ipynb` files; use ECMAScript syntax in `json_schemas/**/*.json` `"pattern"` fields |
 | `expect_column_values_to_have_list_length_in_range` / `expect_column_values_to_have_list_members_of_type` always fail on nested columns | These expectations check `isinstance(cell, list)` and fail after `convert_nested_columns_to_json` converts the column to a JSON string. Use `expect_column_values_to_match_json_schema` with `minItems`/`maxItems` and `"items": {"type": ...}` instead |
 | `nbconvert` execution hangs or takes 60+ minutes | The staging file is too large for `pd.read_json()` to process interactively. Switch to Option B in Step 4: write the JSON directly, then ask the user for a confirmed data source (local file or Synapse ID) to verify the suite on a 500-record sample — do not assume `staging/` is available or up-to-date |
-| New JSON schema missing `$schema` / `$id` | Every GX JSON schema file must begin with `$schema` (draft 2019-09) and a GitHub repo-path `$id` — see Step 2 |
+| New JSON schema missing `$schema` / `$id` (in a file **or** inlined in a suite) | Every GX JSON schema must carry `$schema` (draft 2019-09) and a GitHub repo-path `$id`, whether it lives in a standalone file or is embedded inline in an `expect_column_values_to_match_json_schema` kwarg — see Step 2 |

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -114,6 +114,10 @@ datasets:
       final_format: json
       destination: *dest
       custom_transformations: transform_rna_de_aggregate
+      gx_enabled: true
+      gx_nested_columns:
+        - result_order
+        - data
 
   - rna_de_individual:
       files:
@@ -132,3 +136,9 @@ datasets:
       final_format: json
       destination: *dest
       custom_transformations: transform_rna_de_individual
+      gx_enabled: true
+      gx_nested_columns:
+        - name
+        - "4 months"
+        - "12 months"
+        - "18 months"

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -39,8 +39,6 @@ datasets:
   - model_details:
       files:
         - <<: *model_metadata
-        - <<: *pathology
-        - <<: *biomarkers
         - <<: *model_genetic_modifications
         - <<: *pathology
         - <<: *biomarkers

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -138,6 +138,5 @@ datasets:
       custom_transformations: transform_rna_de_individual
       gx_enabled: true
       gx_nested_columns:
-        - result_order
         - data
 

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -116,8 +116,10 @@ datasets:
       custom_transformations: transform_rna_de_aggregate
       gx_enabled: true
       gx_nested_columns:
-        - result_order
-        - data
+        - name
+        - "4 months"
+        - "12 months"
+        - "18 months"
 
   - rna_de_individual:
       files:
@@ -138,7 +140,6 @@ datasets:
       custom_transformations: transform_rna_de_individual
       gx_enabled: true
       gx_nested_columns:
-        - name
-        - "4 months"
-        - "12 months"
-        - "18 months"
+        - result_order
+        - data
+

--- a/configs/model_ad_preprod.yaml
+++ b/configs/model_ad_preprod.yaml
@@ -139,4 +139,3 @@ datasets:
       gx_enabled: true
       gx_nested_columns:
         - data
-

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -114,6 +114,10 @@ datasets:
       final_format: json
       destination: *dest
       custom_transformations: transform_rna_de_aggregate
+      gx_enabled: true
+      gx_nested_columns:
+        - result_order
+        - data
 
   - rna_de_individual:
       files:
@@ -132,3 +136,9 @@ datasets:
       final_format: json
       destination: *dest
       custom_transformations: transform_rna_de_individual
+      gx_enabled: true
+      gx_nested_columns:
+        - name
+        - "4 months"
+        - "12 months"
+        - "18 months"

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -39,8 +39,6 @@ datasets:
   - model_details:
       files:
         - <<: *model_metadata
-        - <<: *pathology
-        - <<: *biomarkers
         - <<: *model_genetic_modifications
         - <<: *pathology
         - <<: *biomarkers

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -138,6 +138,5 @@ datasets:
       custom_transformations: transform_rna_de_individual
       gx_enabled: true
       gx_nested_columns:
-        - result_order
         - data
 

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -116,8 +116,10 @@ datasets:
       custom_transformations: transform_rna_de_aggregate
       gx_enabled: true
       gx_nested_columns:
-        - result_order
-        - data
+        - name
+        - "4 months"
+        - "12 months"
+        - "18 months"
 
   - rna_de_individual:
       files:
@@ -138,7 +140,6 @@ datasets:
       custom_transformations: transform_rna_de_individual
       gx_enabled: true
       gx_nested_columns:
-        - name
-        - "4 months"
-        - "12 months"
-        - "18 months"
+        - result_order
+        - data
+

--- a/configs/model_ad_prod.yaml
+++ b/configs/model_ad_prod.yaml
@@ -139,4 +139,3 @@ datasets:
       gx_enabled: true
       gx_nested_columns:
         - data
-

--- a/gx_suite_definitions/rna_de_aggregate.ipynb
+++ b/gx_suite_definitions/rna_de_aggregate.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "# Create Expectation Suite for RNA DE Aggregate Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-2",
+   "metadata": {},
+   "source": [
+    "Due to this dataset's large output file size, the rna_de_aggregate GX suite definition was generated using AI, rather than using a Jupyter notebook. \n",
+    "\n",
+    "For more information, see the information on \"Option B\" in .cursor/rules/gx-validation-suite-authoring.mdc"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gx_suite_definitions/rna_de_individual.ipynb
+++ b/gx_suite_definitions/rna_de_individual.ipynb
@@ -1,0 +1,43 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "cell-1",
+   "metadata": {},
+   "source": [
+    "# Create Expectation Suite for RNA DE Individual Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "cell-2",
+   "metadata": {},
+   "source": [
+    "Due to this dataset's large output file size, the rna_de_individual GX suite definition was generated using AI, rather than using a Jupyter notebook. \n",
+    "\n",
+    "For more information, see the information on \"Option B\" in .cursor/rules/gx-validation-suite-authoring.mdc"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/src/agoradatatools/great_expectations/gx/expectations/rna_de_aggregate.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/rna_de_aggregate.json
@@ -197,25 +197,12 @@
       "meta": {}
     },
     {
-      "expectation_type": "expect_column_values_to_be_of_type",
-      "kwargs": {
-        "column": "name",
-        "type_": "str"
-      },
-      "meta": {}
-    },
-    {
-      "expectation_type": "expect_column_values_to_not_be_null",
-      "kwargs": {
-        "column": "name"
-      },
-      "meta": {}
-    },
-    {
       "expectation_type": "expect_column_values_to_match_json_schema",
       "kwargs": {
         "column": "name",
         "json_schema": {
+          "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/name_schema.json",
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
           "type": "object",
           "properties": {
             "link_url":  { "type": "string", "pattern": "^models/" },
@@ -228,18 +215,12 @@
       "meta": {}
     },
     {
-      "expectation_type": "expect_column_values_to_be_of_type",
-      "kwargs": {
-        "column": "4 months",
-        "type_": "str"
-      },
-      "meta": {}
-    },
-    {
       "expectation_type": "expect_column_values_to_match_json_schema",
       "kwargs": {
         "column": "4 months",
         "json_schema": {
+          "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/age_entry_schema.json",
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
           "oneOf": [
             { "type": "null" },
             {
@@ -257,18 +238,35 @@
       "meta": {}
     },
     {
-      "expectation_type": "expect_column_values_to_be_of_type",
+      "expectation_type": "expect_column_values_to_match_json_schema",
       "kwargs": {
         "column": "12 months",
-        "type_": "str"
+        "json_schema": {
+          "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/age_entry_schema.json",
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "properties": {
+                "log2_fc":   { "type": "number" },
+                "adj_p_val": { "type": "number", "minimum": 0, "maximum": 1 }
+              },
+              "required": ["log2_fc", "adj_p_val"],
+              "additionalProperties": false
+            }
+          ]
+        }
       },
       "meta": {}
     },
     {
       "expectation_type": "expect_column_values_to_match_json_schema",
       "kwargs": {
-        "column": "12 months",
+        "column": "18 months",
         "json_schema": {
+          "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/age_entry_schema.json",
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
           "oneOf": [
             { "type": "null" },
             {

--- a/src/agoradatatools/great_expectations/gx/expectations/rna_de_aggregate.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/rna_de_aggregate.json
@@ -156,7 +156,6 @@
         "column": "sex",
         "value_set": [
           "Females",
-          "Females & Males",
           "Males"
         ]
       },

--- a/src/agoradatatools/great_expectations/gx/expectations/rna_de_aggregate.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/rna_de_aggregate.json
@@ -1,0 +1,305 @@
+{
+  "data_asset_type": null,
+  "expectation_suite_name": "rna_de_aggregate",
+  "expectations": [
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "ensembl_gene_id",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "ensembl_gene_id"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_match_regex",
+      "kwargs": {
+        "column": "ensembl_gene_id",
+        "regex": "^ENSMUSG\\d{11}$"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "gene_symbol",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "gene_symbol"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "matched_control",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "matched_control"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "matched_control",
+        "value_set": [
+          "5xFAD",
+          "B6129",
+          "C57BL/6J"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "model_group",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "model_group"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "model_type",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "model_type"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "model_type",
+        "value_set": [
+          "Familial AD",
+          "Late Onset AD"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "tissue",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "tissue"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "tissue",
+        "value_set": [
+          "Cerebral Cortex",
+          "Hemibrain",
+          "Hippocampus"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "sex_cohort",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "sex_cohort"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "sex_cohort",
+        "value_set": [
+          "Females",
+          "Females & Males",
+          "Males"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "biodomains",
+        "type_": "list"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "biodomains"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_have_list_length_in_range",
+      "kwargs": {
+        "column": "biodomains",
+        "list_length_range": [
+          0,
+          30
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_have_list_members_of_type",
+      "kwargs": {
+        "column": "biodomains",
+        "member_type": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "name",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "name"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_match_json_schema",
+      "kwargs": {
+        "column": "name",
+        "json_schema": {
+          "type": "object",
+          "properties": {
+            "link_url":  { "type": "string", "pattern": "^models/" },
+            "link_text": { "type": "string", "minLength": 1 }
+          },
+          "required": ["link_url", "link_text"],
+          "additionalProperties": false
+        }
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "4 months",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_match_json_schema",
+      "kwargs": {
+        "column": "4 months",
+        "json_schema": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "properties": {
+                "log2_fc":   { "type": "number" },
+                "adj_p_val": { "type": "number", "minimum": 0, "maximum": 1 }
+              },
+              "required": ["log2_fc", "adj_p_val"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "12 months",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_match_json_schema",
+      "kwargs": {
+        "column": "12 months",
+        "json_schema": {
+          "oneOf": [
+            { "type": "null" },
+            {
+              "type": "object",
+              "properties": {
+                "log2_fc":   { "type": "number" },
+                "adj_p_val": { "type": "number", "minimum": 0, "maximum": 1 }
+              },
+              "required": ["log2_fc", "adj_p_val"],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_compound_columns_to_be_unique",
+      "kwargs": {
+        "column_list": [
+          "ensembl_gene_id",
+          "name",
+          "tissue",
+          "sex_cohort"
+        ]
+      },
+      "meta": {}
+    }
+  ],
+  "ge_cloud_id": null,
+  "meta": {
+    "great_expectations_version": "0.18.1"
+  }
+}

--- a/src/agoradatatools/great_expectations/gx/expectations/rna_de_aggregate.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/rna_de_aggregate.json
@@ -138,7 +138,7 @@
     {
       "expectation_type": "expect_column_values_to_be_of_type",
       "kwargs": {
-        "column": "sex_cohort",
+        "column": "sex",
         "type_": "str"
       },
       "meta": {}
@@ -146,14 +146,14 @@
     {
       "expectation_type": "expect_column_values_to_not_be_null",
       "kwargs": {
-        "column": "sex_cohort"
+        "column": "sex"
       },
       "meta": {}
     },
     {
       "expectation_type": "expect_column_values_to_be_in_set",
       "kwargs": {
-        "column": "sex_cohort",
+        "column": "sex",
         "value_set": [
           "Females",
           "Females & Males",
@@ -290,7 +290,7 @@
           "ensembl_gene_id",
           "name",
           "tissue",
-          "sex_cohort"
+          "sex"
         ]
       },
       "meta": {}

--- a/src/agoradatatools/great_expectations/gx/expectations/rna_de_individual.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/rna_de_individual.json
@@ -203,6 +203,14 @@
       "meta": {}
     },
     {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "result_order",
+        "type_": "list"
+      },
+      "meta": {}
+    },
+    {
       "expectation_type": "expect_column_values_to_not_be_null",
       "kwargs": {
         "column": "result_order"
@@ -210,45 +218,34 @@
       "meta": {}
     },
     {
-      "expectation_type": "expect_column_values_to_match_json_schema",
-      "kwargs": {
-        "column": "result_order",
-        "json_schema": {
-          "type": "array",
-          "minItems": 2,
-          "maxItems": 4,
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
-        }
-      },
-      "meta": {}
-    },
-    {
-      "expectation_type": "expect_column_values_to_not_be_null",
-      "kwargs": {
-        "column": "data"
-      },
-      "meta": {}
-    },
-    {
       "expectation_type": "expect_column_values_to_have_list_length_in_range",
       "kwargs": {
-        "column": "data",
+        "column": "result_order",
         "list_length_range": [
-          19,
-          44
+          2,
+          4
         ]
       },
       "meta": {}
     },
     {
+      "expectation_type": "expect_column_values_to_have_list_members_of_type",
+      "kwargs": {
+        "column": "result_order",
+        "member_type": "str"
+      },
+      "meta": {}
+    },
+    {
       "expectation_type": "expect_column_values_to_match_json_schema",
       "kwargs": {
         "column": "data",
         "json_schema": {
+          "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_individual/data_schema.json",
+          "$schema": "https://json-schema.org/draft/2019-09/schema",
           "type": "array",
+          "minItems": 19,
+          "maxItems": 44,
           "items": {
             "type": "object",
             "properties": {

--- a/src/agoradatatools/great_expectations/gx/expectations/rna_de_individual.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/rna_de_individual.json
@@ -1,0 +1,254 @@
+{
+  "data_asset_type": null,
+  "expectation_suite_name": "rna_de_individual",
+  "expectations": [
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "ensembl_gene_id",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "ensembl_gene_id"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_value_lengths_to_equal",
+      "kwargs": {
+        "column": "ensembl_gene_id",
+        "value": 18
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_match_regex",
+      "kwargs": {
+        "column": "ensembl_gene_id",
+        "regex": "^ENSMUSG\\d{11}$"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "gene_symbol",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "gene_symbol"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "tissue",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "tissue"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "tissue",
+        "value_set": [
+          "Cerebral Cortex",
+          "Hemibrain",
+          "Hippocampus"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "name",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "name"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "model_group",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "model_group"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "matched_control",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "matched_control"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "matched_control",
+        "value_set": [
+          "B6129",
+          "C57BL/6J"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "units",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "units"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "units",
+        "value_set": [
+          "Log2 Counts per Million"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "age",
+        "type_": "str"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "age"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "age",
+        "value_set": [
+          "4 months",
+          "12 months",
+          "18 months"
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_of_type",
+      "kwargs": {
+        "column": "age_numeric",
+        "type_": "int"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "age_numeric"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_be_in_set",
+      "kwargs": {
+        "column": "age_numeric",
+        "value_set": [
+          4,
+          12,
+          18
+        ]
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_match_json_schema",
+      "kwargs": {
+        "column": "result_order",
+        "json_schema": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 4,
+          "items": { "type": "string", "minLength": 1 }
+        }
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_match_json_schema",
+      "kwargs": {
+        "column": "data",
+        "json_schema": {
+          "type": "array",
+          "minItems": 19,
+          "maxItems": 44,
+          "items": {
+            "type": "object",
+            "properties": {
+              "genotype":      { "type": "string", "minLength": 1 },
+              "sex":           { "type": "string", "minLength": 1 },
+              "individual_id": { "type": "string", "minLength": 1 },
+              "value":         { "type": "number" }
+            },
+            "required": ["genotype", "sex", "individual_id", "value"],
+            "additionalProperties": false
+          }
+        }
+      },
+      "meta": {}
+    }
+  ],
+  "ge_cloud_id": null,
+  "meta": {
+    "great_expectations_version": "0.18.1"
+  }
+}

--- a/src/agoradatatools/great_expectations/gx/expectations/rna_de_individual.json
+++ b/src/agoradatatools/great_expectations/gx/expectations/rna_de_individual.json
@@ -18,14 +18,6 @@
       "meta": {}
     },
     {
-      "expectation_type": "expect_column_value_lengths_to_equal",
-      "kwargs": {
-        "column": "ensembl_gene_id",
-        "value": 18
-      },
-      "meta": {}
-    },
-    {
       "expectation_type": "expect_column_values_to_match_regex",
       "kwargs": {
         "column": "ensembl_gene_id",
@@ -211,6 +203,13 @@
       "meta": {}
     },
     {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "result_order"
+      },
+      "meta": {}
+    },
+    {
       "expectation_type": "expect_column_values_to_match_json_schema",
       "kwargs": {
         "column": "result_order",
@@ -218,8 +217,29 @@
           "type": "array",
           "minItems": 2,
           "maxItems": 4,
-          "items": { "type": "string", "minLength": 1 }
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
         }
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_not_be_null",
+      "kwargs": {
+        "column": "data"
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_column_values_to_have_list_length_in_range",
+      "kwargs": {
+        "column": "data",
+        "list_length_range": [
+          19,
+          44
+        ]
       },
       "meta": {}
     },
@@ -229,20 +249,46 @@
         "column": "data",
         "json_schema": {
           "type": "array",
-          "minItems": 19,
-          "maxItems": 44,
           "items": {
             "type": "object",
             "properties": {
-              "genotype":      { "type": "string", "minLength": 1 },
-              "sex":           { "type": "string", "minLength": 1 },
-              "individual_id": { "type": "string", "minLength": 1 },
-              "value":         { "type": "number" }
+              "genotype": {
+                "type": "string",
+                "minLength": 1
+              },
+              "sex": {
+                "type": "string",
+                "minLength": 1
+              },
+              "individual_id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "value": {
+                "type": "number"
+              }
             },
-            "required": ["genotype", "sex", "individual_id", "value"],
+            "required": [
+              "genotype",
+              "sex",
+              "individual_id",
+              "value"
+            ],
             "additionalProperties": false
           }
         }
+      },
+      "meta": {}
+    },
+    {
+      "expectation_type": "expect_compound_columns_to_be_unique",
+      "kwargs": {
+        "column_list": [
+          "ensembl_gene_id",
+          "name",
+          "tissue",
+          "age"
+        ]
       },
       "meta": {}
     }

--- a/src/agoradatatools/great_expectations/gx/json_schemas/distribution_data/genetics_score.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/distribution_data/genetics_score.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
+    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/distribution_data/genetics_score.json",
     "type": "object",
     "default": {},
     "title": "Genetics Score Schema",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/distribution_data/multi_omics_score.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/distribution_data/multi_omics_score.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
+    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/distribution_data/multi_omics_score.json",
     "type": "object",
     "default": {},
     "title": "Multi Omics Score Schema",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/distribution_data/target_risk_score.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/distribution_data/target_risk_score.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
+    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/distribution_data/target_risk_score.json",
     "type": "object",
     "default": {},
     "title": "Target Risk Score Schema",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/druggability.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/druggability.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
+    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/druggability.json",
     "type": ["object", "null"],
     "default": null,
     "title": "Root Schema",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/ensembl_info.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/ensembl_info.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
+    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/ensembl_info.json",
     "type": "object",
     "default": {},
     "title": "Ensembl Info Schema",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/median_expression.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/median_expression.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
+    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/median_expression.json",
     "type": ["array", "null"],
     "default": [],
     "title": "Median Expression Schema",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/target_nominations.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/target_nominations.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
+    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/gene_info/target_nominations.json",
     "type": ["array", "null"],
     "default": [],
     "title": "Target Nominations Schema",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/immunohisto/points.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/immunohisto/points.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2019-09/schema",
-    "$id": "http://example.com/example.json",
+    "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/immunohisto/points.json",
     "type": "array",
     "default": [],
     "title": "Points Schema",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/model_details/biomarkers_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/model_details/biomarkers_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/model_details/biomarkers_schema.json",
   "type": "array",
   "items": {
     "type": "object",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/model_details/genetic_info_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/model_details/genetic_info_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/model_details/genetic_info_schema.json",
   "type": "array",
   "items": {
     "type": "object",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/model_details/pathology_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/model_details/pathology_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/model_details/pathology_schema.json",
   "type": "array",
   "items": {
     "type": "object",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/biomarkers_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/biomarkers_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/biomarkers_schema.json",
   "oneOf": [
     { "type": "null" },
     {

--- a/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/disease_correlation_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/disease_correlation_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/disease_correlation_schema.json",
   "oneOf": [
     { "type": "null" },
     {

--- a/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/jax_strain_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/jax_strain_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/jax_strain_schema.json",
   "type": "object",
   "properties": {
     "link_url": { "type": "string", "pattern": "^https://jax\\.org/strain/\\d+$" }

--- a/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/pathology_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/pathology_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/pathology_schema.json",
   "oneOf": [
     { "type": "null" },
     {

--- a/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/study_data_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/study_data_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/study_data_schema.json",
   "type": "object",
   "properties": {
     "link_url": { "type": "string", "pattern": "^https://adknowledgeportal\\.synapse\\.org/Explore/Studies/DetailsPage/StudyDetails\\?Study=syn\\d+$" }

--- a/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/transcriptomics_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/transcriptomics_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/model_overview/transcriptomics_schema.json",
   "oneOf": [
     { "type": "null" },
     {

--- a/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/age_entry_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/age_entry_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/age_entry_schema.json",
   "oneOf": [
     { "type": "null" },
     {

--- a/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/age_entry_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/age_entry_schema.json
@@ -1,0 +1,14 @@
+{
+  "oneOf": [
+    { "type": "null" },
+    {
+      "type": "object",
+      "properties": {
+        "log2_fc": { "type": "number" },
+        "adj_p_val": { "type": "number", "minimum": 0, "maximum": 1 }
+      },
+      "required": ["log2_fc", "adj_p_val"],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/name_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/name_schema.json
@@ -1,16 +1,11 @@
 {
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/name_schema.json",
-  "oneOf": [
-    { "type": "null" },
-    {
-      "type": "object",
-      "properties": {
-        "link_url": { "type": "string", "pattern": "^models/" },
-        "link_text": { "type": "string", "minLength": 1 }
-      },
-      "required": ["link_url", "link_text"],
-      "additionalProperties": false
-    }
-  ]
+  "type": "object",
+  "properties": {
+    "link_url": { "type": "string", "pattern": "^models/" },
+    "link_text": { "type": "string", "minLength": 1 }
+  },
+  "required": ["link_url", "link_text"],
+  "additionalProperties": false
 }

--- a/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/name_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/name_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/name_schema.json",
   "oneOf": [
     { "type": "null" },
     {

--- a/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/name_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_aggregate/name_schema.json
@@ -1,0 +1,14 @@
+{
+  "oneOf": [
+    { "type": "null" },
+    {
+      "type": "object",
+      "properties": {
+        "link_url": { "type": "string", "pattern": "^models/" },
+        "link_text": { "type": "string", "minLength": 1 }
+      },
+      "required": ["link_url", "link_text"],
+      "additionalProperties": false
+    }
+  ]
+}

--- a/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_individual/data_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_individual/data_schema.json
@@ -1,4 +1,6 @@
 {
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_individual/data_schema.json",
   "type": "array",
   "items": {
     "type": "object",

--- a/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_individual/data_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_individual/data_schema.json
@@ -2,6 +2,8 @@
   "$schema": "https://json-schema.org/draft/2019-09/schema",
   "$id": "https://github.com/Sage-Bionetworks/agora-data-tools/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_individual/data_schema.json",
   "type": "array",
+  "minItems": 19,
+  "maxItems": 44,
   "items": {
     "type": "object",
     "properties": {

--- a/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_individual/data_schema.json
+++ b/src/agoradatatools/great_expectations/gx/json_schemas/rna_de_individual/data_schema.json
@@ -1,0 +1,14 @@
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "genotype":      { "type": "string", "minLength": 1 },
+      "sex":           { "type": "string", "minLength": 1 },
+      "individual_id": { "type": "string", "minLength": 1 },
+      "value":         { "type": "number" }
+    },
+    "required": ["genotype", "sex", "individual_id", "value"],
+    "additionalProperties": false
+  }
+}


### PR DESCRIPTION
## Problem

Like all datasets, the rna_de_* datasets need to be validated by a GX suite. However, adding GX suites for these datasets was blocked because our Github CI runners cannot handle them due to the data size (See comments on MG-762).

A related issue is that the GX toolchain also experiences issues working with these large files. This makes suite development using the standard Jupyter notebook approach unfeasible. 

This PR replaces these two unmerged, and now quite outdated, PRs:

* [MG-761: Add GX suite for rna_de_aggregate- #311](https://github.com/Sage-Bionetworks/agora-data-tools/pull/311)
* [MG-762: Add GX validation suite for rna_de_individual- #304
#304](https://github.com/Sage-Bionetworks/agora-data-tools/pull/304)

## Solution

Now that model_ad data processing has been ported from Github CI to Nextflow (AG-2123), we can merge these suites so that they run automatically in Nextflow.

We've worked around the suite generation issue by having Claude author the GX suite defintion JSON file directly, outlined in the AI instructions as "Option B". 

While reconciling validation coverage across the rna_de_* datasets and our other datasets, a couple of issues came to light:
1. Our existing `json_schema` objects are inconsistent about including the "best-practice" `$schema` and `$id` properties
2. Claude didn't clearly understand when it should implement `json_schema` validation

These issues are also addressed in this PR:
1. Added `$schema` and `$id` to all existing json_schemas & updated AI instructions to indicate that these should always be included when new ones are generated
2. Added AI instructions clearly outlining how to determine when to implement json_schema validation & to describe what which expectations can be effectively used on fields that are validated via json_schemas

Notes:
Both updated GX suites were tested by locally processing and validating (successfully!) the corresponding full dataset.

Once this is approved, a follow up PR will leverage the revised AI instructions to update the existing suites to address alignment issues discovered by AI audit after clarifying when and how to use json_schema vs expectations.

Depending on merge order, either this PR or the [plural -> singular sex PR](https://github.com/Sage-Bionetworks/agora-data-tools/pull/367) will need to update the GX allowed values for the aggregate sex field.